### PR TITLE
add light mixture example

### DIFF
--- a/examples/examples/Lights_Mixture.php
+++ b/examples/examples/Lights_Mixture.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+  <?php include('../../header.php'); ?>
+  <body id="learn-page">
+
+    <?php include('../../sidebar.php'); ?>
+
+    <!-- content sections -->
+    <div class="column-span">
+      <section>
+          <p id="backlink"><a href="../#examples">< Back to Examples</a></p>
+          <h2>Mixture</h2>
+          <p>Display a box with three different kinds of lights.
+ </p>
+
+          <div id="exampleDisplay">
+            <iframe id="exampleFrame" src="example.html" ></iframe>
+            <div class="edit_space">
+              <button id="runButton" class="edit_button">run</button>
+              <button id="resetButton" class="reset_button">reset</button>
+            </div>
+            <div id="exampleEditor"></div>
+          </div>
+
+          <p><a style="border-bottom:none !important;" href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target=_blank><img src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" style="width:88px"/></a></p>
+      </section>
+
+      <?php include('../../footer.php'); ?>
+    </div><!-- end column-span -->
+
+    <!-- outside of column for footer to go across both -->
+
+    <p class="clearfix"> &nbsp; </p>
+
+    <object type="image/svg+xml" data="../../img/thick-asterisk-alone.svg" id="asterisk-design-element">
+         *<!-- to do: add fallback image in CSS -->
+    </object>
+
+    <?php include('../../end.php'); ?>
+
+    <script src="../../js/vendor/ace-nc/ace.js"></script>
+    <script src="../../js/examples.js"></script>
+    <script>
+      $(document).ready( function () {
+          examples.init('../examples_src/12_Lights/05_Mixture.js');
+      });
+    </script>
+  </body>
+</html>

--- a/examples/examples_src/12_Lights/05_Mixture.js
+++ b/examples/examples_src/12_Lights/05_Mixture.js
@@ -1,0 +1,29 @@
+/*
+ * @name Mixture
+ * @frame 710,400 (optional)
+ * @description Display a box with three different kinds of lights.
+ */
+function setup() {
+	createCanvas(710, 400, WEBGL);
+	noStroke();
+}
+
+function draw() {
+	background(0);
+
+	// // // Orange point light on the right
+	pointLight(150, 100, 0, // Color
+						 500, 0, 200); // Position
+
+	// // Blue directional light from the left
+	directionalLight(0, 102, 255,  // Color
+								   -1, 0, 0); // The x-, y-, z-axis direction
+
+	// Yellow spotlight from the front
+	pointLight(255, 255, 109, // Color
+			  		 0, 0, 300) // Position
+
+	rotateY(map(mouseX, 0, width, 0, PI));
+	rotateX(map(mouseY, 0, height, 0, PI));
+	box(200);
+}

--- a/examples/index.php
+++ b/examples/index.php
@@ -316,6 +316,9 @@
           <a href="examples/Lights_Directional.php">Directional</a><br>
           
         
+          <a href="examples/Lights_Mixture.php">Mixture</a><br>
+          
+        
         </p>
         
       


### PR DESCRIPTION
resolves #213 

The original example has the light functions broken up on two lines with comments explaining what the arguments the function are.

I have not see that convention in the p5.js documentation.

The style guide advices that the code base should look like one person wrote it.

Do you think:
* The line break with comments for the example should be preserved as is? 
* Remove the line break and have comments above the function?
* Remove the line break and have no comments because they can look it up in reference?
* Something else?

Best,