### PR TITLE
Add attribution placeholders in example descriptions

### DIFF
--- a/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx
@@ -18,3 +18,9 @@ primitive functions
 <a href="https://p5js.org/reference/#/p5/line" target="_blank">line()</a>,
 <a href="https://p5js.org/reference/#/p5/triangle" target="_blank">triangle()</a>,
 and <a href="https://p5js.org/reference/#/p5/quad" target="_blank">quad()</a>.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
@@ -18,3 +18,9 @@ sets the color for the inside of shapes.
 turn off line color and inner color, respectively.
 
 Colors can be represented in many different ways. This example demonstrates several options.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/01_Shapes_And_Color/01_Color/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
@@ -8,15 +8,22 @@ Click and drag the mouse to draw a line.
 
 This example demonstrates the use of several built-in
 variables.
+
 <a href="https://p5js.org/reference/#/p5/mouseX">mouseX</a>
 and
 <a href="https://p5js.org/reference/#/p5/mouseY">mouseY</a>
-store the current mouse position, while the
-previous mouse position is represented by
+store the current mouse position, while the previous mouse position is represented
+by
 <a href="https://p5js.org/reference/#/p5/pmouseX">pmouseX</a>
 and
-<a href="https://p5js.org/reference/#/p5/pmouseY">pmouseY</a>.
- *
-This example also shows the use of
+<a href="https://p5js.org/reference/#/p5/pmouseY">pmouseY</a>. * This example
+also shows the use of
 <a href="https://p5js.org/reference/#/p5/colorMode">colorMode</a> with HSB
 (hue-saturation-brightness), so that the first variable sets the hue.
+
+Contributors from the p5 community wrote this example. Soon their names will
+appear here. In the meantime, you can 
+<a
+  href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/code.js"
+  target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
@@ -18,3 +18,9 @@ key presses to be registered.
 Advancing a single frame is accomplished by calling the
 <a href="https://p5js.org/reference/#/p5/redraw">redraw()</a>
 function, which results in a single call to the draw() function.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
@@ -13,3 +13,9 @@ In this example, the
 and <a href="https://p5js.org/reference/#/p5/accelerationZ" target="_blank">accelerationZ</a>
 values set the position and size of a circle.
 This only works for mobile devices.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/02_Animation_And_Variables/03_Conditions/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/03_Conditions/description.mdx
@@ -29,3 +29,9 @@ no more than 300.
 checks that at least one of the conditions is true. The circle reverses horizontal
 speed when it reaches the left or right edge of the canvas because of the if statement
 on line 75.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/02_Animation_And_Variables/03_Conditions/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/03_Imported_Media/00_Words/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/00_Words/description.mdx
@@ -9,3 +9,9 @@ You can change the font and text size using the <a href="https://p5js.org/refere
 and <a href="https://p5js.org/reference/#/p5/fontSize" target="_blank">fontSize()</a> functions.
 The text can be aligned left, center, or right with the <a href="https://p5js.org/reference/#/p5/textAlign" target="_blank">textAlign()</a>
 function, and, like shapes, text can be colored with <a href="https://p5js.org/reference/#/p5/fill" target="_blank">fill()</a>.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/03_Imported_Media/00_Words/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/description.mdx
@@ -7,3 +7,9 @@ oneLineDescription: Paint from an image file onto the canvas.
 Using the <a href="https://p5js.org/reference/#/p5/copy" target="_blank">copy()</a> 
 method, you can simulate coloring an image in by copying an image of the colored 
 image on top of the black-and-white image wherever the cursor is dragged.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/description.mdx
@@ -10,3 +10,9 @@ method, you can create a mask for an image to specify the transparency in
 different parts of the image. To run this example locally, you will need two
 image files and a running 
 <a href="https://github.com/processing/p5.js/wiki/Local-server">local server</a>.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/03_Imported_Media/03_Image_Transparency/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/03_Image_Transparency/description.mdx
@@ -11,3 +11,9 @@ function. Move the cursor left and right across the canvas to change the
 image's position. To run this example
 locally, you will need an image file and a running
 <a href="https://github.com/processing/p5.js/wiki/Local-server">local server</a>.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/03_Imported_Media/03_Image_Transparency/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
