### PR TITLE
Change sound note envelope to start w/ first note

### DIFF
--- a/examples/examples_src/33_Sound/09_Note_Envelope.js
+++ b/examples/examples_src/33_Sound/09_Note_Envelope.js
@@ -35,7 +35,7 @@ function setup() {
 function draw() {
   background(20);
 
-  if (frameCount % 60 == 0) {
+  if (frameCount % 60 == 0 || frameCount == 1) {
     var midiValue = scaleArray[note];
     var freqValue = midiToFreq(midiValue);
     osc.freq(freqValue);


### PR DESCRIPTION
In the [sound envelope example](http://p5js.org/examples/examples/Sound__Note_Envelope.php), because `frameCount` is `1` on the very first call to `draw()`, the note-setting code isn't triggered until one second into the sketch, which means the oscillator is playing its default frequency of 440hz for one second before the first note plays, which seems unintentional/weird (but perhaps I am wrong).

Another way to solve this might be to do `osc.freq(0)` or something during `setup()` I guess.