### PR TITLE
moved test files for library into directory on the website.

### DIFF
--- a/p5-tests/array.json
+++ b/p5-tests/array.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": 0,
+    "species": "Capra hircus",
+    "name": "Goat"
+  },
+  {
+    "id": 1,
+    "species": "Panthera pardus",
+    "name": "Leopard"
+  },
+  {
+    "id": 2,
+    "species": "Equus zebra",
+    "name": "Zebra"
+  }
+]

--- a/p5-tests/csv.csv
+++ b/p5-tests/csv.csv
@@ -1,0 +1,5 @@
+name,age,height
+David,31,80
+"David, Jr.",11,61.5
+"David,
+Sr. ""the boss""",95,88

--- a/p5-tests/object.json
+++ b/p5-tests/object.json
@@ -1,0 +1,5 @@
+{
+	"id": 0,
+	"species": "Panthera leo",
+	"name": "Lion"
+}

--- a/p5-tests/sentences.txt
+++ b/p5-tests/sentences.txt
@@ -1,0 +1,68 @@
+The boy made a house of cards in order to pass the time.
+The baby cried in the middle of the night.
+The sorrowful girl sobbed all day long.
+The severely wounded child smiled more often than you would expect.
+The retired prisoner was tempted to hold someone up and was shunned by all.
+The umpire said "I am the greatest!" with triumph in public.
+The screaming pilot ran out of gas and muttered, "What a day!"
+The bumbling secretary was fired during a press conference.
+The person with sunglasses smelled like a skunk and someone said, ''Are you okay?''
+The man got a haircut regularly.
+The humorless old woman acted pompous.
+The lady wrote bad checks and said, "Mum's the word."
+Not even one person made counterfeit money and lived happily ever after.
+The elderly couple wondered how hushpuppies were made, but honestly now, wouldn't you do the same thing?
+The man cried over spilled milk in vain.
+The bungee-jumping cliff-diver splatted.
+The jaywalker ran like mad.
+No man asked for directions.
+The infamous tycoon got electrocuted and said "Ooh! Ah!"
+The pompous loudmouth was bored when discussing politics with the Duke.
+The parade took the trash out to the curb.
+The nutcase left the scene of an accident while dancing to disco.
+The walrus blew kisses while going over Niagara Falls in a barrel.
+The townspeople threw mashed potatoes up against the wall solemnly.
+The congressman ran a red light and was darn proud of it.
+The lunatic shut a door on an old lady carrying groceries until somebody finally stepped in and brought it to an end.
+The jerk refused to bathe in a big mud puddle.
+The bearded nun considered mugging a stranger in a fancy restaurant.
+Fortunately, the motorcycle gang made oatmeal in a volcano.
+The entire population of a small town walked the dog.
+The crippled man ate paint chips after careful consideration.
+Every single mayor opened a can of green beans with great success.
+The determined one-armed man helped an old lady cross the street while on fire.
+The screaming alligator-wrestler simply adored tea parties!
+The chubby geezer wore a toga.
+The crazed oyster wrote scathing letters into the newspaper because of issues as a child that were never addressed.
+The rugged chap was tarred and feathered while wedged between two boulders.
+The screaming librarian did cartwheels!
+The squid acted pompous.
+In order to illustrate a point, the secret service agent was stuffed in a locker and, for some odd reason, became a national celebrity.
+The nun did the hokey-pokey.
+The scientist cracked jokes while planting turnips.
+A silly birdwatcher grew a mohawk until someone politely said that it was against the law.
+Every population of a small town wore makeup while lost in a maze.
+The old jury lived simply in a dumpster.
+The chatty mime lied during a tornado.
+Fortunately, the pack of seals swayed slowly to music and romance filled the air.
+The meek woman drank an entire cup of maple syrup, which was captured by a photographer.
+The locksmith got a foot caught on a train track and flossed.
+The woman began doing a Russian dance while lost in a maze.
+Fortunately, the mailman made a fort out of couch cushions.
+The severely wounded butler went for a walk after falling out the window.
+The fat freckle-faced boy got a finger caught in a mousetrap and then everybody applauded.
+A really, really weird lad toasted marshmallows while on fire.
+The crazed lady, who is never seen without a hat on, swung a cat and showed no sign of remorse.
+The meek girl frequently stepped on a landmine while caught in a bear trap.
+The choir boy was tarred and feathered, which served as a warning to others.
+The mime used crutches while slowly being flattened by a steam roller.
+The lawyer couldn't stop tripping while on fire.
+The fortunate geezer coined witty sayings and fell off a cliff.
+One whale of a deliveryman fell into the Grand Canyon.
+The stiff man spouted nonsense after falling out the window.
+The dehydrated girl frequently lost a limb while bound and gagged.
+The bartender thought strange thoughts and thought nothing of it.
+The undercover man accidentally accidentally insulted the natives, which turned out to be a great way to make money.
+Whenever possible, the man wondered why abbreviation is such a long word whenever necessary.
+Occasionally, the impostor mocked people as they passed every Tuesday at 7:00.
+No nobody gasped in horror during the Super Bowl.


### PR DESCRIPTION
Here's the test files—they include all of the files in that directory that appear to be data, not just the `csv.csv` file.