### PR TITLE
Make example code snippets easily selectable

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1885,3 +1885,11 @@ footer {
 iframe {
   border: none;
 }
+
+.cnv_div {
+  /* This ensures that all canvases from example code snippets are only
+   * the width of their actual canvases, rather than the width of
+   * the entire page, potentially obscuring the example code and
+   * preventing it from being selected. */
+  display: inline-block;
+}


### PR DESCRIPTION
The `div.cnv_div` holding the canvas in example code snippets, highlighted below in blue, extends to the full width of the page:

![cnv_div](https://cloud.githubusercontent.com/assets/124687/15807852/01cf4b18-2b36-11e6-9109-345da2970d1f.png)

Because this div is above the example code snippet in the z-order, users can't easily select the text of the code snippet.

One solution would be to explicitly set the `z-index` of the `div.cnv_div`, but I think that setting `display: inline-block` is a cleaner fix because it doesn't depend on the z-index of the example code snippet; instead, it ensures that the div holding the canvas never overlaps the example code snippet at all.
