### PR TITLE
Created SPANISH setup.mdx

### DIFF
--- a/src/content/reference/es/p5/setup.mdx
+++ b/src/content/reference/es/p5/setup.mdx
@@ -1,0 +1,44 @@
+---
+title: setup
+module: Structure
+submodule: Structure
+file: src/core/main.js
+description: >
+ <p>La función <a href="/reference/p5/setup">setup()</a> es llamada una vez al comienzo del programa.  Se utiliza para
+definir propiedades iniciales del entorno, como el tamaño de la pantalla y el color del fondo
+y para cargar archivos multimedia como imágenes y fuentes en la iniciación del programa.
+Solo puede haber una función <a href="/reference/p5/setup">setup()</a> por
+programa y no debería volverse a llamar después de su ejecución inicial.</p>
+
+
+ <p>Nota: Las variables declaradas dentro de <a href="/reference/p5/setup">setup()</a>
+  no son accesibles dentro de otras
+
+  funciones, incluyendo a <a href="/reference/p5/draw">draw()</a>.</p>
+  
+line: 82
+isConstructor: false
+itemtype: method
+alt: nothing displayed
+example:
+  - |-
+
+    <div><code>
+    let a = 0;
+
+    function setup() {
+      background(0);
+      noStroke();
+      fill(102);
+    }
+
+    function draw() {
+      rect(a++ % width, 10, 2, 80);
+    }
+    </code></div>
+class: p5
+chainable: false
+---
+
+
+# setup


### PR DESCRIPTION
Added a Spanish translated version of the setup() function. I also made sure that "Structure" module andf submodule is referred to as "Structure" In other Spanish translations on the website