### PR TITLE
Display images with alts on event pages

### DIFF
--- a/src/layouts/EventLayout.astro
+++ b/src/layouts/EventLayout.astro
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const { entry, title } = Astro.props;
-const { Content, components } = await entry.render();
+const { Content } = await entry.render();
 
 setJumpToState(null);
 
@@ -55,7 +55,6 @@ const relatedEvents =
   <div class="rendered-markdown">
     <Content
       components={{
-        ...components,
         img: FreeRatioImage,
       }}
     />

--- a/src/layouts/EventLayout.astro
+++ b/src/layouts/EventLayout.astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from "astro:content";
 import Head from "@components/Head/index.astro";
 import BaseLayout from "./BaseLayout.astro";
 import Image from "@components/Image/index.astro";
+import FreeRatioImage from "@components/Image/FreeRatioImage.astro";
 import RelatedItems from "@components/RelatedItems/index.astro";
 import { setJumpToState } from "../globals/state";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
@@ -14,7 +15,7 @@ interface Props {
 }
 
 const { entry, title } = Astro.props;
-const { Content } = await entry.render();
+const { Content, components } = await entry.render();
 
 setJumpToState(null);
 
@@ -52,7 +53,12 @@ const relatedEvents =
     )
   }
   <div class="rendered-markdown">
-    <Content />
+    <Content
+      components={{
+        ...components,
+        img: FreeRatioImage,
+      }}
+    />
   </div>
 
   {


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/371

This passes in the same image component used for tutorials for the images on event pages, which renders the alt text as a viewable element.

<img width="1234" alt="image" src="https://github.com/processing/p5.js-website/assets/5315059/4222e1b0-dd5d-4354-99ac-fb951b14ff48">
