### PR TITLE
fix for spacing on the homepage hero image on mobile

### DIFF
--- a/src/layouts/HomepageLayout.astro
+++ b/src/layouts/HomepageLayout.astro
@@ -130,12 +130,17 @@ setJumpToState(null);
     }
   }
   .full-bleed-image {
-    width: calc(100% + var(--spacing-lg) * 2);
-    max-width: calc(100% + var(--spacing-lg) * 2);
+    left: -1.25rem;
+    width: calc(100% + 1.25rem * 2);
+    max-width: calc(100% + 1.25rem * 2);
     height: 402px; // extra 2px for border
-    left: calc(-1 * var(--spacing-lg));
     position: relative;
     object-fit: cover;
     @apply border-b border-t border-type-color;
+    @media (min-width: $breakpoint-tablet) {
+      left: calc(-1 * var(--spacing-lg));
+      width: calc(100% + var(--spacing-lg) * 2);
+      max-width: calc(100% + var(--spacing-lg) * 2);
+    }
   }
 </style>


### PR DESCRIPTION
I noticed that there was a horizontal scroll gap again on mobile for the homepage, likely because of the changes I made to the margins on mobile. This updates the full bleed image style to match.
