### PR TITLE
Fix video paths

### DIFF
--- a/src/content/tutorials/en/conditionals-and-interactivity.mdx
+++ b/src/content/tutorials/en/conditionals-and-interactivity.mdx
@@ -545,7 +545,7 @@ Run the sketch and move the sun below the horizon. See how the sky changes as th
 
 Next, you will make a [sunrise animation](https://editor.p5js.org/gbenedis@gmail.com/sketches/9lz2aqfTO) where the sun moves on its own, and creates a gradual change in the color of the sky.
 
-<Video src="/public/videos/tutorials/sunrise.mp4" alt="A sun rises in a red-orange sky behind a mountain range." />
+<Video src="/videos/tutorials/sunrise.mp4" alt="A sun rises in a red-orange sky behind a mountain range." />
 
 
 #### Step One: Declare and initialize variables for sun location and background color

--- a/src/content/tutorials/en/how-to-optimize-your-sketches.mdx
+++ b/src/content/tutorials/en/how-to-optimize-your-sketches.mdx
@@ -44,7 +44,7 @@ This framework is useful for all code improvement and is a standard approach in 
 
 For a blog post I was writing, I wanted to create a simulation of 1,000 particles bouncing around the canvas. I went to the trouble of programming accurate laws of physics that determine the motion of each particle. As I ran the sketch with an increasing number of particles, the particles moved frustratingly slowly.
 
-<Video src="/public/videos/tutorials/slow-no-fr.mp4" alt="A 2D animation of particles bouncing on the canvas." />
+<Video src="/videos/tutorials/slow-no-fr.mp4" alt="A 2D animation of particles bouncing on the canvas." />
 
 The problem is that the animation runs too slowly. I wanted to speed up the simulation to improve the visual experience for the viewer. This guide is designed to help you address any situation where you want your code to run more quickly. We will use my example to illustrate the steps involved. If you like, you can view the final blog post: [Scintillating Simulations](https://gbenedis.medium.com/computing-stories-scintillating-simulations-4dad3c480cd4).
 
@@ -89,7 +89,7 @@ If you don’t specify the frame rate in p5.js, by default, it attempts to reach
 
 Below, I show the animation with the frame rate displayed. Displaying it will make it easier to see the impact of changes we make.
 
-<Video src="/public/videos/tutorials/slow-w-fr.mp4" alt="Bouncing particles with the frame rate displayed on the canvas that reads at or close to “20”" />
+<Video src="/videos/tutorials/slow-w-fr.mp4" alt="Bouncing particles with the frame rate displayed on the canvas that reads at or close to “20”" />
 
 In this case, I am trying to improve the performance of my code. The same type of process would apply to improving other aspects of your code’s functionality. 
 
@@ -152,12 +152,12 @@ Look at the difference it makes! I included the frame rate in the visualization 
 <Column>
 #### Before
 
-<Video src="/public/videos/tutorials/slow-w-fr.mp4" alt="Bouncing particles with the frame rate displayed on the canvas that reads at or close to “20”" />
+<Video src="/videos/tutorials/slow-w-fr.mp4" alt="Bouncing particles with the frame rate displayed on the canvas that reads at or close to “20”" />
 </Column>
 <Column>
 #### After
 
-<Video src="/public/videos/tutorials/fast-w-fr.mp4" alt="Bouncing particles with the frame rate displayed on the canvas that reads at or close to “60”" />
+<Video src="/videos/tutorials/fast-w-fr.mp4" alt="Bouncing particles with the frame rate displayed on the canvas that reads at or close to “60”" />
 </Column>
 </Columns>
 

--- a/src/content/tutorials/en/variables-and-change.mdx
+++ b/src/content/tutorials/en/variables-and-change.mdx
@@ -31,7 +31,7 @@ import EditableSketch from "../../../components/EditableSketch/index.astro";
 
 Follow this tutorial to create an [animated landscape](https://editor.p5js.org/Msqcoding/sketches/WQWNKZppu) as you learn the basics of variables and creating motion in p5.js. 
 
-<Video src="/public/videos/tutorials/landscape.mp4" alt="An animated landscape with a crescent moon and a mountain range in the background, and grass with growing trees in the foreground. Stars randomly appear as clouds move across the canvas." />
+<Video src="/videos/tutorials/landscape.mp4" alt="An animated landscape with a crescent moon and a mountain range in the background, and grass with growing trees in the foreground. Stars randomly appear as clouds move across the canvas." />
 
 In this tutorial you will:
 


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/409

Fixes some videos having `/public` as part of their `src`, when the final path on the live site will not actually include the `public` part.

Videos work now:

![image](https://github.com/processing/p5.js-website/assets/5315059/3376a1ca-775b-4056-9ab2-3215a9899b42)
