### PR TITLE
Examples pages QA fixes

### DIFF
--- a/src/components/GridItem/Example.astro
+++ b/src/components/GridItem/Example.astro
@@ -11,7 +11,11 @@ const { item } = Astro.props;
 ---
 
 <a href={`/examples/${exampleContentSlugToLegacyWebsiteSlug(item.slug)}`}>
-  <Image src={item.data.featuredImage} alt={item.data.featuredImageAlt} />
+  <Image
+    src={item.data.featuredImage}
+    alt={item.data.featuredImageAlt}
+    class="w-3/5"
+  />
   <div class="text-xl mt-xs break-words break-keep">
     {item.data.title}
   </div>

--- a/src/content/examples/config.ts
+++ b/src/content/examples/config.ts
@@ -13,6 +13,7 @@ export const examplesCollection = defineCollection({
       oneLineDescription: z.string(),
       // Aria label used for the live example code
       arialabel: z.string().optional(),
+      featured: z.boolean().optional(),
       relatedReference: z.array(reference("reference")).optional(),
       featuredImage: image(),
       featuredImageAlt: z.string().optional().default(""),

--- a/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
@@ -2,6 +2,7 @@
 featuredImage: "../../../images/featured/02_Animation_And_Variables-02_Mobile_Device_Movement-thumbnail.jpg"
 title: Mobile Device Movement
 oneLineDescription: Animate based on device motion.
+featured: true
 ---
 
 The <a href="https://p5js.org/reference/#/p5/deviceMoved" target="_blank">deviceMoved()</a>

--- a/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
@@ -2,6 +2,7 @@
 featuredImage: "../../../images/featured/09_Angles_And_Motion-00_Sine_Cosine-thumbnail.png"
 title: Sine and Cosine
 oneLineDescription: Animate circular, back and forth, and wave motion.
+featured: true
 ---
 
 This example demonstrates the

--- a/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
+++ b/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
@@ -2,6 +2,7 @@
 featuredImage: "../../../images/featured/11_3D-03_Orbit_Control-thumbnail.png"
 title: Orbit Control
 oneLineDescription: Control the camera with the mouse.
+featured: true
 ---
 
 <a href="https://p5js.org/reference/#/p5/orbitControl" target="_blank">Orbit control</a>

--- a/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
@@ -2,6 +2,7 @@
 featuredImage: "../../../images/featured/15_Math_And_Physics-03_Smoke_Particle_System-thumbnail.png"
 title: Smoke Particles
 oneLineDescription: Simulate smoke with a particle system.
+featured: true
 ---
 
 

--- a/src/content/examples/es/07_Repetition/03_Kaleidoscope/description.mdx
+++ b/src/content/examples/es/07_Repetition/03_Kaleidoscope/description.mdx
@@ -2,6 +2,7 @@
 featuredImage: "../../../images/featured/07_Repetition-03_Kaleidoscope-thumbnail.png"
 title: Caleidoscopio
 oneLineDescription: Dibuja diseños reflejados con el mouse.
+featured: true
 ---
 
 Un caleidoscopio es un instrumento óptico con dos o más superficies reflectantes inclinadas entre sí a un ángulo. 

--- a/src/content/examples/es/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
+++ b/src/content/examples/es/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
@@ -2,6 +2,7 @@
 featuredImage: "../../../images/featured/09_Angles_And_Motion-00_Sine_Cosine-thumbnail.png"
 title: Seno y Coseno
 oneLineDescription: Animar movimiento circular, de vaivén y de onda.
+featured: true
 ---
 
 Este ejemplo demuestra las funciones matemáticas del <a href="https://en.wikipedia.org/wiki/Sine_and_cosine">seno y coseno</a>

--- a/src/content/examples/es/15_Math_And_Physics/02_Forces/description.mdx
+++ b/src/content/examples/es/15_Math_And_Physics/02_Forces/description.mdx
@@ -2,6 +2,7 @@
 featuredImage: "../../../images/featured/15_Math_And_Physics-02_Forces-thumbnail.png"
 title: Fuerzas
 oneLineDescription: Simula fuerzas en múltiples cuerpos mientras se mueven a través de un líquido.
+featured: true
 ---
 
 Demostración de múltiples fuerzas actuando sobre cuerpos.

--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -89,6 +89,23 @@ tutorialCategories:
   accessibility: "Accessibility"
   webgl: "WebGL"
   "advanced": "Advanced Topics"
+exampleCategories:
+  Featured: "Featured"
+  Shapes And Color: "Shapes And Color"
+  Animation And Variables: "Animation And Variables"
+  Imported Media: "Imported Media"
+  Input Elements: "Input Elements"
+  Transformation: "Transformation"
+  Calculating Values: "Calculating Values"
+  Repetition: "Repetition"
+  Listing Data With Arrays: "Listing Data With Arrays"
+  Angles And Motion: "Angles And Motion"
+  Games: "Games"
+  3D: "3D"
+  Advanced Canvas Rendering: "Advanced Canvas Rendering"
+  Classes And Objects: "Classes And Objects"
+  Loading And Saving Data: "Loading And Saving Data"
+  Math And Physics: "Math And Physics"
 referenceCategories:
   modules:
     Foundation: Foundation

--- a/src/content/ui/es.yaml
+++ b/src/content/ui/es.yaml
@@ -48,6 +48,8 @@ briefPageDescriptions:
   Libraries: Expande las posibilidades de p5.js con bibliotecas creadas por la comunidad.
   About: Aprende acerca de la misión, valores y personas detrás de p5.js.
   People: Conoce al equipo de p5.js.
+exampleCategories:
+  Featured: Destacado
 referenceCategories:
   modules:
     Math: Matemáticas

--- a/src/layouts/ExampleLayout.astro
+++ b/src/layouts/ExampleLayout.astro
@@ -1,19 +1,9 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { setJumpToState } from "../globals/state";
+import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 import {
-  setJumpToState,
-  type JumpToLink,
-  type JumpToState,
-} from "../globals/state";
-import {
-  getCurrentLocale,
-  removeLocalePrefix,
-  getUiTranslator,
-} from "../i18n/utils";
-import {
-  exampleContentSlugToLegacyWebsiteSlug,
   generateJumpToState,
-  getExampleCategory,
   getRelatedEntriesinCollection,
 } from "../pages/_utils";
 import BaseLayout from "./BaseLayout.astro";

--- a/src/layouts/ExamplesLayout.astro
+++ b/src/layouts/ExamplesLayout.astro
@@ -3,11 +3,7 @@ import BaseLayout from "./BaseLayout.astro";
 import GridItemExample from "@components/GridItem/Example.astro";
 import { getExampleCategory } from "../pages/_utils";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
-import {
-  setJumpToState,
-  type JumpToState,
-  type JumpToLink,
-} from "../globals/state";
+import { setJumpToState } from "../globals/state";
 import type { CollectionEntry } from "astro:content";
 
 interface Props {
@@ -25,38 +21,49 @@ exampleEntries.forEach((exampleEntry) => {
 
 const examplesByCategory = Array.from(exampleCategories).map((category) => {
   return {
-    name: category,
+    name: t("exampleCategories", category) as string,
     examples: exampleEntries.filter((exampleEntry) => {
       return getExampleCategory(exampleEntry.id) === category;
     }),
   };
 });
 
-const jumpToLinks = Array.from(exampleCategories).map((category) => ({
-  label: category as string,
-  url: `/examples/#${category.toLowerCase()}`,
-})) as unknown as JumpToLink[];
+// If there are any featured examples, add a Featured category at the top
+const featuredEntries = exampleEntries.filter(
+  (exampleEntry) => exampleEntry.data.featured
+);
+if (featuredEntries.length > 0) {
+  examplesByCategory.unshift({
+    name: t("exampleCategories", "Featured") as string,
+    examples: featuredEntries,
+  });
+}
+
+const jumpToLinks = Array.from(examplesByCategory).map(({ name }) => ({
+  label: name as string,
+  url: `/examples/#${name.toLowerCase()}`,
+}));
 
 const jumpToState = {
   links: jumpToLinks,
   heading: t("Examples") as string,
-} as JumpToState;
+};
 
 setJumpToState(jumpToState);
 ---
 
 <BaseLayout title="Examples">
-  <div class="grid grid-cols-2 md:grid-cols-4 gap-x-md gap-y-2xl mt-md mb-2xl">
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-md gap-y-2xl mt-md mb-2xl">
     {
       examplesByCategory.map((category, i) => (
-        <div class="col-span-2 md:col-span-4 grid grid-cols-subgrid gap-y-xl md:gap-y-lg">
+        <div class="col-span-2 lg:col-span-4 grid grid-cols-subgrid gap-y-xl lg:gap-y-lg">
           <div class="col-span-full">
             {i !== 0 ? <hr class="mb-md" /> : null}
             <h2 class="mt-0">
               {category.name} <a id={category.name.toLowerCase()} />
             </h2>
           </div>
-          <div class="col-span-full grid grid-cols-subgrid gap-y-2xl md:gap-y-lg">
+          <div class="col-span-full grid grid-cols-subgrid gap-y-2xl lg:gap-y-lg">
             {category.examples.map((exampleEntry) => (
               <div class="col-span-1">
                 {<GridItemExample item={exampleEntry} />}


### PR DESCRIPTION
addresses everything in #198 except #272
closes #184 

- adds a "featured" flag for the content collection (and I added it to a few random picks)
- adds a "Featured" category on the examples page when there is at least one featured example
- adds translation keys for example categories so they can be translated
- styling fixes