### PR TITLE
Updates Modify DOM Example to use selectAll instead of getElements

### DIFF
--- a/examples/examples_src/16_Dom/07_Modify_DOM.js
+++ b/examples/examples_src/16_Dom/07_Modify_DOM.js
@@ -29,7 +29,7 @@ function setup() {
   // This line grabs the paragraph just created, but it would 
   // also grab any other elements with class 'text' in the HTML
   // page.
-  var texts = getElements('text');
+  var texts = selectAll('.text');
 
   for (var i=0; i<texts.length; i++) {
     var paragraph = texts[i].html();


### PR DESCRIPTION
Before only loading sadness:

![screen shot 2015-07-24 at 2 08 16 pm](https://cloud.githubusercontent.com/assets/361387/8884688/7303bfc6-320d-11e5-8de5-bddc043bb322.png)

Now, moving happiness.

![asdf](https://cloud.githubusercontent.com/assets/361387/8884682/70760200-320d-11e5-8d5c-c2f4adaab55c.gif)

