### PR TITLE
Fix for mobile example pages

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -626,13 +626,18 @@ h3.contribute-title{
   right: 0;
   bottom: 0;
   z-index: 1000;
-  display: none;
+  /*display: none;*/
+  border: none;
 }
 
-#popupExampleFrame #exampleFrame {
+/*#popupExampleFrame #exampleFrame {
   width: 100%;
   height: 100%;
-}
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 999;
+}*/
 
 #exampleDisplay button {
     color: #2D7BB6;

--- a/examples/build_examples/build.js
+++ b/examples/build_examples/build.js
@@ -101,7 +101,7 @@ function buildFolder(type, inputRoot, outputRoot, folder, cb0) {
 
           var content;
           
-          // If this is for Mobile examples, use mobile_example_template
+          //If this is for Mobile examples, use mobile_example_template
           if (folderName.indexOf('Mobile') >= 0) {
             content = mobile_example_template({'type':type, 
                                             'formattedType':formattedType, 
@@ -110,7 +110,7 @@ function buildFolder(type, inputRoot, outputRoot, folder, cb0) {
                                             'js':code, 
                                             'file':inputRoot+folder+'/'+file});
           
-          // Otherwise use regular example template
+          //Otherwise use regular example template
           } else {
             content = example_template({'type':type, 
                                             'formattedType':formattedType, 

--- a/examples/build_examples/mobile_example_template.ejs
+++ b/examples/build_examples/mobile_example_template.ejs
@@ -6,7 +6,7 @@
     <?php include('../../sidebar.php'); ?>
 
     <!-- <div id="popupExampleFrame"></div> -->
-    <iframe id="exampleFrame" src="example.html" ></iframe>
+    <!-- <iframe id="exampleFrame" src="example.html" ></iframe> -->
     <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
     <!-- content sections -->
     <div class="column-span">
@@ -17,6 +17,7 @@
           <button id="isMobile-displayButton" class="display_button">display sketch</button>
 
           <div id="exampleDisplay">
+            <iframe id="exampleFrame" src="example.html" ></iframe>
             <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
             
             <div class="edit_space">
@@ -61,11 +62,12 @@
             $('#resetButton').hide();
           }
 
-          $('#isMobile-displayButton').click( function() { 
-            $('#exampleFrame').show();
-            // $('#popupExampleFrame').show();
-           examples.init('<%=file%>');
-          });
+          // $('#isMobile-displayButton').click( function() { 
+          //   $('#exampleFrame').show();
+          //   // $('#popupExampleFrame').show();
+          //  examples.init('<%=file%>');
+          // });
+          examples.init('<%=file%>');
            
       });
 

--- a/examples/build_examples/mobile_example_template.ejs
+++ b/examples/build_examples/mobile_example_template.ejs
@@ -5,8 +5,9 @@
 
     <?php include('../../sidebar.php'); ?>
 
-    <div id="popupExampleFrame"></div>
-
+    <!-- <div id="popupExampleFrame"></div> -->
+    <iframe id="exampleFrame" src="example.html" ></iframe>
+    <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
     <!-- content sections -->
     <div class="column-span">
       <section>
@@ -17,6 +18,7 @@
 
           <div id="exampleDisplay">
             <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
+            
             <div class="edit_space">
               <button id="runButton" class="edit_button">run</button>
               <button id="resetButton" class="reset_button">reset</button>
@@ -44,8 +46,10 @@
     <script src="../../js/examples.js"></script>
     <script>
       $(document).ready( function () {
+          //examples.init('<%=file%>');
           var isMobile = window.matchMedia("only screen and (max-width: 480px)");
-          examples.init('<%=file%>');
+          $('#exampleFrame').hide();
+          // $('#popupExampleFrame').hide();
           if (isMobile.matches) {
           //Conditional script here
             $('#notMobile-message').hide();
@@ -56,7 +60,16 @@
             $('#runButton').hide();
             $('#resetButton').hide();
           }
+
+          $('#isMobile-displayButton').click( function() { 
+            $('#exampleFrame').show();
+            // $('#popupExampleFrame').show();
+           examples.init('<%=file%>');
+          });
+           
       });
+
+
     </script>
   </body>
 </html>

--- a/examples/examples/Mobile_Acceleration_Ball_Bounce.php
+++ b/examples/examples/Mobile_Acceleration_Ball_Bounce.php
@@ -5,8 +5,9 @@
 
     <?php include('../../sidebar.php'); ?>
 
-    <div id="popupExampleFrame"></div>
-
+    <!-- <div id="popupExampleFrame"></div> -->
+    <iframe id="exampleFrame" src="example.html" ></iframe>
+    <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
     <!-- content sections -->
     <div class="column-span">
       <section>
@@ -18,6 +19,7 @@
 
           <div id="exampleDisplay">
             <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
+            
             <div class="edit_space">
               <button id="runButton" class="edit_button">run</button>
               <button id="resetButton" class="reset_button">reset</button>
@@ -45,8 +47,10 @@
     <script src="../../js/examples.js"></script>
     <script>
       $(document).ready( function () {
+          //examples.init('../examples_src/35_Mobile/00_acceleration_ballBounce.js');
           var isMobile = window.matchMedia("only screen and (max-width: 480px)");
-          examples.init('../examples_src/35_Mobile/00_acceleration_ballBounce.js');
+          $('#exampleFrame').hide();
+          // $('#popupExampleFrame').hide();
           if (isMobile.matches) {
           //Conditional script here
             $('#notMobile-message').hide();
@@ -57,7 +61,25 @@
             $('#runButton').hide();
             $('#resetButton').hide();
           }
+
+          $('#isMobile-displayButton').click( function() { 
+            $('#exampleFrame').show();
+            // $('#popupExampleFrame').show();
+           examples.init('../examples_src/35_Mobile/00_acceleration_ballBounce.js');
+          });
+
+          // $('#exampleFrame').width('100%');
+          // $('#exampleFrame').height('100%');
+           //$('#exampleFrame').height(window.innerHeight);
+
+          // $('#exampleFrame').css('position', 'fixed');
+          // $('#exampleFrame').css('top', '0px');
+          // $('#exampleFrame').css('left', '0px');
+          // $('#exampleFrame').css('z-index', '999');
+           
       });
+
+
     </script>
   </body>
 </html>

--- a/examples/examples/Mobile_Acceleration_Ball_Bounce.php
+++ b/examples/examples/Mobile_Acceleration_Ball_Bounce.php
@@ -6,7 +6,7 @@
     <?php include('../../sidebar.php'); ?>
 
     <!-- <div id="popupExampleFrame"></div> -->
-    <iframe id="exampleFrame" src="example.html" ></iframe>
+    <!-- <iframe id="exampleFrame" src="example.html" ></iframe> -->
     <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
     <!-- content sections -->
     <div class="column-span">
@@ -18,6 +18,7 @@
           <button id="isMobile-displayButton" class="display_button">display sketch</button>
 
           <div id="exampleDisplay">
+            <iframe id="exampleFrame" src="example.html" ></iframe>
             <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
             
             <div class="edit_space">
@@ -62,20 +63,12 @@
             $('#resetButton').hide();
           }
 
-          $('#isMobile-displayButton').click( function() { 
-            $('#exampleFrame').show();
-            // $('#popupExampleFrame').show();
-           examples.init('../examples_src/35_Mobile/00_acceleration_ballBounce.js');
-          });
-
-          // $('#exampleFrame').width('100%');
-          // $('#exampleFrame').height('100%');
-           //$('#exampleFrame').height(window.innerHeight);
-
-          // $('#exampleFrame').css('position', 'fixed');
-          // $('#exampleFrame').css('top', '0px');
-          // $('#exampleFrame').css('left', '0px');
-          // $('#exampleFrame').css('z-index', '999');
+          // $('#isMobile-displayButton').click( function() { 
+          //   $('#exampleFrame').show();
+          //   // $('#popupExampleFrame').show();
+          //  examples.init('../examples_src/35_Mobile/00_acceleration_ballBounce.js');
+          // });
+          examples.init('../examples_src/35_Mobile/00_acceleration_ballBounce.js');
            
       });
 