@@ -13,3 +13,9 @@ audio players is on the
 <a href="https://p5js.org/reference/#/p5.MediaElement" target="_blank">p5.MediaElement</a>
 reference page. The audio file is a
 <a href="https://freesound.org/people/josefpres/sounds/711156/" target="_blank">public domain piano loop by Josef Pres</a>.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/03_Imported_Media/04_Create_Audio/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
@@ -11,3 +11,9 @@ functions, you can upload a video into the
 without embedding the video within a canvas. For building a video embedded within the canvas element,
 visit the 
 <a href="https://p5js.org/examples/dom-video-canvas.html" target="_blank">Video Canvas</a> example.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/03_Imported_Media/05_Video/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
@@ -16,3 +16,9 @@ method. To run this example locally, you will need a running
 <a href="https://github.com/processing/p5.js/wiki/Local-server">local server</a>.
 To build a video without embedding it within the canvas, visit the 
 <a href="https://p5js.org/examples/dom-video.html">Video</a> example.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/03_Imported_Media/06_Video_Canvas/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/03_Imported_Media/07_Video_Capture/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/07_Video_Capture/description.mdx
@@ -17,3 +17,9 @@ visit the
 <a href="https://p5js.org/examples/dom-video.html" target="_blank">Video</a> and
 <a href="https://p5js.org/examples/dom-video-canvas.html" target="_blank">Video Canvas</a> 
 examples.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/03_Imported_Media/07_Video_Capture/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
@@ -12,3 +12,9 @@ class. You can use the
 <a href="https://p5js.org/reference/#/p5.Element/drop" target="_blank">drop()</a> 
 callback to check the file type, then write conditional statements responding to 
 the file type.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/04_Input_Elements/00_Image_Drop/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/04_Input_Elements/01_Input_Button/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/01_Input_Button/description.mdx
@@ -10,3 +10,9 @@ Using the
 and <a href="https://p5js.org/reference/#/p5.Element/createButton" target="_blank">createButton()</a> 
 functions, you can take a string of text submitted via text input and display 
 it on your canvas.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/04_Input_Elements/01_Input_Button/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
@@ -13,3 +13,8 @@ a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select" tar
 <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input" target="_blank">input</a>,
 or <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio" target="_blank">radio button</a> and update the DOM based on the information.
  
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/05_Transformation/00_Translate/description.mdx
+++ b/src/content/examples/en/05_Transformation/00_Translate/description.mdx
@@ -18,3 +18,9 @@ other drawing settings, such as the fill color.
 
 Note that in this example, we draw the shapes (rectangle and
 circle) each time in a different coordinate system.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/05_Transformation/00_Translate/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
+++ b/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
@@ -18,3 +18,9 @@ The
 and
 <a href="https://p5js.org/reference/#/p5/pop">pop()</a>
 functions save and restore the coordinate system, respectively.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/05_Transformation/01_Rotate/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/05_Transformation/02_Scale/description.mdx
+++ b/src/content/examples/en/05_Transformation/02_Scale/description.mdx
@@ -17,3 +17,9 @@ functions save and restore the coordinate system, respectively.
 
 In this example, a square size 200 is drawn at the origin, with
 three different scaling factors.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/05_Transformation/02_Scale/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
@@ -15,3 +15,9 @@ function linearly interpolates between two numbers.
 Move the mouse across the screen and the symbol will follow.
 Between drawing each frame of the animation, the ellipse moves part
 of the distance from its current position toward the cursor.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/06_Calculating_Values/00_Interpolate/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
@@ -11,3 +11,9 @@ converts the cursor's horizontal position from a range of 0-720 to 0-360.
 The resulting value become the circle's hue. Map also converts the cursor's
 vertical position from a range of 0-400 to 20-300. The resulting value
 becomes the circle's diameter.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/06_Calculating_Values/01_Map/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
@@ -10,3 +10,9 @@ function.
 
 When the user presses the mouse button, the position and color
 of the circle change randomly.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/06_Calculating_Values/02_Random/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
