### PR TITLE
fixed the Particle System & Forces examples

### DIFF
--- a/learn/examples_src/09_Simulate/01_Forces.js
+++ b/learn/examples_src/09_Simulate/01_Forces.js
@@ -84,7 +84,7 @@ Liquid.prototype.calculateDrag = function(m) {
   var dragMagnitude = this.c * speed * speed;
 
   // Direction is inverse of velocity
-  var dragForce = m.velocity.get();
+  var dragForce = m.velocity.copy();
   dragForce.mult(-1);
   
   // Scale according to magnitude

--- a/learn/examples_src/09_Simulate/02_ParticleSystem.js
+++ b/learn/examples_src/09_Simulate/02_ParticleSystem.js
@@ -20,7 +20,7 @@ function draw() {
 var Particle = function(position) {
   this.acceleration = createVector(0, 0.05);
   this.velocity = createVector(random(-1, 1), random(-1, 0));
-  this.position = position.get();
+  this.position = position.copy();
   this.lifespan = 255.0;
 };
 
@@ -54,7 +54,7 @@ Particle.prototype.isDead = function(){
 };
 
 var ParticleSystem = function(position) {
-  this.origin = position.get();
+  this.origin = position.copy();
   this.particles = [];
 };
 


### PR DESCRIPTION
I fixed the [Particle System](http://p5js.org/learn/examples/Simulate_Particle_System.php) and [Forces](http://p5js.org/learn/examples/Simulate_Forces.php) examples. They are broken because they are using get() but the method name has been changed to copy(). I found [commit 338b468](https://github.com/processing/p5.js/commit/338b468a1bb9c05104abeacf7c7f8d8dc6cd7f4e) of p5.js which gave me the answer.