--- a/examples/examples/Mobile_Acceleration_Color.php
+++ b/examples/examples/Mobile_Acceleration_Color.php
@@ -5,8 +5,9 @@
 
     <?php include('../../sidebar.php'); ?>
 
-    <div id="popupExampleFrame"></div>
-
+    <!-- <div id="popupExampleFrame"></div> -->
+    <iframe id="exampleFrame" src="example.html" ></iframe>
+    <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
     <!-- content sections -->
     <div class="column-span">
       <section>
@@ -18,6 +19,7 @@
 
           <div id="exampleDisplay">
             <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
+            
             <div class="edit_space">
               <button id="runButton" class="edit_button">run</button>
               <button id="resetButton" class="reset_button">reset</button>
@@ -45,8 +47,10 @@
     <script src="../../js/examples.js"></script>
     <script>
       $(document).ready( function () {
+          //examples.init('../examples_src/35_Mobile/02_accelerationColor.js');
           var isMobile = window.matchMedia("only screen and (max-width: 480px)");
-          examples.init('../examples_src/35_Mobile/02_accelerationColor.js');
+          $('#exampleFrame').hide();
+          // $('#popupExampleFrame').hide();
           if (isMobile.matches) {
           //Conditional script here
             $('#notMobile-message').hide();
@@ -57,7 +61,25 @@
             $('#runButton').hide();
             $('#resetButton').hide();
           }
+
+          $('#isMobile-displayButton').click( function() { 
+            $('#exampleFrame').show();
+            // $('#popupExampleFrame').show();
+           examples.init('../examples_src/35_Mobile/02_accelerationColor.js');
+          });
+
+          // $('#exampleFrame').width('100%');
+          // $('#exampleFrame').height('100%');
+           //$('#exampleFrame').height(window.innerHeight);
+
+          // $('#exampleFrame').css('position', 'fixed');
+          // $('#exampleFrame').css('top', '0px');
+          // $('#exampleFrame').css('left', '0px');
+          // $('#exampleFrame').css('z-index', '999');
+           
       });