@@ -9,3 +9,9 @@ keeps the circle within a rectangle. It does so by passing the
 mouse's coordinates into the
 <a href="https://p5js.org/reference/#/p5/constrain" target="_blank">constrain()</a>
 function.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/06_Calculating_Values/03_Constrain/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
@@ -13,3 +13,9 @@ functions. This example uses
 to calculate the angle of the hands. It then uses
 <a href="https://p5js.org/reference/#group-Transform" target="_blank">transformations</a>
 to set their position.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/06_Calculating_Values/04_Clock/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
+++ b/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
@@ -16,3 +16,9 @@ function, demonstrated here, linearly interpolates between two colors.
 In this example, the stripeCount variable adjusts how many horizontal
 stripes appear. Setting the value to a higher number will look less
 like individual stripes and more like a gradient.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/07_Repetition/00_Color_Interpolation/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
+++ b/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
@@ -14,3 +14,9 @@ relative to the center of the canvas. The
 <a href="https://p5js.org/reference/#/p5/push" target="_blank">push()</a>
 and <a href="https://p5js.org/reference/#/p5/pop" target="_blank">pop()</a>
 functions make these transformations affect only the individual circle.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/07_Repetition/01_Color_Wheel/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
+++ b/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
@@ -11,3 +11,9 @@ The first two parameters for the
 function specify the first point in the curve and the last two parameters 
 specify the last point. The middle parameters set the control points that 
 define the shape of the curve.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/07_Repetition/02_Bezier/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
+++ b/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
@@ -10,3 +10,9 @@ reflecting surfaces tilted to each other at an angle. Using the
 <a href="https://p5js.org/reference/#/p5/rotate" target="_blank">rotate()</a>,
 and <a href="https://p5js.org/reference/#/p5/scale" target="_blank">scale()</a> functions, you can replicate the resulting visual
 of a kaleidoscope in a canvas.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/07_Repetition/03_Kaleidoscope/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/07_Repetition/04_Noise/description.mdx
+++ b/src/content/examples/en/07_Repetition/04_Noise/description.mdx
@@ -13,3 +13,9 @@ function in p5 produces Perlin noise.
 The dots in this example are sized based on noise values. The slider on the
 left sets the distance between dots. The slider on the right sets an offset
 in the noise calculation.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/07_Repetition/04_Noise/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/07_Repetition/05_Recursive_Tree/description.mdx
+++ b/src/content/examples/en/07_Repetition/05_Recursive_Tree/description.mdx
@@ -8,3 +8,9 @@ This is an example of rendering a simple tree-like structure via recursion.
 The branching angle is calculated as a function of the horizontal mouse
 location. Move the mouse left and right to change the angle.
 Based on Daniel Shiffman's <a href="https://processing.org/examples/tree.html">Recursive Tree Example</a> for Processing.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/07_Repetition/05_Recursive_Tree/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
+++ b/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
@@ -10,3 +10,9 @@ and
 <a href="https://p5js.org/reference/#/p5/random" target="_blank">random()</a>
 functions, you can randomly select a series of items from an array
 and draw them at different sizes and positions on the canvas.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
@@ -14,3 +14,9 @@ The animation shows uniform circular motion around the unit circle
 determines a point on the circle. The cosine and sine of the angle
 are defined to be the x and y coordinates, respectively, of that
 point.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-example/blame/d2d90590a41abf4630fab256324c0da44185a968/examples/curated/29_Sine_Cosine.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
@@ -9,3 +9,9 @@ The
 function calculates the angle between two positions. The angle it
 calculates can be used to rotate a shape toward something. In this
 example, the eyes rotate to look at the cursor.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/09_Angles_And_Motion/01_Aim/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
@@ -11,3 +11,9 @@ by specifying its vertices in TRIANGLE_STRIP mode, using the
 and
 <a href="https://p5js.org/reference/#/p5/vertex">vertex()</a>
 functions.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/10_Games/00_Circle_Clicker/description.mdx
+++ b/src/content/examples/en/10_Games/00_Circle_Clicker/description.mdx
@@ -8,3 +8,9 @@ This example demonstrates a game with a time limit and score. The browser's
 <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage" target="_blank">local storage</a>
 stores the high score so when the game is played again using the same browser,
 the high score remains. Clearing the browser data also clears the high score.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/10_Games/00_Circle_Clicker/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/10_Games/01_Ping_Pong/description.mdx
