### PR TITLE
Show alt text on homepage images

### DIFF
--- a/src/components/PageHeader/HomePage.astro
+++ b/src/components/PageHeader/HomePage.astro
@@ -32,12 +32,20 @@ const { config } = Astro.props;
 
   {
     config.data.heroImages.map((im, i) => (
-      <img
-        class={`hero-image ${i > 0 ? "hidden" : ""}`}
-        src={im.image.src}
-        alt={im.altText}
-        loading={i > 0 ? "lazy" : "eager"}
-      />
+      <div class={`relative hero-image-container ${i > 0 ? "hidden" : ""}`}>
+        <img
+          class={"hero-image"}
+          src={im.image.src}
+          alt={im.altText}
+          loading={i > 0 ? "lazy" : "eager"}
+        />
+        <p
+          aria-hidden
+          class={"renderable-alt bg-bg-gray-40 line-clamp-3 absolute top-0 mt-sm mx-sm px-[7.5px] pb-[2.5px] rounded-xl text-body-caption text-ellipsis"}
+        >
+          {im.altText}
+        </p>
+      </div>
     ))
   }
 </div>
@@ -45,7 +53,7 @@ const { config } = Astro.props;
 <script>
   document.addEventListener("DOMContentLoaded", (event) => {
     // find all hero image elements
-    const images = document.querySelectorAll("img.hero-image");
+    const images = document.querySelectorAll(".hero-image-container");
     if (images.length > 1) {
       const shownImageInd = Math.round(Math.random() * (images.length - 1));
       console.log(shownImageInd);


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/376

I was initially going to use the Image component in the components folder, but it seemed to not like the string `src`s we were passing into the `<img>` tag, and also I needed to add some classes to the container itself to make it show/hide everything correctly, so in the end I just mirrored some of the same structure in the HomePage component.

<img width="1458" alt="image" src="https://github.com/processing/p5.js-website/assets/5315059/16fcbdcc-3324-4f14-b6bc-29e194665595">
