### PR TITLE
Remove duplicate Functions link

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -37,9 +37,6 @@
           <a href="examples/Structure_Functions.php">Functions</a><br>
           
         
-          <a href="examples/Structure_Functions.php">Functions</a><br>
-          
-        
         </p>
         
       


### PR DESCRIPTION
I noticed that "Functions" appears twice on the Examples page, so removing the second one.