+
+
     </script>
   </body>
 </html>

--- a/examples/examples/Mobile_Acceleration_Color.php
+++ b/examples/examples/Mobile_Acceleration_Color.php
@@ -6,7 +6,7 @@
     <?php include('../../sidebar.php'); ?>
 
     <!-- <div id="popupExampleFrame"></div> -->
-    <iframe id="exampleFrame" src="example.html" ></iframe>
+    <!-- <iframe id="exampleFrame" src="example.html" ></iframe> -->
     <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
     <!-- content sections -->
     <div class="column-span">
@@ -18,6 +18,7 @@
           <button id="isMobile-displayButton" class="display_button">display sketch</button>
 
           <div id="exampleDisplay">
+            <iframe id="exampleFrame" src="example.html" ></iframe>
             <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
             
             <div class="edit_space">
@@ -62,20 +63,12 @@
             $('#resetButton').hide();
           }
 
-          $('#isMobile-displayButton').click( function() { 
-            $('#exampleFrame').show();
-            // $('#popupExampleFrame').show();
-           examples.init('../examples_src/35_Mobile/02_accelerationColor.js');
-          });
-
-          // $('#exampleFrame').width('100%');
-          // $('#exampleFrame').height('100%');
-           //$('#exampleFrame').height(window.innerHeight);
-
-          // $('#exampleFrame').css('position', 'fixed');
-          // $('#exampleFrame').css('top', '0px');
-          // $('#exampleFrame').css('left', '0px');
-          // $('#exampleFrame').css('z-index', '999');
+          // $('#isMobile-displayButton').click( function() { 
+          //   $('#exampleFrame').show();
+          //   // $('#popupExampleFrame').show();
+          //  examples.init('../examples_src/35_Mobile/02_accelerationColor.js');
+          // });
+          examples.init('../examples_src/35_Mobile/02_accelerationColor.js');
            
       });
 

