### PR TITLE
Fix horizontal scrollbars caused by nav bar

### DIFF
--- a/src/components/Settings/styles.module.scss
+++ b/src/components/Settings/styles.module.scss
@@ -19,7 +19,7 @@
   gap: 20px;
 
   @media (min-width: $breakpoint-tablet) {
-    width: calc(100vw - 200px);
+    width: calc(100% - var(--nav-offset-x));
     padding: var(--spacing-sm) var(--spacing-lg);
   }
 


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/289

Turns out it was because it was using `100vw`, which does not subtract the width of the vertical scroll bar, causing a slight overflow the size of the scroll bar width. Using `100%` seems to fix it. I also replaced a hardcoded `200px` with the variable for the sidebar offset.

![image](https://github.com/processing/p5.js-website/assets/5315059/d387021f-7ef5-4e78-9587-60bcc9963d82)
