### PR TITLE
remove line clamp on hover for visible alt text

### DIFF
--- a/src/components/Image/index.astro
+++ b/src/components/Image/index.astro
@@ -37,7 +37,8 @@ const noAltText = t("No alt text");
     class:list={[
       "renderable-alt",
       "text-body-caption",
-      "bg-bg-gray-40 line-clamp-3 absolute top-0 mt-sm mx-sm px-[7.5px] pb-[2.5px] rounded-xl text-ellipsis",
+      "bg-bg-gray-40 absolute top-0 mt-sm mx-sm px-[7.5px] pb-[2.5px] rounded-xl text-ellipsis",
+      "line-clamp-3 hover:line-clamp-none",
       props.visibleAltTextClass,
     ]}
   >


### PR DESCRIPTION
![alt text hover behavior](https://github.com/processing/p5.js-website/assets/964912/1f75e3cb-10fd-4ccc-9e81-ff471129af92)
