### PR TITLE
dont pass example name as a css class

### DIFF
--- a/src/layouts/ExampleLayout.astro
+++ b/src/layouts/ExampleLayout.astro
@@ -53,6 +53,7 @@ const { Content } = await example.render();
 
 <BaseLayout
   title={example.data.title}
+  titleClass=""
   subtitle={null}
   variant="item"
   topic="examples"


### PR DESCRIPTION
some examples with the word "events" in them were getting the events page header color