+++ b/src/content/examples/en/10_Games/01_Ping_Pong/description.mdx
@@ -12,3 +12,9 @@ white rectangle. The W and S keys move the paddle on the left up and down,
 and the up and down arrow keys move the paddle on the right up and down.
 Players score points by bouncing the ball, represented by a white square,
 past the edge of the opponent's side of the canvas.`
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/10_Games/01_Ping_Pong/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/10_Games/02_Snake/description.mdx
+++ b/src/content/examples/en/10_Games/02_Snake/description.mdx
@@ -19,3 +19,9 @@ This example uses an array of
 <a href="https://p5js.org/reference/#/p5.Vector" target="_blank">vectors</a>
 to store the positions of each of the segments of the snake. The arrow
 keys control the snake's movement.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/10_Games/02_Snake/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/11_3D/00_Geometries/description.mdx
+++ b/src/content/examples/en/11_3D/00_Geometries/description.mdx
@@ -13,3 +13,9 @@ displays a custom geometry loaded via
 <a href="https://p5js.org/reference/#/p5/loadModel" target="_blank">loadModel()</a>.
 This example includes each of the primitive shapes. It also includes a model
 from <a href="https://nasa3d.arc.nasa.gov/models" target="_blank">NASA's collection</a>.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/11_3D/00_Geometries/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
+++ b/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
@@ -8,3 +8,9 @@ The
 <a href="https://p5js.org/reference/#/p5/buildGeometry" target="_blank">buildGeometry()</a>
 function stores shapes into a 3D model that can be efficiently used and
 reused.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/11_3D/01_Custom_Geometry/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/11_3D/02_Materials/description.mdx
+++ b/src/content/examples/en/11_3D/02_Materials/description.mdx
@@ -30,3 +30,9 @@ Additionally,
 <a href="https://p5js.org/reference/#/p5/texture" target="_blank">texture()</a>
 wraps an object with an image. The model and image texture in this example are
 from <a href="https://nasa3d.arc.nasa.gov" target="_blank">NASA's collection</a>.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/11_3D/02_Materials/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
+++ b/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
@@ -12,3 +12,9 @@ on a touch screen. To pan the camera, right click and drag a mouse
 or swipe with multiple fingers on a touch screen. To move the camera
 closer or further to the center of the sketch, use the scroll wheel
 on a mouse or pinch in/out on a touch screen.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/11_3D/03_Orbit_Control/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/11_3D/04_Filter_Shader/description.mdx
+++ b/src/content/examples/en/11_3D/04_Filter_Shader/description.mdx
@@ -6,3 +6,9 @@ oneLineDescription: Manipulate imagery with a shader.
 
 Filter shaders are a way to apply an effect to anything that
 is on the canvas. In this example, the effect is applied to a video.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/11_3D/04_Filter_Shader/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/description.mdx
+++ b/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/description.mdx
@@ -6,3 +6,9 @@ oneLineDescription: Use a shader to adjust shape vertices.
 
 Shaders can adjust the positions of the vertices of shapes.
 This lets you distort and animate 3D models.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/description.mdx
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/description.mdx
@@ -12,3 +12,9 @@ to apply a blur. On a real camera, objects appear blurred if they
 are closer or farther than the lens's focus. This simulates that
 effect. First, the sketch renders five spheres to the framebuffer.
 Then, it renders the framebuffer to the canvas using the blur shader.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
@@ -10,3 +10,9 @@ function can be used to create a new p5.Graphics object, which can serve as
 an off-screen graphics buffer within the canvas. Off-screen buffers can have
 different dimensions and properties than their current display surface, even
 though they appear to be existing in the same space.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/01_Multiple_Canvases/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/01_Multiple_Canvases/description.mdx
@@ -14,3 +14,9 @@ To use instance mode, a function must be defined with a parameter representing
 the p5 instance (labeled p in this example). All the p5 functions and variables
 that are typically global will belong to this parameter within this function's
 scope. Passing the function into the p5 constructor, runs it.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/02_Shader_As_A_Texture/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/02_Shader_As_A_Texture/description.mdx
