### PR TITLE
Update editor repo and references

### DIFF
--- a/download/index.php
+++ b/download/index.php
@@ -54,13 +54,13 @@
 
         </div>
 
-  
+
         <div class="link_group">
         <a name="editor" class="anchor"><h3>Editor</h3></a>
         <p>The p5.js editor is currently in development, try out an alpha version of it now. Help out by posting
-        <a href="https://github.com/antiboredom/jside/issues">feedback and bugs</a>. Support for Windows and Linux
-        coming soon, along with more <a href="https://github.com/antiboredom/jside/labels/enhancement">features</a>.</p>
-        <a href="https://github.com/antiboredom/jside/releases/download/v<?php echo $jside_version; ?>/p5.zip">
+        <a href="https://github.com/processing/p5.js-editor/issues">feedback and bugs</a>. Support for Windows and Linux
+        coming soon, along with more <a href="https://github.com/processing/p5.js-editor/labels/enhancement">features</a>.</p>
+        <a href="https://github.com/processing/p5.js-editor/releases/download/v<?php echo $jside_version; ?>/p5.zip">
         <div class="download_box half_box">
         <h4>Mac OS X</h4>
         <p>p5 Editor<br>Version <?php echo $jside_version; ?></p>
@@ -84,12 +84,12 @@
         -->
         <div class="spacer"></div>
         </div>
-      
+
         <div class="link_group">
         <h3>ETC</h3>
-        <p>Older releases <a href="https://github.com/processing/p5.js/releases">p5</a>, <a href="https://github.com/antiboredom/jside/releases">editor</a><br>
-        Github <a href="https://github.com/processing/p5.js">p5</a>, <a href="https://github.com/antiboredom/jside">editor</a><br>
-        Report bugs <a href="https://github.com/processing/p5.js/issues">p5</a>, <a href="https://github.com/antiboredom/jside/issues">editor</a><br>
+        <p>Older releases <a href="https://github.com/processing/p5.js/releases">p5</a>, <a href="https://github.com/processing/p5.js-editor/releases">editor</a><br>
+        Github <a href="https://github.com/processing/p5.js">p5</a>, <a href="https://github.com/processing/p5.js-editor">editor</a><br>
+        Report bugs <a href="https://github.com/processing/p5.js/issues">p5</a>, <a href="https://github.com/processing/p5.js-editor/issues">editor</a><br>
         Supported browsers <a href="https://github.com/processing/p5.js/wiki/Supported-browsers">editor</a></p>
         </a>
 

--- a/download/index.php
+++ b/download/index.php
@@ -60,10 +60,10 @@
         <p>The p5.js editor is currently in development, try out an alpha version of it now. Help out by posting
         <a href="https://github.com/processing/p5.js-editor/issues">feedback and bugs</a>. Support for Windows and Linux
         coming soon, along with more <a href="https://github.com/processing/p5.js-editor/labels/enhancement">features</a>.</p>
-        <a href="https://github.com/processing/p5.js-editor/releases/download/v<?php echo $jside_version; ?>/p5.zip">
+        <a href="https://github.com/processing/p5.js-editor/releases/download/v<?php echo $p5jseditor_version; ?>/p5.zip">
         <div class="download_box half_box">
         <h4>Mac OS X</h4>
-        <p>p5 Editor<br>Version <?php echo $jside_version; ?></p>
+        <p>p5 Editor<br>Version <?php echo $p5jseditor_version; ?></p>
         </div>
         </a>
 

--- a/download/release.php
+++ b/download/release.php
@@ -67,7 +67,7 @@ function updateLib($jside_v) {
 
 function updateJSIDE($lib_v, $lib_d) {
 
-  $r = 'https://raw.githubusercontent.com/antiboredom/jside/master/';
+  $r = 'https://raw.githubusercontent.com/processing/p5.js-editor/master/';
   download($r.'package.json', 'package.json');
   $v = getPackageVersion('package.json');
   unlink('package.json');

--- a/download/release.php
+++ b/download/release.php
@@ -54,32 +54,32 @@ function updateFiles() {
   download($r.'lib/addons/p5.sound.js', '../js/p5.sound.js');
 }
 
-function updateLib($jside_v) {
+function updateLib($p5jseditor_v) {
   updateFiles();
   $v = getLibVersion('../js/p5.min.js');
   //unlink('p5.min.js');
   echo 'updating library to v'.$v[0].' ('.$v[1].')';
-  $contents = '<?php $version = "'.$v[0].'"; $date = "'.$v[1].'"; $jside_version = "'.$jside_v.'"; ?>';
+  $contents = '<?php $version = "'.$v[0].'"; $date = "'.$v[1].'"; $p5jseditor_version = "'.$p5jseditor_v.'"; ?>';
 
   file_put_contents('version.php', $contents);
 }
 
 
-function updateJSIDE($lib_v, $lib_d) {
+function updateP5JSEDITOR($lib_v, $lib_d) {
 
   $r = 'https://raw.githubusercontent.com/processing/p5.js-editor/master/';
   download($r.'package.json', 'package.json');
   $v = getPackageVersion('package.json');
   unlink('package.json');
-  $contents = '<?php $version = "'.$lib_v.'"; $date = "'.$lib_d.'"; $jside_version = "'.$v.'"; ?>';
+  $contents = '<?php $version = "'.$lib_v.'"; $date = "'.$lib_d.'"; $p5jseditor_version = "'.$v.'"; ?>';
   file_put_contents('version.php', $contents);
 }
 
 if ($_GET['f'] == 'update_lib') {
-  updateLib($jside_version);
+  updateLib($p5jseditor_version);
 }
-else if ($_GET['f'] == 'update_jside') {
-  updateJSIDE($version, $date);
+else if ($_GET['f'] == 'update_p5jseditor') {
+  updateP5JSEDITOR($version, $date);
 }
 else if ($_GET['f'] == 'update_files') {
   updateFiles();

--- a/setup.sh
+++ b/setup.sh
@@ -6,12 +6,11 @@ cd download
 touch version.php
 
 # Call release.php, which populates the version file
-php -r '$_GET["f"] = "update_lib" ; $jside_version=""; include("release.php");'
-php -r '$_GET["f"] = "update_jside" ; include("release.php");'
+php -r '$_GET["f"] = "update_lib" ; $p5jseditor_version=""; include("release.php");'
+php -r '$_GET["f"] = "update_p5jseditor" ; include("release.php");'
 echo ""
 echo "New version.php looks like this:"
 cat version.php
 echo ""
 echo ""
 cd - &>/dev/null
-


### PR DESCRIPTION
`https://github.com/antiboredom/jside` changed to `https://github.com/processing/p5.js-editor`and other `jside` references on the PHP changed to `p5jseditor`.

Commented out code was left untouched.