### PR TITLE
UI bugs 3

### DIFF
--- a/src/components/DonorBoxWidget/index.astro
+++ b/src/components/DonorBoxWidget/index.astro
@@ -1,6 +1,6 @@
 <script src="https://donorbox.org/widget.js"></script>
 <!-- @ts-expect-error  -->
-<div>
+<div class="rounded-lg overflow-hidden mt-md pb-0 max-w-[420px] min-w-[250px]">
   <iframe
     allowpaymentrequest=""
     height="525"
@@ -8,7 +8,7 @@
     title="Support the Processing Foundation, Donorbox"
     name="donorbox"
     src="https://donorbox.org/embed/support-the-processing-foundation?hide_donation_meter=true"
-    style="max-width: 550px; min-width: 250px; max-height:none!important; margin-top: 1em; border-radius: 10px;"
+    style="max-width: 420px; min-width: 250px; max-height:none !important;"
   >
     </div>
   </iframe>

--- a/src/components/Footer/index.astro
+++ b/src/components/Footer/index.astro
@@ -7,7 +7,7 @@ const t = await getUiTranslator(currentLocale);
 ---
 
 <footer
-  class="border-t border-black grid-cols-3 lg:grid-cols-4 grid gap-x-md text-xl lg:text-xl pt-md pb-lg px-lg bg-accent-color text-accent-type-color content-start"
+  class="border-t border-black grid-cols-3 lg:grid-cols-4 grid gap-x-md text-xl lg:text-xl pt-md pb-5 px-lg bg-accent-color text-accent-type-color content-start"
 >
   <div class="grid lg:row-span-2 grid-rows-subgrid">
     <div>

--- a/src/components/GridItem/ContributorDoc.astro
+++ b/src/components/GridItem/ContributorDoc.astro
@@ -13,7 +13,7 @@ const { item } = Astro.props;
   class="group hover:no-underline"
   href={`/contribute/${removeLocaleAndExtension(item.slug)}`}
 >
-  <div class="grid place-content-center mt-xs bg-bg-blue h-32 p-4 mb-2">
+  <div class="grid place-content-center mt-xs bg-bg-blue aspect-photo p-4 mb-2">
     <span
       class="text-lg text-center align-middle line-clamp-3 text-pretty group-hover:underline"
     >

--- a/src/components/PageHeader/ItemPage.astro
+++ b/src/components/PageHeader/ItemPage.astro
@@ -14,10 +14,13 @@ const { title, topic, subtitle } = Astro.props;
 ---
 
 <div class="px-5 md:px-lg pt-5xl lg:pt-3xl pb-sm">
-  <div class="[&>*]:pr-sm pb-xs flex flex-nowrap">
+  <div class="pb-xs flex flex-nowrap gap-2.5">
     <a href={topic.url}>{topic.name}</a>
     <span class="grid place-items-center"
