### PR TITLE
Update rect() example text.

### DIFF
--- a/reference/data.json
+++ b/reference/data.json
@@ -4587,7 +4587,7 @@
                 "type": "P5"
             },
             "example": [
-                "\n<div>\n<code>\n// Draw a rectangle at location (30, 25) with a width and height of 55.\nrect(30, 20, 55, 55);\n</code>\n</div>\n\n<div>\n<code>\n// Draw a rectangle with rounded corners, each having a radius of 20.\nrect(30, 20, 55, 55, 20);\n</code>\n</div>\n\n<div>\n<code>\n// Draw a rectangle with rounded corners having the following radii:\n// top-left = 20, top-right = 15, bottom-right = 10, bottom-left = 5.\nrect(30, 20, 55, 55, 20, 15, 10, 5)\n</code>\n</div>"
+                "\n<div>\n<code>\n// Draw a rectangle at location (30, 20) with a width and height of 55.\nrect(30, 20, 55, 55);\n</code>\n</div>\n\n<div>\n<code>\n// Draw a rectangle with rounded corners, each having a radius of 20.\nrect(30, 20, 55, 55, 20);\n</code>\n</div>\n\n<div>\n<code>\n// Draw a rectangle with rounded corners having the following radii:\n// top-left = 20, top-right = 15, bottom-right = 10, bottom-left = 5.\nrect(30, 20, 55, 55, 20, 15, 10, 5)\n</code>\n</div>"
             ],
             "class": "p5",
             "module": "Shape",


### PR DESCRIPTION
Little fix to make the y coordinate of the comment in rect()'s first example reflect what is actually being drawn.