--- a/examples/examples/Mobile_Shake_Ball_Bounce.php
+++ b/examples/examples/Mobile_Shake_Ball_Bounce.php
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+
+  <?php include('../../header.php'); ?>
+  <body id="learn-page">
+
+    <?php include('../../sidebar.php'); ?>
+
+    <!-- <div id="popupExampleFrame"></div> -->
+    <!-- <iframe id="exampleFrame" src="example.html" ></iframe> -->
+    <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
+    <!-- content sections -->
+    <div class="column-span">
+      <section>
+          <p id="backlink"><a href="../#examples">< Back to Examples</a></p>
+          <h2>Shake Ball Bounce</h2>
+          <p>Create a Ball class, instantiate multiple objects, move it around the screen, and bounce when touch the edge of the canvas.
+ Detect shake event based on total change in accelerationX and accelerationY and speed up or slow down objects based on detection. 
+ </p>
+          <button id="isMobile-displayButton" class="display_button">display sketch</button>
+
+          <div id="exampleDisplay">
+            <iframe id="exampleFrame" src="example.html" ></iframe>
+            <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
+            
+            <div class="edit_space">
+              <button id="runButton" class="edit_button">run</button>
+              <button id="resetButton" class="reset_button">reset</button>
+            </div>
+            <div id="exampleEditor"></div>
+          </div>
+
+          <p><a style="border-bottom:none !important;" href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target=_blank><img src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" style="width:88px"/></a></p>
+      </section>
+
+      <?php include('../../footer.php'); ?>
+    </div><!-- end column-span -->
+
+    <!-- outside of column for footer to go across both -->
+
+    <p class="clearfix"> &nbsp; </p>
+
+    <object type="image/svg+xml" data="../../img/thick-asterisk-alone.svg" id="asterisk-design-element">
+         *<!-- to do: add fallback image in CSS -->
+    </object>
+
+    <?php include('../../end.php'); ?>
+
+    <script src="../../js/vendor/ace-nc/ace.js"></script>
+    <script src="../../js/examples.js"></script>
+    <script>
+      $(document).ready( function () {
+          //examples.init('../examples_src/35_Mobile/03_shake_ballBounce.js');
+          var isMobile = window.matchMedia("only screen and (max-width: 480px)");
+          $('#exampleFrame').hide();
+          // $('#popupExampleFrame').hide();
+          if (isMobile.matches) {
+          //Conditional script here
+            $('#notMobile-message').hide();
+            $('#isMobile-displayButton').show();           
+          } else {
+            $('#notMobile-message').show();
+            $('#isMobile-displayButton').hide();
+            $('#runButton').hide();
+            $('#resetButton').hide();
+          }
+
+          // $('#isMobile-displayButton').click( function() { 
+          //   $('#exampleFrame').show();
+          //   // $('#popupExampleFrame').show();
+          //  examples.init('../examples_src/35_Mobile/03_shake_ballBounce.js');
+          // });
+          examples.init('../examples_src/35_Mobile/03_shake_ballBounce.js');
+           
+      });
+
+
+    </script>
+  </body>
+</html>

--- a/examples/examples/Mobile_Simple_Draw.php
+++ b/examples/examples/Mobile_Simple_Draw.php
@@ -6,7 +6,7 @@
     <?php include('../../sidebar.php'); ?>
 
     <!-- <div id="popupExampleFrame"></div> -->
-    <iframe id="exampleFrame" src="example.html" ></iframe>
+    <!-- <iframe id="exampleFrame" src="example.html" ></iframe> -->
     <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
     <!-- content sections -->
     <div class="column-span">
@@ -18,6 +18,7 @@
           <button id="isMobile-displayButton" class="display_button">display sketch</button>
 
           <div id="exampleDisplay">
+            <iframe id="exampleFrame" src="example.html" ></iframe>
             <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
             
             <div class="edit_space">
@@ -62,20 +63,12 @@
             $('#resetButton').hide();
           }
 
-          $('#isMobile-displayButton').click( function() { 
-            $('#exampleFrame').show();
-            // $('#popupExampleFrame').show();
-           examples.init('../examples_src/35_Mobile/01_simpleDraw.js');
-          });
-
-          // $('#exampleFrame').width('100%');
-          // $('#exampleFrame').height('100%');
-           //$('#exampleFrame').height(window.innerHeight);
-
-          // $('#exampleFrame').css('position', 'fixed');
-          // $('#exampleFrame').css('top', '0px');
-          // $('#exampleFrame').css('left', '0px');
-          // $('#exampleFrame').css('z-index', '999');
+          // $('#isMobile-displayButton').click( function() { 
+          //   $('#exampleFrame').show();
+          //   // $('#popupExampleFrame').show();
+          //  examples.init('../examples_src/35_Mobile/01_simpleDraw.js');
+          // });
+          examples.init('../examples_src/35_Mobile/01_simpleDraw.js');
            
       });
 

--- a/examples/examples/Mobile_Simple_Draw.php
+++ b/examples/examples/Mobile_Simple_Draw.php
@@ -5,8 +5,9 @@
 
     <?php include('../../sidebar.php'); ?>
 
-    <div id="popupExampleFrame"></div>
-
+    <!-- <div id="popupExampleFrame"></div> -->
+    <iframe id="exampleFrame" src="example.html" ></iframe>
+    <!-- <iframe id="popupExampleFrame" src="example.html" ></iframe> -->
     <!-- content sections -->
     <div class="column-span">
       <section>
