### PR TITLE
Fix minor top bar bug

### DIFF
--- a/src/components/Settings/styles.module.scss
+++ b/src/components/Settings/styles.module.scss
@@ -11,7 +11,7 @@
   position: absolute;
   display: grid;
   width: 100%;
-  z-index: 9998;
+  z-index: 9999;
 
   padding: var(--spacing-sm) 1.25rem;
   grid-template-columns: repeat(6, minmax(0, 1fr));
@@ -74,7 +74,7 @@
   width: 100%;
   height: 20px;
   position: fixed;
-  z-index: 9999;
+  z-index: 9998;
 }
 
 .placeholder {


### PR DESCRIPTION
fixes #260 

Uses z-index to move the settings above the hitbox