### PR TITLE
Make front page links clickable on Edge and IE.

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@
       <li><a href="<?php echo getRoot(); ?>contribute/">Contribute</a></li>
     </ul>
 
-    <section id="home" style='pointer-events:none;'>
+    <section id="home">
 
       
 <!--       <div class='focus_blue'>
@@ -74,10 +74,25 @@
     $('#home-sketch-frame').css('top', '0px');
     $('#home-sketch-frame').css('left', '0px');
     $('#home-sketch-frame').css('z-index', '-2');
-    $('body').css('pointer-events', 'none');
-    $('iframe').css('pointer-events', 'auto');
-    $('a').css('pointer-events', 'auto');
 
+
+    // Microsoft Edge and IE appear to have an implementation of
+    // CSS pointer-events whereby the children of elements with
+    // "pointer-events: none" cannot *ever* receive pointer events,
+    // even if they are explicitly styled as "pointer-events: auto".
+    //
+    // Unfortunately, this means that the following behavior would render
+    // all links inaccessible on IE and Edge, so we'll have to do
+    // user-agent detection (ugh) to disable it on Edge and IE.
+
+    // http://stackoverflow.com/a/33505753/2422398
+    var EDGE_IE_REGEX = /(?:\b(MS)?IE\s+|\bTrident\/7\.0;.*\s+rv:|\bEdge\/)(\d+)/;
+
+    if (!EDGE_IE_REGEX.test(navigator.userAgent)) {
+      $('body, #home').css('pointer-events', 'none');
+      $('iframe').css('pointer-events', 'auto');
+      $('a').css('pointer-events', 'auto');
+    }
   </script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -75,23 +75,22 @@
     $('#home-sketch-frame').css('left', '0px');
     $('#home-sketch-frame').css('z-index', '-2');
 
+    $('body, #home').css('pointer-events', 'none');
+    $('iframe').css('pointer-events', 'auto');
+    $('a').css('pointer-events', 'auto');
 
-    // Microsoft Edge and IE appear to have an implementation of
-    // CSS pointer-events whereby the children of elements with
-    // "pointer-events: none" cannot *ever* receive pointer events,
-    // even if they are explicitly styled as "pointer-events: auto".
-    //
-    // Unfortunately, this means that the following behavior would render
-    // all links inaccessible on IE and Edge, so we'll have to do
-    // user-agent detection (ugh) to disable it on Edge and IE.
+    // Microsoft Edge and IE appear to have a bug whereby
+    // CSS pointer-events don't do anything on purely inline elements.
+    // This means that almost all our links will be inaccessible, so
+    // we'll force them to be styled as inline-block on affected browsers.
+    // This does result in a few visual artifacts, but it's better than
+    // having completely inaccessible links.
 
     // http://stackoverflow.com/a/33505753/2422398
     var EDGE_IE_REGEX = /(?:\b(MS)?IE\s+|\bTrident\/7\.0;.*\s+rv:|\bEdge\/)(\d+)/;
 
-    if (!EDGE_IE_REGEX.test(navigator.userAgent)) {
-      $('body, #home').css('pointer-events', 'none');
-      $('iframe').css('pointer-events', 'auto');
-      $('a').css('pointer-events', 'auto');
+    if (EDGE_IE_REGEX.test(navigator.userAgent)) {
+      $('a').css('display', 'inline-block');
     }
   </script>
 </body>


### PR DESCRIPTION
~~This fixes #242, but not in a particularly optimal way: it basically uses user-agent sniffing (uggghh) to disable all `pointer-events`-related CSS on Edge and IE, which is what's causing the bug on those browsers. The downside is that on these browsers, the user largely loses their ability to interact with the featured background sketch. But at least the links can be clicked, which is arguably more important.~~

(The above paragraph is struck-through because my original assessment of what was causing this bug was wrong, so I revised my solution.)

This fixes #242 by making all links `display: inline-block` on IE and Edge. This does result in a bit of weirdness on these browsers--basically, the line-height of the line a link is on changes by a few pixels whenever it's hovered over--but it seems a small price to pay for making the links accessible while still allowing the background sketch to be tinkered with.

Aside from that, the only thing I don't like about this solution is the user-agent sniffing. But I can't think of any other way to feature-detect for IE/Edge's odd behavior.