@@ -18,6 +19,7 @@
 
           <div id="exampleDisplay">
             <p id="notMobile-message">Open this page on a mobile device to display the sketch</p>
+            
             <div class="edit_space">
               <button id="runButton" class="edit_button">run</button>
               <button id="resetButton" class="reset_button">reset</button>
@@ -45,8 +47,10 @@
     <script src="../../js/examples.js"></script>
     <script>
       $(document).ready( function () {
+          //examples.init('../examples_src/35_Mobile/01_simpleDraw.js');
           var isMobile = window.matchMedia("only screen and (max-width: 480px)");
-          examples.init('../examples_src/35_Mobile/01_simpleDraw.js');
+          $('#exampleFrame').hide();
+          // $('#popupExampleFrame').hide();
           if (isMobile.matches) {
           //Conditional script here
             $('#notMobile-message').hide();
@@ -57,7 +61,25 @@
             $('#runButton').hide();
             $('#resetButton').hide();
           }
+
+          $('#isMobile-displayButton').click( function() { 
+            $('#exampleFrame').show();
+            // $('#popupExampleFrame').show();
+           examples.init('../examples_src/35_Mobile/01_simpleDraw.js');
+          });
+
+          // $('#exampleFrame').width('100%');
+          // $('#exampleFrame').height('100%');
+           //$('#exampleFrame').height(window.innerHeight);
+
+          // $('#exampleFrame').css('position', 'fixed');
+          // $('#exampleFrame').css('top', '0px');
+          // $('#exampleFrame').css('left', '0px');
+          // $('#exampleFrame').css('z-index', '999');
+           
       });
+
+
     </script>
   </body>
 </html>

--- a/examples/examples_src/35_Mobile/00_acceleration_ballBounce.js
+++ b/examples/examples_src/35_Mobile/00_acceleration_ballBounce.js
@@ -19,9 +19,7 @@ var vMultiplier = 0.007;
 var bMultiplier = 0.6;
 
 function setup() {
-    // createCanvas(windowWidth, windowHeight);
-    createCanvas(windowWidth, windowHeight);
-    //frameRate(2000);
+    createCanvas(displayWidth, displayHeight);
     fill(0);
 }
 
@@ -60,3 +58,4 @@ function ballMove() {
  	}
 	
 }
+

--- a/examples/examples_src/35_Mobile/00_acceleration_ballBounce.js
+++ b/examples/examples_src/35_Mobile/00_acceleration_ballBounce.js
@@ -19,8 +19,9 @@ var vMultiplier = 0.007;
 var bMultiplier = 0.6;
 
 function setup() {
-    createCanvas(710, 400);
-    frameRate(2000);
+    // createCanvas(windowWidth, windowHeight);
+    createCanvas(windowWidth, windowHeight);
+    //frameRate(2000);
     fill(0);
 }
 

--- a/examples/examples_src/35_Mobile/01_simpleDraw.js
+++ b/examples/examples_src/35_Mobile/01_simpleDraw.js
@@ -4,7 +4,7 @@
  */
 
  function setup() {
- 	createCanvas(710, 400);
+ 	createCanvas(windowWidth, windowHeight);
 	strokeWeight(10)
 	stroke(0);
 }

--- a/examples/examples_src/35_Mobile/01_simpleDraw.js
+++ b/examples/examples_src/35_Mobile/01_simpleDraw.js
@@ -4,7 +4,7 @@
  */
 
  function setup() {
- 	createCanvas(windowWidth, windowHeight);
+ 	createCanvas(displayWidth, displayHeight);
 	strokeWeight(10)
 	stroke(0);
 }
@@ -13,3 +13,4 @@ function touchMoved() {
 	line(touchX, touchY, ptouchX, ptouchY);
 	return false;
 }
+