-      ><Icon className="w-[1rem] h-[1rem]" kind="chevron-right" /></span
+      ><Icon
+        className="w-3 h-3 relative top-[1px]"
+        kind="chevron-right"
+      /></span
     >
     <span>{title}</span>
   </div>

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -80,7 +80,7 @@ const sortedFeaturedPeople = featuredPeople.sort((a, b) => {
   <hr />
   <section class="pb-3xl lg:pb-2xl">
     <h2 id="contact">{t("Contact")}</h2>
-    <div class="text-2xl grid grid-cols-6 lg:grid-cols-9 gap-x-md mt-xl">
+    <div class="text-2xl grid grid-cols-6 lg:grid-cols-9 gap-x-[40px] mt-xl">
       <div class="col-span-2 lg:col-span-3">Email</div><div
         class="col-span-4 lg:col-span-6"
       >

--- a/src/layouts/CommunityLayout.astro
+++ b/src/layouts/CommunityLayout.astro
@@ -46,7 +46,7 @@ setJumpToState({
 <BaseLayout title="Community">
   <section class="mt-md mb-xl">
     <h2 class="mb-lg">{t("Sketches")}<a id="sketches"></a></h2>
-    <ul class="grid grid-cols-2 gap-y-xl gap-x-md lg:grid-cols-4">
+    <ul class="grid grid-cols-2 gap-y-xl gap-x-[40px] lg:grid-cols-4">
       {
         sketches.map((sk, i) => (
           <li
@@ -71,7 +71,7 @@ setJumpToState({
   <hr />
   <section class="mt-md mb-xl">
     <h2 class="mb-lg">{t("Libraries")}<a id="libraries"></a></h2>
-    <ul class="grid grid-cols-2 gap-y-xl gap-x-md lg:grid-cols-4">
+    <ul class="grid grid-cols-2 gap-y-xl gap-x-[40px] lg:grid-cols-4">
       {
         libraries.map((lib) => (
           <li>
@@ -87,7 +87,7 @@ setJumpToState({
   <hr />
   <section class="mt-md mb-xl">
     <h2 class="mb-lg">{t("Events")}<a id="events"></a></h2>
-    <ul class="grid grid-cols-2 gap-y-xl gap-x-md lg:grid-cols-4">
+    <ul class="grid grid-cols-2 gap-y-xl gap-x-[40px] lg:grid-cols-4">
       {
         events.map((event, i) => (
           <li

--- a/src/layouts/ContributeLayout.astro
+++ b/src/layouts/ContributeLayout.astro
@@ -80,7 +80,7 @@ setJumpToState({
   <hr />
   <section class="mt-md mb-xl">
     <h2 class="mt-md mb-lg" id="donate">{t("Donate")}</h2>
-    <ul class="grid grid-cols-2 gap-y-xl gap-x-md lg:grid-cols-4">
+    <ul class="grid grid-cols-2 gap-y-xl gap-x-[40px] lg:grid-cols-4">
       {
         // This is the same markup as in ContributorDocItem
         donateSectionItems.map((it) => (

--- a/src/layouts/ContributeLayout.astro
+++ b/src/layouts/ContributeLayout.astro
@@ -86,7 +86,7 @@ setJumpToState({
         donateSectionItems.map((it) => (
           <li>
             <a href={it.url}>
-              <div class="grid place-content-center mt-xs bg-bg-blue h-32 p-4 mb-2">
+              <div class="grid place-content-center mt-xs bg-bg-blue aspect-photo p-4 mb-2">
                 <span class="text-lg text-center align-middle line-clamp-3 text-pretty">
                   {it.title}
                 </span>

--- a/src/layouts/EventsLayout.astro
+++ b/src/layouts/EventsLayout.astro
@@ -23,7 +23,7 @@ setJumpToState(null);
 <Head title={"Events"} locale={currentLocale} />
 
 <BaseLayout title="Events" variant="item" topic="community">
-  <ul class="grid grid-cols-2 gap-y-xl gap-x-md lg:grid-cols-4">
+  <ul class="grid grid-cols-2 gap-y-xl gap-x-[40px] lg:grid-cols-4">
     {entries.map((entry) => <GridItemEvent item={entry} />)}
   </ul>
   <PaginationNav

--- a/src/layouts/LibrariesLayout.astro
+++ b/src/layouts/LibrariesLayout.astro
@@ -73,7 +73,7 @@ setJumpToState({
         <h2 id={slug} class="mb-lg mt-sm lg:mt-md">
           {name}
         </h2>
-        <ul class="grid grid-cols-2 gap-y-xl gap-x-md lg:grid-cols-4">
+        <ul class="grid grid-cols-2 gap-y-xl gap-x-[40px] lg:grid-cols-4">
           {sectionEntries.map((entry: LibraryEntry) => (
             <li>
               <GridItemLibrary item={entry} />

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -8,6 +8,7 @@ import {
   separateReferenceExamples,
   normalizeReferenceRoute,
   getRelatedEntriesinCollection,
+  generateJumpToState,
 } from "@pages/_utils";
 import BaseLayout from "./BaseLayout.astro";
 import RelatedItems from "@components/RelatedItems/index.astro";
@@ -28,7 +29,16 @@ const description = escapeCodeTagsContent(entry.data.description);
 const t = await getUiTranslator(currentLocale);
 const title = getRefEntryTitleConcatWithParen(entry);
 
-const jumpToLinks = relatedEntries.map((relatedEntry: any) => {
+const jumpToState = await generateJumpToState(
+  "reference",
+  entry.id,
+  "Reference",
+  t,
+  currentLocale
+);
+
+// make related entry links
+const relatedEntriesLinks = relatedEntries.map((relatedEntry: any) => {
   return {
     label: getRefEntryTitleConcatWithParen(relatedEntry),
     url: `/reference/${normalizeReferenceRoute(relatedEntry.id)}`,
@@ -36,17 +46,13 @@ const jumpToLinks = relatedEntries.map((relatedEntry: any) => {
     current: relatedEntry.id === entry.id,
   };
 });
-
 // Add link for submodule itself
-jumpToLinks.unshift({
+relatedEntriesLinks.unshift({
   label: entry.data.submodule,
   url: `/reference/#${entry.data.submodule}`,
 });
-
-const jumpToState = {
-  heading: t("Reference") as string,
-  links: jumpToLinks,
-};
+// Put related links at top of the list
+jumpToState.links?.unshift(...relatedEntriesLinks);
 
 setJumpToState(jumpToState);
 

--- a/src/layouts/SketchesLayout.astro
+++ b/src/layouts/SketchesLayout.astro
@@ -24,7 +24,7 @@ const { entries, totalNumSketches, currentPage } = Astro.props;
 <Head title="Sketches" locale={currentLocale} />
 
 <BaseLayout title="Sketches" variant="item" topic="community">
-  <ul class="grid grid-cols-2 gap-y-xl gap-x-md lg:grid-cols-4">
+  <ul class="grid grid-cols-2 gap-y-xl gap-x-[40px] lg:grid-cols-4">
     {entries.map((entry) => <GridItemSketch item={entry} />)}
   </ul>
   <PaginationNav

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -11,6 +11,7 @@ import { load } from "cheerio";
 import he from "he";
 import { JSDOM } from "jsdom";
 import type { JumpToLink, JumpToState } from "../globals/state";
+import { categories as referenceCategories } from "../content/reference/config";
 
 interface EntryWithId {
   id: string;
@@ -286,6 +287,8 @@ export const decodeHtml = (html: string) => {
  * @param collectionType The type of collection
  * @param currentEntrySlug The id of the currently viewed entry
  * @param jumpToHeading The heading for the jumpToLinks
+ * @param t Pass in the result from getUiTranslator()
+ * @param currentLocale The current locale to translate the header with
  * @returns JumpToState object
  */
 export const generateJumpToState = async (
@@ -309,8 +312,7 @@ export const generateJumpToState = async (
   // Get the categories based on the collection type
   switch (collectionType) {
     case "reference":
-      // @ts-expect-error - We know that the category exists because of the collection type
-      categories = new Set(localeEntries.map((entry) => entry.data.category));
+      categories = new Set(referenceCategories);
       break;
     case "tutorials":
       // @ts-expect-error - We know that the category exists because of the collection type
@@ -331,11 +333,11 @@ export const generateJumpToState = async (
   const getCategoryLabel = (category: string) => {
     switch (collectionType) {
       case "reference":
-        return category;
+        return t("referenceCategories", "modules", category) as string;
       case "tutorials":
         return t("tutorialCategories", category) as string;
       case "examples":
-        return category;
+        return t("exampleCategories", category) as string;
       default:
         return "";
     }

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -67,8 +67,11 @@
     margin-top: var(--spacing-xl);
   }
 
-  img,
+  img {
+    margin-top: var(--spacing-md);
+  }
   > iframe {
     margin-top: var(--spacing-md);
+    width: 100%;
   }
 }

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -67,7 +67,7 @@
     margin-top: var(--spacing-xl);
   }
 
-  > img,
+  img,
   > iframe {
     margin-top: var(--spacing-md);
   }


### PR DESCRIPTION
#309 #308 

- breadcrumb spacing and sizing
- make footer bottom padding smaller
- more rounded corners on donorbox embed
- use 40px column gutter everywhere
- make contribute doc items 2:3 aspect ratio
- default image spacing in markdown pages
- make video embeds full width
- include full category list in reference item jump to links
- slower asterisk spin