### PR TITLE
Default Astro syntax highlighting for non-embed Code Snippets

### DIFF
--- a/src/components/CodeBlockWrapper/index.astro
+++ b/src/components/CodeBlockWrapper/index.astro
@@ -3,8 +3,7 @@ import CodeContainerWithCopy from "../CodeContainer/CodeContainerWithCopy.astro"
 ---
 
 <div>
-  <CodeContainerWithCopy>
-    <pre
-      class="[&_code]:p-0 [&_code]:bg-transparent [&_span]:!text-sidebar-type-color"><slot /></pre>
+  <CodeContainerWithCopy darkTheme>
+    <pre class="[&_code]:p-0 [&_code]:bg-transparent"><slot /></pre>
   </CodeContainerWithCopy>
 </div>

--- a/src/components/CodeContainer/CodeContainerWithCopy.astro
+++ b/src/components/CodeContainer/CodeContainerWithCopy.astro
@@ -2,11 +2,17 @@
 import CodeContainer from "@components/CodeContainer/index.astro";
 import { CopyCodeButton } from "../CopyCodeButton";
 import { decodeHtml } from "@pages/_utils";
+
+interface Props {
+  darkTheme?: boolean;
+}
+
+const { darkTheme } = Astro.props;
 const codeContent = await Astro.slots.render("default");
 const toCopy = decodeHtml(codeContent);
 ---
 
-<CodeContainer class="pr-lg">
+<CodeContainer class={`pr-lg ${darkTheme && "bg-black"}`}>
   <slot />
   <div class="absolute top-xs right-xs">
     <CopyCodeButton client:load textToCopy={toCopy} />


### PR DESCRIPTION
This PR would add syntax highlighting back to the code snippets in tutorials. [Based on this conversation.](https://github.com/processing/p5.js-website/issues/221#issuecomment-2076069004)

Current:
<img width="1068" alt="Screenshot 2024-04-25 at 2 46 33 PM" src="https://github.com/processing/p5.js-website/assets/10382506/ccbe575b-39ae-43fc-810f-b559c677e922">

After this PR:
<img width="1099" alt="Screenshot 2024-04-25 at 2 44 11 PM" src="https://github.com/processing/p5.js-website/assets/10382506/b0dfd72e-bf91-4fcc-ade7-857acda9c1e4">

The Figma mockups match the current but this sacrifices readability on longer snippets. The default Astro syntax highlighting could be replaced with syntax highlighting more similar to the `CodeEmbed` in the future but it does not make sense to attempt this before launch.

I'll leave it to the PF team to decide whether to merge.