--- a/examples/examples_src/35_Mobile/02_accelerationColor.js
+++ b/examples/examples_src/35_Mobile/02_accelerationColor.js
@@ -6,8 +6,7 @@
 var r, g, b;
 
 function setup() {
-  createCanvas(windowWidth, windowHeight);
-  
+  createCanvas(displayWidth, displayHeight);
   r = random(50, 255);
   g = random(0, 200);
   b = random(50, 255);
@@ -15,6 +14,7 @@ function setup() {
 
 function draw() {
   background(r, g, b);
+  console.log('draw');
 }
 
 function deviceMoved() {   
@@ -22,4 +22,6 @@ function deviceMoved() {
     g = map(accelerationY, -90, 90, 100, 200);
     b = map(accelerationZ, -90, 90, 100, 200);   
 }
+
+
 

--- a/examples/examples_src/35_Mobile/02_accelerationColor.js
+++ b/examples/examples_src/35_Mobile/02_accelerationColor.js
@@ -6,7 +6,7 @@
 var r, g, b;
 
 function setup() {
-  createCanvas(710, 400);
+  createCanvas(windowWidth, windowHeight);
   
   r = random(50, 255);
   g = random(0, 200);

--- a/examples/examples_src/35_Mobile/03_shake_ballBounce.js
+++ b/examples/examples_src/35_Mobile/03_shake_ballBounce.js
@@ -1,0 +1,117 @@
+/*
+ * @name Shake Ball Bounce
+ * @description Create a Ball class, instantiate multiple objects, move it around the screen, and bounce when touch the edge of the canvas.
+ * Detect shake event based on total change in accelerationX and accelerationY and speed up or slow down objects based on detection. 
+ */
+
+var balls = []; 
+
+var threshold = 30;
+var accChangeX = 0; 
+var accChangeY = 0;
+var accChangeT = 0;
+
+function setup() {
+  createCanvas(displayWidth, displayHeight);
+  
+  for (var i=0; i<20; i++) {
+    balls.push(new Ball());
+  }
+}
+
+function draw() {
+  background(0);
+  
+  for (var i=0; i<balls.length; i++) { 
+    balls[i].move(); 
+    balls[i].display();    
+  }
+
+  checkForShake();
+ }
+
+// Ball class
+function Ball() {
+  this.x = random(width);
+  this.y = random(height);
+  this.diameter = random(10, 30);
+  this.xspeed = random(-2, 2);
+  this.yspeed = random(-2, 2);
+  this.oxspeed = this.xspeed;
+  this.oyspeed = this.yspeed;
+  this.direction = 0.7;
+
+  this.move = function() {
+    this.x += this.xspeed * this.direction;
+    this.y += this.yspeed * this.direction;       
+  };
+  
+  // Bounce when touch the edge of the canvas  
+  this.turn = function() {
+    if (this.x < 0) { 
+      this.x = 0; 
+      this.direction = -this.direction; 
+    }
+    else if (this.y < 0) { 
+      this.y = 0; 
+      this.direction = -this.direction;   
+    }
+    else if (this.x > width - 20) { 
+      this.x = width - 20; 
+      this.direction = -this.direction; 
+    }
+    else if (this.y > height - 20) { 
+      this.y = height - 20; 
+      this.direction = -this.direction;   
+    } 
+  };
+
+  // Add to xspeed and yspeed based on 
+  // the change in accelerationX value
+  this.shake = function() {
+    this.xspeed += random(5, accChangeX/3);
+    this.yspeed += random(5, accChangeX/3);
+  };
+
+  // Gradually slows down 
+  this.stopShake = function() {
+    if (this.xspeed > this.oxspeed) {
+      this.xspeed -= 0.6;
+    } 
+    else {
+      this.xspeed = this.oxspeed;
+    }
+    if (this.yspeed > this.oyspeed) {
+      this.yspeed -= 0.6;
+    } 
+    else {
+      this.yspeed = this.oyspeed;
+    }
+  };
+
+  this.display = function() {
+    ellipse(this.x, this.y, this.diameter, this.diameter);
+  };
+}
+
+function checkForShake() {
+  // Calculate total change in accelerationX and accelerationY
+  accChangeX = abs(accelerationX - pAccelerationX);
+  accChangeY = abs(accelerationY - pAccelerationY);
+  accChangeT = accChangeX + accChangeY;
+  // If shake
+  if (accChangeT >= threshold) {
+    for (var i=0; i<balls.length; i++) {
+      balls[i].shake();
+      balls[i].turn();
+    }
+  } 
+  // If not shake
+  else {
+    for (var i=0; i<balls.length; i++) {
+      balls[i].stopShake();
+      balls[i].turn();
+      balls[i].move(); 
+    }
+  }
+}

--- a/examples/index.php
+++ b/examples/index.php
@@ -394,6 +394,9 @@
           <a href="examples/Mobile_Acceleration_Color.php">Acceleration Color</a><br>
           
         
+          <a href="examples/Mobile_Shake_Ball_Bounce.php">Shake Ball Bounce</a><br>
+          
+        
         </p>
         
       

--- a/js/examples.js
+++ b/js/examples.js
@@ -21,15 +21,20 @@ var examples = {
 
     // Mobile Button
     
-    $('#isMobile-displayButton').click( function() { 
-      $('#popupExampleFrame').html('<iframe id="exampleFrame" src="example.html" ></iframe>').show();
-      $('body').addClass('freeze');
+    // $('#isMobile-displayButton').click( function() { 
+    //   // $('#popupExampleFrame').html('<iframe id="exampleFrame" src="example.html" ></iframe>').show();
+    //   // $('body').addClass('freeze');
+    //   $('#popupExampleFrame').html('<iframe id="exampleFrame" src="example.html" ></iframe>').show();
 
-      $('#exampleFrame').load(function() {
-        examples.loadExample(true);
-      });
+    //   $('#exampleFrame').load(function() {
+    //     examples.loadExample(true);
+    //   });
        
-    });
+    // });
+
+    // $('#popupExampleFrame').load(function() {
+    //   examples.loadExample(true);
+    // });
 
     // Example Frame
 
@@ -51,6 +56,7 @@ var examples = {
       var frameRe = /@frame (.*),(.*)/g;
       //var re = /createCanvas\((.*),(.*)\)/g;
       var arr = data.split(frameRe);
+      //var arr = data.split(re);
       if (arr.length > 2) {
         examples.dims[0] = arr[1];
         examples.dims[1] = arr[2];
@@ -74,12 +80,14 @@ var examples = {
     examples.runExample();
     $('#exampleDisplay').show();
   },
+  // display iframe
   runExample: function() {
     $('#exampleFrame').attr('src', $('#exampleFrame').attr('src'));
   },
   resetExample: function() {
     examples.showExample();
   },
+  // load script into iframe
   loadExample: function(isMobile) {
     var exampleCode = examples.editor.getSession().getValue();
 
@@ -90,15 +98,25 @@ var examples = {
       }
 
       if(isMobile) {
-        var re = /createCanvas\((.*),(.*)\)/g;
-        var arr = exampleCode.split(re);
+        // var re = /createCanvas\((.*),(.*)\)/g;
+        // var arr = exampleCode.split(re);
         $('#exampleFrame').height('100%');
         $('#exampleFrame').width('100%');
-
-        if (examples.dims.length < 2) {
-          var re = /createCanvas\((.*),(.*)\)/g;
-          exampleCode = exampleCode.replace(re, 'createCanvas(windowWidth, windowHeight)');
-        }
+        $('#exampleFrame').css('position', 'fixed');
+          $('#exampleFrame').css('top', '0px');
+          $('#exampleFrame').css('left', '0px');
+          $('#exampleFrame').css('z-index', '999');
+        // if (examples.dims.length < 2) {
+        //   var re = /createCanvas\((.*),(.*)\)/g;
+        //   exampleCode = exampleCode.replace(re, 'createCanvas(windowWidth, windowHeight)');
+        // }
+        // if (examples.dims.length < 2) {
+        //   var re = /createCanvas\((.*),(.*)\)/g;
+        //   var arr = exampleCode.split(re);
+        //   $('#exampleFrame').height(arr[2]+'px');
+        // } else {
+        //   $('#exampleFrame').height(examples.dims[1]+'px');
+        // }
       } else {
         if (examples.dims.length < 2) {
           var re = /createCanvas\((.*),(.*)\)/g;

--- a/js/examples.js
+++ b/js/examples.js
@@ -107,11 +107,11 @@ var examples = {
         $('#exampleFrame').css('z-index', '999');
         // var re = /createCanvas\((.*),(.*)\)/g;
         //   var arr = exampleCode.split(re);
-        var height = $(screen).height();
-        var width = $(screen).width()
-          $('#exampleFrame').css('height', height+'px');
-          $('#exampleFrame').css('width', width+'px');
-          console.log(height + ' ,' + width);
+        // var height = $(screen).height();
+        // var width = $(screen).width()
+        //   $('#exampleFrame').css('height', height+'px');
+        //   $('#exampleFrame').css('width', width+'px');
+        //   console.log(height + ' ,' + width);
         //exampleCode = exampleCode.replace(/windowWidth/, winWidth).replace(/windowHeight/, winHeight);
 
       // var userCSS = $('#exampleFrame')[0].contentWindow.document.createElement('style');

--- a/js/examples.js
+++ b/js/examples.js
@@ -18,29 +18,29 @@ var examples = {
     $('#resetButton').click( function() { 
     examples.resetExample();        
     });
-
-    // Mobile Button
     
-    // $('#isMobile-displayButton').click( function() { 
-    //   // $('#popupExampleFrame').html('<iframe id="exampleFrame" src="example.html" ></iframe>').show();
-    //   // $('body').addClass('freeze');
-    //   $('#popupExampleFrame').html('<iframe id="exampleFrame" src="example.html" ></iframe>').show();
-
-    //   $('#exampleFrame').load(function() {
-    //     examples.loadExample(true);
-    //   });
-       
-    // });
-
-    // $('#popupExampleFrame').load(function() {
-    //   examples.loadExample(true);
-    // });
 
     // Example Frame
+    if($("#isMobile-displayButton").length == 0) {
+      //it not mobile
+      
+      $('#exampleFrame').load(function() {
+          examples.loadExample(false);
+      });
+    } else {
+      $('#isMobile-displayButton').click( function() { 
+            
+           $('#exampleFrame').show();
+           $('#exampleFrame').ready(function() {
+              // alert('exampleFrame load')
+              examples.loadExample(true);
+            });
+                      
+      });
+      
+      
+    }
 
-    $('#exampleFrame').load(function() {
-      examples.loadExample(false);
-    });
 
 
   // Capture clicks
@@ -90,7 +90,7 @@ var examples = {
   // load script into iframe
   loadExample: function(isMobile) {
     var exampleCode = examples.editor.getSession().getValue();
-
+    
     try {       
 
       if (exampleCode.indexOf('new p5()') === -1) {
@@ -98,25 +98,27 @@ var examples = {
       }
 
       if(isMobile) {
-        // var re = /createCanvas\((.*),(.*)\)/g;
-        // var arr = exampleCode.split(re);
-        $('#exampleFrame').height('100%');
-        $('#exampleFrame').width('100%');
+
         $('#exampleFrame').css('position', 'fixed');
-          $('#exampleFrame').css('top', '0px');
-          $('#exampleFrame').css('left', '0px');
-          $('#exampleFrame').css('z-index', '999');
-        // if (examples.dims.length < 2) {
-        //   var re = /createCanvas\((.*),(.*)\)/g;
-        //   exampleCode = exampleCode.replace(re, 'createCanvas(windowWidth, windowHeight)');
-        // }
-        // if (examples.dims.length < 2) {
-        //   var re = /createCanvas\((.*),(.*)\)/g;
+        $('#exampleFrame').css('top', '0px');
+        $('#exampleFrame').css('left', '0px');
+        $('#exampleFrame').css('right', '0px');
+        $('#exampleFrame').css('bottom', '0px');
+        $('#exampleFrame').css('z-index', '999');
+        // var re = /createCanvas\((.*),(.*)\)/g;
         //   var arr = exampleCode.split(re);
-        //   $('#exampleFrame').height(arr[2]+'px');
-        // } else {
-        //   $('#exampleFrame').height(examples.dims[1]+'px');
-        // }
+        var height = $(screen).height();
+        var width = $(screen).width()
+          $('#exampleFrame').css('height', height+'px');
+          $('#exampleFrame').css('width', width+'px');
+          console.log(height + ' ,' + width);
+        //exampleCode = exampleCode.replace(/windowWidth/, winWidth).replace(/windowHeight/, winHeight);
+
+      // var userCSS = $('#exampleFrame')[0].contentWindow.document.createElement('style');
+      // userCSS.type = 'text/css';
+      // userCSS.innerHTML = 'html, body, canvas { width: 100% !important; height: 100% !important;}';
+      //$('#exampleFrame')[0].contentWindow.document.head.appendChild(userCSS);
+
       } else {
         if (examples.dims.length < 2) {
           var re = /createCanvas\((.*),(.*)\)/g;
@@ -127,12 +129,14 @@ var examples = {
         }
 
       }
-
+      
       var userScript = $('#exampleFrame')[0].contentWindow.document.createElement('script');
       userScript.type = 'text/javascript';
       userScript.text = exampleCode;
       userScript.async = false;
       $('#exampleFrame')[0].contentWindow.document.body.appendChild(userScript);
+
+
 
     } catch (e) {
       console.log(e.message);


### PR DESCRIPTION
On mobile browsers, loadExamples() is called only when the display example button is tapped. 

Having issue with displayWidth and displayHeight. The canvas is 1/2 of the screen width and height. I noticed that the website's header is also only 1/2 width of the screen on the example pages. 