### PR TITLE
remove p5 instances on reference page back button (hash change)

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -188,6 +188,9 @@ function renderCode(sel) {
     if (typeof Prism !== 'undefined') Prism.highlightAll();
 
     $( document ).ready(function() {
+
+      registerHashChange();
+
       setTimeout(function() {
         var myp5 = new _p5(s, cnv);      
         $( ".example-content" ).find('div').each(function() {
@@ -201,6 +204,16 @@ function renderCode(sel) {
       }, 100); 
     });
 
+  }
+
+  // when a hash is changed, remove all the sounds,
+  // even tho the p5 sketch has been disposed.
+  function registerHashChange() {
+    window.onhashchange = function(e) {
+      for (var i = 0; i < instances.length; i++) {
+        instances[i].remove();
+      }
+    }
   }
 
 }


### PR DESCRIPTION
fixes https://github.com/processing/p5.js-website/issues/186

looks like it was removed [here](https://github.com/processing/p5.js-website/commit/ff18b48612df460d63cc84fb11ac54e657c4db0f#diff-05aaf1f7b3e768c9abe28e85f5fe955bL198), maybe for good reasons that I'm not aware of? But I think that some hash change event listener is needed to remove sketches when navigating the reference - especially sketches that make noise!