### PR TITLE
Change styles for education resources materials links

### DIFF
--- a/src/components/EducationResource/index.astro
+++ b/src/components/EducationResource/index.astro
@@ -23,7 +23,7 @@ const { name, featuredImage, featuredImageAlt } = Astro.props;
     <div class="text-sm">
       <slot name="description" />
     </div>
-    <div class="text-sm">
+    <div class="text-sm leading-8 [&_a]:whitespace-nowrap [&_a]:rounded-full [&_a]:mr-1 [&_a]:py-1 [&_a]:px-2 [&_a]:outline [&_a]:outline-1 [&_a]:outline-[var(--type-magenta-dark)]">
       <slot name="materials" />
     </div>
   </div>


### PR DESCRIPTION
<img width="1545" alt="image" src="https://github.com/processing/p5.js-website/assets/5315059/838584ea-c81e-4008-b3a9-8a350c246d07">

This makes the ones with multiple links look a tad better.