### PR TITLE
fixed Triangle Strip example

### DIFF
--- a/learn/examples_src/01_Form/05_Triangle_Strip.js
+++ b/learn/examples_src/01_Form/05_Triangle_Strip.js
@@ -19,7 +19,7 @@ function setup() {
 function draw() {
   background(204);
   
-  var numPoints = map(mouseX, 0, width, 6, 60);
+  var numPoints = int(map(mouseX, 0, width, 6, 60));
   var angle = 0;
   var angleStep = 180.0/numPoints;
     


### PR DESCRIPTION
In the [triangle strip example](http://p5js.org/learn/examples/Form_Triangle_Strip.php) the map function is setting the numPoints variable to a double, creating triangles with the wrong angles and an incomplete ring, so I cast it to an int.
