### PR TITLE
UI bugs 4

### DIFF
--- a/src/components/CodeEmbed/index.jsx
+++ b/src/components/CodeEmbed/index.jsx
@@ -68,25 +68,29 @@ export const CodeEmbed = (props) => {
       className={`my-md flex w-full flex-col gap-md overflow-hidden ${props.allowSideBySide && "lg:flex-row"}`}
     >
       {props.previewable ? (
-        <div className="ml-0 flex w-fit lg:flex-col">
-          <CodeFrame
-            jsCode={previewCodeString}
-            width={props.previewWidth}
-            height={props.previewHeight}
-            base={props.base}
-            frameRef={codeFrameRef}
-            lazyLoad={props.lazyLoad}
-          />
-          <div className="gap-xs lg:flex">
+        <div
+          className={`ml-0 flex w-fit gap-5 ${props.allowSideBySide ? "" : "flex-col lg:flex-row"}`}
+        >
+          <div>
+            <CodeFrame
+              jsCode={previewCodeString}
+              width={props.previewWidth}
+              height={props.previewHeight}
+              base={props.base}
+              frameRef={codeFrameRef}
+              lazyLoad={props.lazyLoad}
+            />
+          </div>
+          <div className="flex gap-2.5 md:flex-row lg:flex-col">
             <CircleButton
-              className="!bg-bg-gray-40 !p-sm"
+              className="bg-bg-gray-40"
               onClick={updateOrReRun}
               ariaLabel="Run sketch"
             >
               <Icon kind="play" />
             </CircleButton>
             <CircleButton
-              className="!bg-bg-gray-40 !p-sm "
+              className="bg-bg-gray-40"
               onClick={() => {
                 setPreviewCodeString("");
               }}

--- a/src/components/GridItem/Reference.astro
+++ b/src/components/GridItem/Reference.astro
@@ -18,7 +18,7 @@ const { item } = Astro.props;
   >
     {item.data.title}
   </p>
-  <p class="text-body-caption mt-xxs">
+  <p class="text-sm mt-xxs">
     {
       `${item.data.description.replace(/<[^>]*>/g, "").split(/\.(\s|$)/, 1)[0]}.`
     }

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -43,7 +43,8 @@
     width: 100%;
     justify-content: space-between;
     flex-grow: 0;
-    height: 70px;
+    height: 80px;
+    padding: 1.25rem 1.25rem var(--spacing-xs);
     overflow: hidden;
     border-bottom-width: 0;
 
@@ -71,7 +72,7 @@
       grid-template-rows: min-content 2fr;
       min-height: 350px;
       height: 100%;
-      padding: var(--spacing-xs) 1.25rem;
+      padding: 1.25rem 1.25rem var(--spacing-xs);
     }
   }
 
@@ -156,7 +157,7 @@
   }
 
   @media (min-width: $breakpoint-tablet) {
-    height: 70px;
+    height: 80px;
     border-top-width: 1px;
 
     &:global(.open) {

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -145,7 +145,7 @@ export const ReferenceDirectoryWithFilter = ({
 
   return (
     <>
-      <div class="border-b border-sidebar-type-color bg-accent-color px-lg pb-lg">
+      <div class="border-b border-sidebar-type-color bg-accent-color px-5 pb-lg md:px-lg">
         <div class="max-w-screen-md">
           <input
             type="text"
@@ -159,7 +159,7 @@ export const ReferenceDirectoryWithFilter = ({
           />
         </div>
       </div>
-      <div class="mx-lg">{renderCategoryData()}</div>
+      <div class="mx-5 md:mx-lg">{renderCategoryData()}</div>
     </>
   );
 };

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -79,15 +79,16 @@ export const ReferenceDirectoryWithFilter = ({
         <div class="col-span-3 w-full overflow-hidden" key={entry.id}>
           <a
             href={`/reference/${entry.data.path}`}
-            class="text-body-mono group hover:no-underline"
+            class="group hover:no-underline"
             aria-label={entry.data.title}
             aria-describedby={`${entry.data.title}-description`}
           >
             <span
-              class="group-hover:underline"
+              class="text-body-mono group-hover:underline"
               dangerouslySetInnerHTML={{ __html: entry.data.title }}
             />
             <p
+              class="mt-1 text-sm"
               id={`${entry.data.title}-description`}
             >{`${getOneLineDescription(entry.data.description)}`}</p>
           </a>

--- a/src/components/Settings/styles.module.scss
+++ b/src/components/Settings/styles.module.scss
@@ -20,7 +20,7 @@
 
   @media (min-width: $breakpoint-tablet) {
     width: calc(100% - var(--nav-offset-x));
-    padding: var(--spacing-sm) var(--spacing-lg);
+    padding: 1.25rem var(--spacing-lg) var(--spacing-sm);
   }
 
   @media (min-width: $breakpoint-laptop) {

--- a/src/layouts/PeopleLayout.astro
+++ b/src/layouts/PeopleLayout.astro
@@ -66,7 +66,7 @@ setJumpToState(null);
         <ul class="content-grid">
           {category.members.map((person) => (
             <li class="col-span-6 md:col-span-9 lg:col-span-12 content-grid">
-              <div class="col-span-4 md:col-span-9 lg:col-span-3 grayscale">
+              <div class="col-span-4 md:col-span-9 lg:col-span-4 grayscale">
                 <Image
                   src={person.data.image!}
                   alt={person.data.imageAlt!}
@@ -84,7 +84,7 @@ setJumpToState(null);
                 </div>
                 <p class="text-body-caption mt-0">{person.data.role}</p>
               </div>
-              <p class="col-span-6 md:col-span-9 p-0 m-0">
+              <p class="col-span-6 md:col-span-9 lg:col-span-8 p-0 m-0">
                 {person.data.blurb}
               </p>
             </li>

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -100,8 +100,8 @@ const relatedReferences = [
                   previewable
                   editable
                   lazyLoad={i > 0}
-                  previewHeight="120px"
-                  previewWidth="120px"
+                  previewHeight="100px"
+                  previewWidth="100px"
                   allowSideBySide={true}
                 />
               );

--- a/src/layouts/TutorialsLayout.astro
+++ b/src/layouts/TutorialsLayout.astro
@@ -63,7 +63,7 @@ setJumpToState({
       </>
     ))
   }
-  <section class="mt-md mb-xl">
+  <section class="mt-md">
     <h2 class="mb-lg">
       {t("tutorialsPage", "education-resources")}<a id="education-resources"
       ></a>


### PR DESCRIPTION
- [fix reference card text sizes](https://github.com/processing/p5.js-website/commit/a98a4ae4992787eb0adc3127a17822edda180c56)
- [remove extra padding at bottom of tutorials](https://github.com/processing/p5.js-website/commit/32ff3f3052a4f36a52895064bc5394a36548ee23)
- [adjust max content widths for people page](https://github.com/processing/p5.js-website/commit/0bbb3a46b8eec5a42205e3ee41d776761f8a4fbb)
- [update mobile margins on reference page](https://github.com/processing/p5.js-website/commit/f06a6bc27ce552c9baf08d8398ca13bd92494fe4)
- [update reference sketch layout height + width](https://github.com/processing/p5.js-website/commit/26804db1a9d2bbce9becdc3008382682bd138eb8)
- [improve code embed spacing and margin](https://github.com/processing/p5.js-website/commit/caaf02db7d6c704cd4300d25108246dffa4ab5cf)
- [set top nav's top gap to 20px](https://github.com/processing/p5.js-website/commit/0e06e832e64bd0a5a8026281677114ff3e81cfc5)