### PR TITLE
Ensure an eval() in render.js won't throw

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -166,7 +166,8 @@ function renderCode(sel) {
             // this is a gross hack within a hacky script that
             // ensures the function names found are not substrings
             // proper use of regex would be preferable...
-            if (ind !== -1 && runnable[ind+f.length] === '(') {
+            if (ind !== -1 && runnable[ind+f.length] === '(' &&
+                eval('typeof ' + f) !== 'undefined') {
               with (p) {
                 p[f] = eval(f);
               }


### PR DESCRIPTION
This is a hacky attempt to fix #188.

I'm actually not sure if there *is* a (reasonable) regex that will work for all possible snippets, since e.g. someone could define a `function draw() {}` within a closure that doesn't get added to the local scope... I'd rather just use a library like [esprima](http://esprima.org/) to walk the AST of the snippet and specifically pick out the top-level functions we need, but esprima isn't exactly a small library and it seems the reference pages are already a bit slow to load in some places, so I don't want to add to that.

Another more long-term option might be to actually run each sketch in its own iframe, though that could get expensive on pages with lots of examples...

So, just doing an `eval('typeof ' + f)` seemed to be the most lightweight solution that'd ensure the sort of "false positives" found in #188 wouldn't break the page. :disappointed: