### PR TITLE
Examples/Math/Polar-to-Cartesian: Moved translate() from draw() to setup()

### DIFF
--- a/examples/examples_src/08_Math/08_polartocartesian.js
+++ b/examples/examples_src/08_Math/08_polartocartesian.js
@@ -19,14 +19,14 @@ function setup() {
   theta = 0;
   theta_vel = 0;
   theta_acc = 0.0001;
+  
+// Translate the origin point to the center of the screen
+  translate(width/2, height/2);
 }
 
 function draw() {
   
   background(0);
-  
-  // Translate the origin point to the center of the screen
-  translate(width/2, height/2);
   
   // Convert polar to cartesian
   var x = r * cos(theta);


### PR DESCRIPTION
translate() was part of the draw() loop, so on the p5.js webpage for this example, [the sketch looked blank](http://p5js.org/examples/examples/Math_PolarToCartesian.php), not showing the animation.

Moved translate() to setup() so that center of circle is set to center of canvas once.

[See this CodePen](http://codepen.io/AmundsenJunior/pen/RrKLWG) for working example of correction (running with p5.js 0.4.20, if that is a factor).