@@ -8,3 +8,9 @@ Shaders can be applied to 2D/3D shapes as textures.
 
 To learn more about using shaders in p5.js:
 <a href="https://itp-xstory.github.io/p5js-shaders/">p5.js Shaders</a>
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/12_Advanced_Canvas_Rendering/02_Shader_As_A_Texture/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/description.mdx
@@ -9,3 +9,9 @@ to simulate the motion of falling snowflakes. This program defines a
 snowflake
 <a href="https://p5js.org/reference/#/p5/class">class</a>
 and uses an array to hold the snowflake objects.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
@@ -9,3 +9,9 @@ Using a
 you can create a collection of circles that move within the canvas in 
 response to the tilt of a mobile device. You must open this page on a mobile 
 device to display the sketch.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
@@ -14,3 +14,9 @@ connecting each of the particles. When the user clicks the mouse, the
 sketch creates a new instance of the Path class. When the user drags
 the mouse, the sketch adds a new instance of the Particle class to
 the current path.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/13_Classes_And_Objects/03_Flocking/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/03_Flocking/description.mdx
@@ -10,3 +10,9 @@ Full discussion of the implementation can be found in the
 book by Daniel Shiffman. The simulation is based on the research of
 <a href="http://www.red3d.com/cwr/">Craig Reynolds</a>, who
 used the term 'boid' to represent a bird-like object.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/13_Classes_And_Objects/03_Flocking/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
@@ -19,3 +19,9 @@ Tabular Data examples for Processing written in Java. It uses a
 to organize data for a bubble. The visitor can add new bubbles, and their data 
 will be saved in local storage. If the visitor revisits the sketch, it will
 reload the same bubbles.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
@@ -13,3 +13,9 @@ written in Java. It uses a
 to organize data for a bubble. When the sketch starts, it
 loads the data for two bubbles from a JSON file. The visitor can add
 new bubbles, download an updated JSON file, and load in a JSON file.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
@@ -13,3 +13,9 @@ example for Processing. It uses a class to organize data representing
 a bubble. When the sketch starts, it loads the data for four bubbles
 from a CSV file. The visitor can add new bubbles, download an updated
 CSV file, and load in a CSV file.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
@@ -16,3 +16,9 @@ and the vector methods
 and
 <a href="https://p5js.org/reference/#/p5.Vector/dot">dot()</a>
 for the vector calculations.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
@@ -10,3 +10,9 @@ with curves using
 <a href="https://p5js.org/reference/#/p5/curveVertex">curveVertex()</a>
 and
 <a href="https://p5js.org/reference/#/p5/curveTightness">curveTightness()</a>.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
@@ -14,3 +14,9 @@ The force calculations are performed using the
 class, including the
 <a href="https://p5js.org/reference/#/p5/createVector">createVector()</a>
 function to create vectors.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/15_Math_And_Physics/02_Forces/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
@@ -21,3 +21,9 @@ positions and velocities are performed with p5.Vector methods.
 The particle system is implemented as a
 <a href="https://p5js.org/reference/#/p5/class">class</a>, which contains an array of
 objects (of class Particle).
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/description.mdx
@@ -20,3 +20,9 @@ to the next generation.</li>
 These rules generate complex interactions. Click the canvas to start
 the simulation with randomized cells. Clicking the canvas again will
 restart it.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/code.js" target="_blank"
+>see their contributions in the source code</a>.

--- a/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/description.mdx
@@ -7,3 +7,9 @@ oneLineDescription: Visualize a mathematical set that produces fractal structure
 Colorful rendering of the Mandelbrot set
 based on Daniel Shiffman's
 <a href="https://processing.org/examples/mandelbrot.html">Mandelbrot Example</a> for Processing.
+
+Contributors from the p5 community wrote this example. Soon their names will 
+appear here. In the meantime, you can 
+<a 
+href="https://github.com/processing/p5.js-website/blame/d6b28924185dac5e25c39cd0fc2fc4a1f6392883/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/code.js" target="_blank"
+>see their contributions in the source code</a>.


### PR DESCRIPTION
Add a placeholder for each example with a link to blame on Github while adding attribution is in progress