### PR TITLE
Nav state

### DIFF
--- a/src/components/Nav/JumpToLinks.tsx
+++ b/src/components/Nav/JumpToLinks.tsx
@@ -1,44 +1,36 @@
 import styles from "./styles.module.scss";
-import { useEffect, useState } from "preact/hooks";
 import { Icon } from "../Icon";
 import type { JumpToLink } from "@/src/globals/state";
 
 type JumpToLinksProps = {
   links?: JumpToLink[];
   heading: string;
+  toggleCallback: () => void;
+  isOpen: boolean;
 };
 
-export const JumpToLinks = ({ links, heading }: JumpToLinksProps) => {
-  const [open, setOpen] = useState(true);
-
-  const handleClick = () => {
-    setOpen(!open);
-  };
-
-  // Defaults to closed on mobile, open on desktop
-  // Have to do this in a lifecycle method
-  // so that we can still server-side render
-  useEffect(() => {
-    const isMobile = window.innerWidth <= 768;
-    setOpen(!isMobile);
-  }, []);
-
+export const JumpToLinks = ({
+  links,
+  heading,
+  isOpen,
+  toggleCallback,
+}: JumpToLinksProps) => {
   if (!links || links?.length <= 0) return null;
 
   return (
-    <div class={`${styles.jumpto} ${open && "open"}`}>
+    <div class={`${styles.jumpto} ${isOpen && "open"}`}>
       <button
         class={styles.toggle}
-        onClick={handleClick}
+        onClick={toggleCallback}
         aria-hidden="true"
         tabIndex={-1}
       >
         <span>{heading}</span>
         <div class="pt-xs">
-          <Icon kind={open ? "chevron-up" : "chevron-down"} />
+          <Icon kind={isOpen ? "chevron-up" : "chevron-down"} />
         </div>
       </button>
-      {open && (
+      {isOpen && (
         <ul>
           {links?.map((link) => (
             <li

--- a/src/components/Nav/JumpToLinks.tsx
+++ b/src/components/Nav/JumpToLinks.tsx
@@ -5,7 +5,7 @@ import type { JumpToLink } from "@/src/globals/state";
 type JumpToLinksProps = {
   links?: JumpToLink[];
   heading: string;
-  toggleCallback: () => void;
+  handleToggle: () => void;
   isOpen: boolean;
 };
 
@@ -13,7 +13,7 @@ export const JumpToLinks = ({
   links,
   heading,
   isOpen,
-  toggleCallback,
+  handleToggle,
 }: JumpToLinksProps) => {
   if (!links || links?.length <= 0) return null;
 
@@ -21,7 +21,7 @@ export const JumpToLinks = ({
     <div class={`${styles.jumpto} ${isOpen && "open"}`}>
       <button
         class={styles.toggle}
-        onClick={toggleCallback}
+        onClick={handleToggle}
         aria-hidden="true"
         tabIndex={-1}
       >

--- a/src/components/Nav/MainNavLinks.tsx
+++ b/src/components/Nav/MainNavLinks.tsx
@@ -12,7 +12,7 @@ type MainNavLinksProps = {
   mobileMenuLabel: string;
   isHomepage: boolean;
   hasJumpTo: boolean;
-  toggleCallback: () => void;
+  handleToggle: () => void;
   isOpen: boolean;
 };
 
@@ -22,7 +22,7 @@ export const MainNavLinks = ({
   editorButtonLabel,
   mobileMenuLabel,
   isHomepage = false,
-  toggleCallback,
+  handleToggle,
   isOpen,
   hasJumpTo,
 }: MainNavLinksProps) => {
@@ -44,7 +44,7 @@ export const MainNavLinks = ({
 
       <button
         class={styles.toggle}
-        onClick={toggleCallback}
+        onClick={handleToggle}
         aria-hidden="true"
         tabIndex={-1}
       >

--- a/src/components/Nav/MainNavLinks.tsx
+++ b/src/components/Nav/MainNavLinks.tsx
@@ -1,7 +1,6 @@
 import styles from "./styles.module.scss";
 import { Logo } from "../Logo";
 import { Icon } from "../Icon";
-import { useEffect, useState } from "preact/hooks";
 
 type MainNavLinksProps = {
   links: {
@@ -13,6 +12,8 @@ type MainNavLinksProps = {
   mobileMenuLabel: string;
   isHomepage: boolean;
   hasJumpTo: boolean;
+  toggleCallback: () => void;
+  isOpen: boolean;
 };
 
 export const MainNavLinks = ({
@@ -21,24 +22,10 @@ export const MainNavLinks = ({
   editorButtonLabel,
   mobileMenuLabel,
   isHomepage = false,
+  toggleCallback,
+  isOpen,
   hasJumpTo,
 }: MainNavLinksProps) => {
-  const [isMobile, setIsMobile] = useState(false);
-  const [open, setOpen] = useState(!isMobile);
-
-  const handleClick = () => {
-    setOpen(!open);
-  };
-
-  // Defaults to closed on mobile, open on desktop
-  // Have to do this in a lifecycle method
-  // so that we can still server-side render
-  useEffect(() => {
-    const _isMobile = window.innerWidth < 768;
-    setIsMobile(_isMobile);
-    setOpen(!_isMobile);
-  }, []);
-
   if (!links || links?.length <= 0) return null;
 
   const renderLogo = () => (
@@ -57,12 +44,12 @@ export const MainNavLinks = ({
 
       <button
         class={styles.toggle}
-        onClick={handleClick}
+        onClick={toggleCallback}
         aria-hidden="true"
         tabIndex={-1}
       >
         <div class={styles.mobileMenuLabel}>
-          {open ? (
+          {isOpen ? (
             <Icon kind="close" />
           ) : (
             <>
@@ -72,7 +59,7 @@ export const MainNavLinks = ({
           )}
         </div>
         <span class={styles.desktopMenuLabel}>
-          <Icon kind={open ? "chevron-up" : "chevron-down"} />
+          <Icon kind={isOpen ? "chevron-up" : "chevron-down"} />
         </span>
       </button>
     </div>
@@ -80,7 +67,7 @@ export const MainNavLinks = ({
 
   return (
     <div
-      class={`${styles.mainlinks} ${open && "open"} ${
+      class={`${styles.mainlinks} ${isOpen && "open"} ${
         !hasJumpTo && "noJumpTo"
       }`}
     >

--- a/src/components/Nav/NavLinks.tsx
+++ b/src/components/Nav/NavLinks.tsx
@@ -1,0 +1,75 @@
+import type { JumpToState } from "@/src/globals/state";
+import { JumpToLinks } from "./JumpToLinks";
+import { MainNavLinks } from "./MainNavLinks";
+import { useEffect, useState } from "preact/hooks";
+
+interface NavLinksProps {
+  mainLinks: {
+    label: string;
+    url: string;
+  }[];
+  editorButtonLabel: string;
+  donateButtonLabel: string;
+  mobileMenuLabel: string;
+  jumpToLabel: string;
+  isHomepage: boolean;
+  jumpToState: JumpToState | null;
+}
+
+export const NavLinks = (props: NavLinksProps) => {
+  const {
+    mainLinks,
+    isHomepage,
+    editorButtonLabel,
+    donateButtonLabel,
+    mobileMenuLabel,
+    jumpToLabel,
+    jumpToState,
+  } = props;
+
+  const [isOpen, setIsOpen] = useState({ main: false, jump: false });
+
+  const isMobile = () => window.innerWidth <= 768;
+
+  // Defaults to closed on mobile, open on desktop
+  // Have to do this in a lifecycle method
+  // so that we can still server-side render
+  useEffect(() => {
+    setIsOpen({ main: !isMobile(), jump: !isMobile() });
+  }, []);
+
+  const handleMainNavToggle = () => {
+    setIsOpen((prev) => ({
+      main: !prev.main,
+      jump: isMobile() ? false : prev.jump || prev.main,
+    }));
+  };
+
+  const handleJumpToToggle = () => {
+    setIsOpen((prev) => ({
+      jump: !prev.jump,
+      main: isMobile() ? false : prev.main || prev.jump,
+    }));
+  };
+
+  return (
+    <>
+      <MainNavLinks
+        links={mainLinks}
+        isHomepage={isHomepage}
+        editorButtonLabel={editorButtonLabel}
+        donateButtonLabel={donateButtonLabel}
+        mobileMenuLabel={mobileMenuLabel}
+        hasJumpTo={jumpToState !== null}
+        isOpen={isOpen.main}
+        toggleCallback={handleMainNavToggle}
+      />
+      <JumpToLinks
+        heading={jumpToState?.heading || jumpToLabel}
+        links={jumpToState?.links}
+        isOpen={isOpen.jump}
+        toggleCallback={handleJumpToToggle}
+      />
+    </>
+  );
+};

--- a/src/components/Nav/NavPanels.tsx
+++ b/src/components/Nav/NavPanels.tsx
@@ -3,7 +3,7 @@ import { JumpToLinks } from "./JumpToLinks";
 import { MainNavLinks } from "./MainNavLinks";
 import { useEffect, useState } from "preact/hooks";
 
-interface NavLinksProps {
+interface NavPanelsProps {
   mainLinks: {
     label: string;
     url: string;
@@ -16,7 +16,7 @@ interface NavLinksProps {
   jumpToState: JumpToState | null;
 }
 
-export const NavLinks = (props: NavLinksProps) => {
+export const NavPanels = (props: NavPanelsProps) => {
   const {
     mainLinks,
     isHomepage,

--- a/src/components/Nav/NavPanels.tsx
+++ b/src/components/Nav/NavPanels.tsx
@@ -16,6 +16,11 @@ interface NavPanelsProps {
   jumpToState: JumpToState | null;
 }
 
+/**
+ * This component primarily exists to manage open/closed state between
+ * the two link menus, which behaves differently on mobile than on desktop.
+ *
+ */
 export const NavPanels = (props: NavPanelsProps) => {
   const {
     mainLinks,
@@ -62,13 +67,13 @@ export const NavPanels = (props: NavPanelsProps) => {
         mobileMenuLabel={mobileMenuLabel}
         hasJumpTo={jumpToState !== null}
         isOpen={isOpen.main}
-        toggleCallback={handleMainNavToggle}
+        handleToggle={handleMainNavToggle}
       />
       <JumpToLinks
         heading={jumpToState?.heading || jumpToLabel}
         links={jumpToState?.links}
         isOpen={isOpen.jump}
-        toggleCallback={handleJumpToToggle}
+        handleToggle={handleJumpToToggle}
       />
     </>
   );

--- a/src/components/Nav/index.astro
+++ b/src/components/Nav/index.astro
@@ -1,9 +1,8 @@
 ---
 import { getCurrentLocale, getUiTranslator } from "@/src/i18n/utils";
 import { jumpToState } from "@/src/globals/state";
-import { JumpToLinks } from "./JumpToLinks";
-import { MainNavLinks } from "./MainNavLinks";
 import styles from "./styles.module.scss";
+import { NavLinks } from "./NavLinks";
 
 const currentLocale = getCurrentLocale(Astro.url.pathname);
 // We force the logo to the accent color only on the homepage
@@ -23,24 +22,21 @@ const mainLinks = [
 const editorButtonLabel = t("Start Coding");
 const donateButtonLabel = t("Donate");
 const mobileMenuLabel = t("Menu");
+const jumpToLabel = t("Jump To");
 ---
 
 <nav class={styles.container}>
   <a href="#main-content" class="skip-to-main">
     {t("Skip to main content")}
   </a>
-  <MainNavLinks
-    links={mainLinks}
+  <NavLinks
+    mainLinks={mainLinks}
     isHomepage={isHomepage}
     editorButtonLabel={editorButtonLabel as string}
     donateButtonLabel={donateButtonLabel as string}
     mobileMenuLabel={mobileMenuLabel as string}
-    hasJumpTo={jumpToState !== null}
-    client:load
-  />
-  <JumpToLinks
-    heading={jumpToState?.heading || (t("Jump To") as string)}
-    links={jumpToState?.links}
+    jumpToLabel={jumpToLabel as string}
+    jumpToState={jumpToState}
     client:load
   />
 </nav>

--- a/src/components/Nav/index.astro
+++ b/src/components/Nav/index.astro
@@ -2,7 +2,7 @@
 import { getCurrentLocale, getUiTranslator } from "@/src/i18n/utils";
 import { jumpToState } from "@/src/globals/state";
 import styles from "./styles.module.scss";
-import { NavLinks } from "./NavLinks";
+import { NavPanels } from "./NavPanels";
 
 const currentLocale = getCurrentLocale(Astro.url.pathname);
 // We force the logo to the accent color only on the homepage
@@ -29,7 +29,7 @@ const jumpToLabel = t("Jump To");
   <a href="#main-content" class="skip-to-main">
     {t("Skip to main content")}
   </a>
-  <NavLinks
+  <NavPanels
     mainLinks={mainLinks}
     isHomepage={isHomepage}
     editorButtonLabel={editorButtonLabel as string}

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -156,6 +156,7 @@
   @media (min-width: $breakpoint-tablet) {
     height: 80px;
     border-top-width: 1px;
+    margin-top: auto;
 
     &:global(.open) {
       height: 100%;


### PR DESCRIPTION
- refactors the state management of the main nav links and jump to links panels to:
  - on mobile: make it such that both panels _cannot_ be open at the same time
  - on desktop: at least one panel _must_ be open at all times
  - watches for viewport changes require switching from one behavior to another

this introduces a bit more javascript to the app, but i think its unavoidable to get the behavior right here