### PR TITLE
tweak render.js to fix mouse/touch events on p5.Elements

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -173,8 +173,9 @@ function renderCode(sel) {
             var ind = runnable.indexOf(f);
             // this is a gross hack within a hacky script that
             // ensures the function names found are not substrings
+            // or methods of a p5.Element like cnv.mouseClicked().
             // proper use of regex would be preferable...
-            if (ind !== -1) {//} && runnable[ind+f.length] === '(') {
+            if (ind !== -1 && runnable[ind - 1] !== '.') {//} && runnable[ind+f.length] === '(') {
               with (p) {
                 p[f] = eval(f);
               }


### PR DESCRIPTION
I'd been using ``cnv.mouseClicked()`` to toggle sound in the inline reference examples. For example, [here](p5js.org/reference/#/p5.Amplitude). At some point, [this line in render.js](https://github.com/processing/p5.js-website/compare/master...therewasaguy:render?expand=1#diff-05aaf1f7b3e768c9abe28e85f5fe955bR169) caused them to stop working. This is because p5.Elements have methods with the same name as the p5 touch / mouse events that render.js is looking for. I changed the "gross hack" in render.js to make sure that those functions aren't preceded by a ``.``