### PR TITLE
Allow site root to be configured via environment variable

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2,6 +2,9 @@
 
 function getRoot() {
 
+  if (strlen(getenv('PHP_P5_SITE_ROOT')) > 0) {
+    return getenv('PHP_P5_SITE_ROOT');
+  }
   if (strpos(getenv('HTTP_HOST'), 'localhost') !== FALSE){
     return 'http://'.getenv('HTTP_HOST').'/p5js.org/';
   } else return 'http://p5js.org/';


### PR DESCRIPTION
Hi!

I recently made this experiment to make contributing to and/or deploying the website and p5 reference easier:

https://github.com/toolness/p5.js-docker

However, doing this required being able to change the return value of `getRoot()` in `functions.php`. It seems to currently be configured to return either `/p5js.org/` if the hostname is "localhost" (presumably for development purposes), and `http://p5js.org/` if it is not.

However, this strategy has some limitations. For example, it's possible to be developing the website but need it to be accessible at a hostname other than localhost: what if I'm developing the site on my laptop but want to make sure it looks OK on my cell phone? Or what if I want to host a copy of the p5 website on my LAN so that people at my learning event can consult it even if our internet is spotty?

So this PR makes it possible to configure the site root via a `PHP_P5_SITE_ROOT` environment variable. If it's defined, the function returns its value, but otherwise it falls back to its current behavior. I'm not sure if this is the most PHP-ish solution, as I'm not very familiar with PHP, so any suggestions are welcome!
