### PR TITLE
set textContent instead of innerHTML for reference examples

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -114,7 +114,7 @@ function renderCode(sel) {
           });
           edit_button.innerHTML = 'edit';
           edit_area.style.display = 'none';
-          sketch.innerHTML = edit_area.value;
+          sketch.textContent = edit_area.value;
           runCode(sketch, true, i);
         }
       }


### PR DESCRIPTION
this fixes #167 but only after the code is edited. So if we change the code to say ``x <width`` rather than say it with a space like ``x < width``, it won't break the code.

But still need to find where the HTML is set to begin with in the template. I think it has to do with this https://github.com/processing/p5.js-website/blob/master/reference/assets/js/reference.js#L6934 