### PR TITLE
Round both top corners of the donate box

### DIFF
--- a/src/components/DonorBoxWidget/index.astro
+++ b/src/components/DonorBoxWidget/index.astro
@@ -1,6 +1,6 @@
 <script src="https://donorbox.org/widget.js"></script>
 <!-- @ts-expect-error  -->
-<div class="rounded-lg overflow-hidden mt-md pb-0 max-w-[420px] min-w-[250px]">
+<div class="overflow-hidden mt-md pb-0 max-w-[420px] min-w-[250px]">
   <iframe
     allowpaymentrequest=""
     height="525"
@@ -9,6 +9,7 @@
     name="donorbox"
     src="https://donorbox.org/embed/support-the-processing-foundation?hide_donation_meter=true"
     style="max-width: 420px; min-width: 250px; max-height:none !important;"
+    class="rounded-lg"
   >
   </iframe>
 </div>


### PR DESCRIPTION
We can't round the bottom two corners because we can't style the inner content of the `<iframe>` and also the height changes on each step of the donation flow, but since the container constraints the width enough to make the header always full-width of the container, moving the `border-radius` from the container to the iframe itself seems to get both top corners to be round.

<img width="763" alt="image" src="https://github.com/processing/p5.js-website/assets/5315059/322c3bb8-514a-4af9-996f-8b4d46929073">
