### PR TITLE
Missing closing tags in Interactivity 1 example

### DIFF
--- a/examples/demos_src/01_Hello_P5/02_interactivity.js
+++ b/examples/demos_src/01_Hello_P5/02_interactivity.js
@@ -3,7 +3,8 @@
  * @frame 720,425
  * @description The circle changes color when you click on it.
  * <p><em><span class="small"> To run this example locally, you will need the
- * <a href="http://p5js.org/reference/#/libraries/p5.dom">p5.dom library</a>.
+ * <a href="http://p5js.org/reference/#/libraries/p5.dom">p5.dom library</a>
+ * </em></p>.
  */
 
 // for red, green, and blue color values

--- a/examples/demos_src/01_Hello_P5/02_interactivity.js
+++ b/examples/demos_src/01_Hello_P5/02_interactivity.js
@@ -3,8 +3,8 @@
  * @frame 720,425
  * @description The circle changes color when you click on it.
  * <p><em><span class="small"> To run this example locally, you will need the
- * <a href="http://p5js.org/reference/#/libraries/p5.dom">p5.dom library</a>
- * </em></p>.
+ * <a href="http://p5js.org/reference/#/libraries/p5.dom">p5.dom library</a>.
+ * </em></p>
  */
 
 // for red, green, and blue color values


### PR DESCRIPTION
Missing closing tags puts the code in the editor into italics.

![image](https://cloud.githubusercontent.com/assets/451107/7947733/04e1f8fc-094d-11e5-8e35-ffc798314db7.png)
