### PR TITLE
Add attribution links to each example description

### DIFF
--- a/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx
@@ -18,3 +18,5 @@ primitive functions
 <a href="https://p5js.org/reference/#/p5/line" target="_blank">line()</a>,
 <a href="https://p5js.org/reference/#/p5/triangle" target="_blank">triangle()</a>,
 and <a href="https://p5js.org/reference/#/p5/quad" target="_blank">quad()</a>.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>

--- a/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
@@ -18,3 +18,5 @@ sets the color for the inside of shapes.
 turn off line color and inner color, respectively.
 
 Colors can be represented in many different ways. This example demonstrates several options.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
@@ -20,3 +20,5 @@ and
 This example also shows the use of
 <a href="https://p5js.org/reference/#/p5/colorMode">colorMode</a> with HSB
 (hue-saturation-brightness), so that the first variable sets the hue.
+
+Contributors: <a href="https://github.com/jareddonovan" target="_blank">Jared Donovan</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
@@ -18,3 +18,5 @@ key presses to be registered.
 Advancing a single frame is accomplished by calling the
 <a href="https://p5js.org/reference/#/p5/redraw">redraw()</a>
 function, which results in a single call to the draw() function.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
@@ -13,3 +13,5 @@ In this example, the
 and <a href="https://p5js.org/reference/#/p5/accelerationZ" target="_blank">accelerationZ</a>
 values set the position and size of a circle.
 This only works for mobile devices.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/02_Animation_And_Variables/03_Conditions/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/03_Conditions/description.mdx
@@ -29,3 +29,5 @@ no more than 300.
 checks that at least one of the conditions is true. The circle reverses horizontal
 speed when it reaches the left or right edge of the canvas because of the if statement
 on line 75.
+
+Contributors: <a href="https://github.com/suhascv" target="_blank">Suhas CV</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/03_Imported_Media/00_Words/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/00_Words/description.mdx
@@ -9,3 +9,5 @@ You can change the font and text size using the <a href="https://p5js.org/refere
 and <a href="https://p5js.org/reference/#/p5/fontSize" target="_blank">fontSize()</a> functions.
 The text can be aligned left, center, or right with the <a href="https://p5js.org/reference/#/p5/textAlign" target="_blank">textAlign()</a>
 function, and, like shapes, text can be colored with <a href="https://p5js.org/reference/#/p5/fill" target="_blank">fill()</a>.
+
+Contributors: <a href="https://github.com/geealbers" target="_blank">Greg Albers</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/description.mdx
@@ -7,3 +7,5 @@ oneLineDescription: Paint from an image file onto the canvas.
 Using the <a href="https://p5js.org/reference/#/p5/copy" target="_blank">copy()</a> 
 method, you can simulate coloring an image in by copying an image of the colored 
 image on top of the black-and-white image wherever the cursor is dragged.
+
+Contributors: <a href="https://github.com/Acha0203" target="_blank">Acha</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/limzykenneth" target="_blank">Kenneth Lim</a>

--- a/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/description.mdx
@@ -4,9 +4,15 @@ title: Alpha Mask
 oneLineDescription: Use one image to cut out a section of another image.
 ---
 
-Using the 
-<a href="https://p5js.org/reference/#/p5/mask" target="_blank">mask()</a> 
-method, you can create a mask for an image to specify the transparency in
-different parts of the image. To run this example locally, you will need two
-image files and a running 
-<a href="https://github.com/processing/p5.js/wiki/Local-server">local server</a>.
+Using the
+
+<a href="https://p5js.org/reference/#/p5/mask" target="_blank">
+  mask()
+</a>
+method, you can create a mask for an image to specify the transparency in different
+parts of the image. To run this example locally, you will need two image files and
+a running
+<a href="https://github.com/processing/p5.js/wiki/Local-server">local server</a>
+.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/Malayvasa" target="_blank">Malay Vasa</a>

--- a/src/content/examples/en/03_Imported_Media/03_Image_Transparency/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/03_Image_Transparency/description.mdx
@@ -11,3 +11,5 @@ function. Move the cursor left and right across the canvas to change the
 image's position. To run this example
 locally, you will need an image file and a running
 <a href="https://github.com/processing/p5.js/wiki/Local-server">local server</a>.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
@@ -13,3 +13,5 @@ audio players is on the
 <a href="https://p5js.org/reference/#/p5.MediaElement" target="_blank">p5.MediaElement</a>
 reference page. The audio file is a
 <a href="https://freesound.org/people/josefpres/sounds/711156/" target="_blank">public domain piano loop by Josef Pres</a>.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
@@ -11,3 +11,5 @@ functions, you can upload a video into the
 without embedding the video within a canvas. For building a video embedded within the canvas element,
 visit the 
 <a href="https://p5js.org/examples/dom-video-canvas.html" target="_blank">Video Canvas</a> example.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>, <a href="undefined" target="_blank">Aaron Welles</a>

--- a/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
@@ -16,3 +16,5 @@ method. To run this example locally, you will need a running
 <a href="https://github.com/processing/p5.js/wiki/Local-server">local server</a>.
 To build a video without embedding it within the canvas, visit the 
 <a href="https://p5js.org/examples/dom-video.html">Video</a> example.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/03_Imported_Media/07_Video_Capture/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/07_Video_Capture/description.mdx
@@ -17,3 +17,5 @@ visit the
 <a href="https://p5js.org/examples/dom-video.html" target="_blank">Video</a> and
 <a href="https://p5js.org/examples/dom-video-canvas.html" target="_blank">Video Canvas</a> 
 examples.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/macarena" target="_blank">Marco Macarena</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
@@ -12,3 +12,5 @@ class. You can use the
 <a href="https://p5js.org/reference/#/p5.Element/drop" target="_blank">drop()</a> 
 callback to check the file type, then write conditional statements responding to 
 the file type.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>

--- a/src/content/examples/en/04_Input_Elements/01_Input_Button/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/01_Input_Button/description.mdx
@@ -10,3 +10,5 @@ Using the
 and <a href="https://p5js.org/reference/#/p5.Element/createButton" target="_blank">createButton()</a> 
 functions, you can take a string of text submitted via text input and display 
 it on your canvas.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>

--- a/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
@@ -13,3 +13,5 @@ a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select" tar
 <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input" target="_blank">input</a>,
 or <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio" target="_blank">radio button</a> and update the DOM based on the information.
  
+
+Contributors: <a href="https://github.com/suhascv" target="_blank">Suhas CV</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>

--- a/src/content/examples/en/05_Transformation/00_Translate/description.mdx
+++ b/src/content/examples/en/05_Transformation/00_Translate/description.mdx
@@ -18,3 +18,5 @@ other drawing settings, such as the fill color.
 
 Note that in this example, we draw the shapes (rectangle and
 circle) each time in a different coordinate system.
+
+Contributors: <a href="https://github.com/digitalcoleman" target="_blank">Christopher Coleman</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>

--- a/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
+++ b/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
@@ -18,3 +18,5 @@ The
 and
 <a href="https://p5js.org/reference/#/p5/pop">pop()</a>
 functions save and restore the coordinate system, respectively.
+
+Contributors: <a href="https://github.com/digitalcoleman" target="_blank">Christopher Coleman</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>

--- a/src/content/examples/en/05_Transformation/02_Scale/description.mdx
+++ b/src/content/examples/en/05_Transformation/02_Scale/description.mdx
@@ -17,3 +17,5 @@ functions save and restore the coordinate system, respectively.
 
 In this example, a square size 200 is drawn at the origin, with
 three different scaling factors.
+
+Contributors: <a href="https://github.com/digitalcoleman" target="_blank">Christopher Coleman</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
@@ -15,3 +15,5 @@ function linearly interpolates between two numbers.
 Move the mouse across the screen and the symbol will follow.
 Between drawing each frame of the animation, the ellipse moves part
 of the distance from its current position toward the cursor.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/khamiltonuk" target="_blank">Kristian Hamilton</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
@@ -11,3 +11,5 @@ converts the cursor's horizontal position from a range of 0-720 to 0-360.
 The resulting value become the circle's hue. Map also converts the cursor's
 vertical position from a range of 0-400 to 20-300. The resulting value
 becomes the circle's diameter.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/keshavg2" target="_blank">Keshav Gupta</a>, <a href="https://github.com/berkeozgen08" target="_blank">Berke Özgen</a>

--- a/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
@@ -10,3 +10,5 @@ function.
 
 When the user presses the mouse button, the position and color
 of the circle change randomly.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
@@ -9,3 +9,5 @@ keeps the circle within a rectangle. It does so by passing the
 mouse's coordinates into the
 <a href="https://p5js.org/reference/#/p5/constrain" target="_blank">constrain()</a>
 function.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>, <a href="https://github.com/AdilRabbani" target="_blank">adil rabbani</a>

--- a/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
@@ -13,3 +13,5 @@ functions. This example uses
 to calculate the angle of the hands. It then uses
 <a href="https://p5js.org/reference/#group-Transform" target="_blank">transformations</a>
 to set their position.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>, <a href="https://github.com/AdilRabbani" target="_blank">adil rabbani</a>

--- a/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
+++ b/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
@@ -16,3 +16,5 @@ function, demonstrated here, linearly interpolates between two colors.
 In this example, the stripeCount variable adjusts how many horizontal
 stripes appear. Setting the value to a higher number will look less
 like individual stripes and more like a gradient.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/Malayvasa" target="_blank">Malay Vasa</a>

--- a/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
+++ b/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
@@ -14,3 +14,5 @@ relative to the center of the canvas. The
 <a href="https://p5js.org/reference/#/p5/push" target="_blank">push()</a>
 and <a href="https://p5js.org/reference/#/p5/pop" target="_blank">pop()</a>
 functions make these transformations affect only the individual circle.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/Malayvasa" target="_blank">Malay Vasa</a>

--- a/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
+++ b/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
@@ -11,3 +11,5 @@ The first two parameters for the
 function specify the first point in the curve and the last two parameters 
 specify the last point. The middle parameters set the control points that 
 define the shape of the curve.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
+++ b/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
@@ -10,3 +10,5 @@ reflecting surfaces tilted to each other at an angle. Using the
 <a href="https://p5js.org/reference/#/p5/rotate" target="_blank">rotate()</a>,
 and <a href="https://p5js.org/reference/#/p5/scale" target="_blank">scale()</a> functions, you can replicate the resulting visual
 of a kaleidoscope in a canvas.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/riteshsp2000" target="_blank">Ritesh Patil</a>

--- a/src/content/examples/en/07_Repetition/04_Noise/description.mdx
+++ b/src/content/examples/en/07_Repetition/04_Noise/description.mdx
@@ -13,3 +13,5 @@ function in p5 produces Perlin noise.
 The dots in this example are sized based on noise values. The slider on the
 left sets the distance between dots. The slider on the right sets an offset
 in the noise calculation.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/07_Repetition/05_Recursive_Tree/description.mdx
+++ b/src/content/examples/en/07_Repetition/05_Recursive_Tree/description.mdx
@@ -8,3 +8,6 @@ This is an example of rendering a simple tree-like structure via recursion.
 The branching angle is calculated as a function of the horizontal mouse
 location. Move the mouse left and right to change the angle.
 Based on Daniel Shiffman's <a href="https://processing.org/examples/tree.html">Recursive Tree Example</a> for Processing.
+
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/ihsavru" target="_blank">Urvashi</a>

--- a/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
+++ b/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
@@ -5,8 +5,15 @@ oneLineDescription: Generate a poem with words randomly selected from a bank.
 ---
 
 Using the
-<a href="https://p5js.org/reference/#/p5/floor" target="_blank">floor()</a>
+
+<a href="https://p5js.org/reference/#/p5/floor" target="_blank">
+  floor()
+</a>
 and
-<a href="https://p5js.org/reference/#/p5/random" target="_blank">random()</a>
-functions, you can randomly select a series of items from an array
-and draw them at different sizes and positions on the canvas.
+<a href="https://p5js.org/reference/#/p5/random" target="_blank">
+  random()
+</a>
+functions, you can randomly select a series of items from an array and draw them
+at different sizes and positions on the canvas.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/Malayvasa" target="_blank">Malay Vasa</a>

--- a/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
@@ -6,6 +6,7 @@ featured: true
 ---
 
 This example demonstrates the
+
 <a href="https://en.wikipedia.org/wiki/Sine_and_cosine">sine and cosine</a>
 mathematical functions.
 
@@ -14,3 +15,5 @@ The animation shows uniform circular motion around the unit circle
 determines a point on the circle. The cosine and sine of the angle
 are defined to be the x and y coordinates, respectively, of that
 point.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/Malayvasa" target="_blank">Malay Vasa</a>

--- a/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
@@ -5,7 +5,12 @@ oneLineDescription: Rotate toward a point.
 ---
 
 The
-<a href="https://p5js.org/reference/#/p5/atan2" target="_blank">atan2()</a>
-function calculates the angle between two positions. The angle it
-calculates can be used to rotate a shape toward something. In this
-example, the eyes rotate to look at the cursor.
+
+<a href="https://p5js.org/reference/#/p5/atan2" target="_blank">
+  atan2()
+</a>
+function calculates the angle between two positions. The angle it calculates can
+be used to rotate a shape toward something. In this example, the eyes rotate to look
+at the cursor.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/limzykenneth" target="_blank">Kenneth Lim</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>, <a href="https://github.com/Malayvasa" target="_blank">Malay Vasa</a>

--- a/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
@@ -11,3 +11,5 @@ by specifying its vertices in TRIANGLE_STRIP mode, using the
 and
 <a href="https://p5js.org/reference/#/p5/vertex">vertex()</a>
 functions.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/10_Games/00_Circle_Clicker/description.mdx
+++ b/src/content/examples/en/10_Games/00_Circle_Clicker/description.mdx
@@ -8,3 +8,5 @@ This example demonstrates a game with a time limit and score. The browser's
 <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage" target="_blank">local storage</a>
 stores the high score so when the game is played again using the same browser,
 the high score remains. Clearing the browser data also clears the high score.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/10_Games/01_Ping_Pong/description.mdx
+++ b/src/content/examples/en/10_Games/01_Ping_Pong/description.mdx
@@ -12,3 +12,5 @@ white rectangle. The W and S keys move the paddle on the left up and down,
 and the up and down arrow keys move the paddle on the right up and down.
 Players score points by bouncing the ball, represented by a white square,
 past the edge of the opponent's side of the canvas.`
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/10_Games/02_Snake/description.mdx
+++ b/src/content/examples/en/10_Games/02_Snake/description.mdx
@@ -19,3 +19,5 @@ This example uses an array of
 <a href="https://p5js.org/reference/#/p5.Vector" target="_blank">vectors</a>
 to store the positions of each of the segments of the snake. The arrow
 keys control the snake's movement.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/prashantgupta24" target="_blank">Prashant Gupta</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/11_3D/00_Geometries/description.mdx
+++ b/src/content/examples/en/11_3D/00_Geometries/description.mdx
@@ -13,3 +13,5 @@ displays a custom geometry loaded via
 <a href="https://p5js.org/reference/#/p5/loadModel" target="_blank">loadModel()</a>.
 This example includes each of the primitive shapes. It also includes a model
 from <a href="https://nasa3d.arc.nasa.gov/models" target="_blank">NASA's collection</a>.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>, <a href="https://github.com/aceslowman" target="_blank">Austin Lee Slominski</a>, <a href="https://github.com/gabrielsroka" target="_blank">Gabriel Sroka</a>

--- a/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
+++ b/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
@@ -8,3 +8,5 @@ The
 <a href="https://p5js.org/reference/#/p5/buildGeometry" target="_blank">buildGeometry()</a>
 function stores shapes into a 3D model that can be efficiently used and
 reused.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/davepagurek" target="_blank">Dave Pagurek</a>

--- a/src/content/examples/en/11_3D/02_Materials/description.mdx
+++ b/src/content/examples/en/11_3D/02_Materials/description.mdx
@@ -30,3 +30,5 @@ Additionally,
 <a href="https://p5js.org/reference/#/p5/texture" target="_blank">texture()</a>
 wraps an object with an image. The model and image texture in this example are
 from <a href="https://nasa3d.arc.nasa.gov" target="_blank">NASA's collection</a>.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AidanNelson" target="_blank">Aidan Nelson</a>

--- a/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
+++ b/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
@@ -12,3 +12,5 @@ on a touch screen. To pan the camera, right click and drag a mouse
 or swipe with multiple fingers on a touch screen. To move the camera
 closer or further to the center of the sketch, use the scroll wheel
 on a mouse or pinch in/out on a touch screen.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/11_3D/04_Filter_Shader/description.mdx
+++ b/src/content/examples/en/11_3D/04_Filter_Shader/description.mdx
@@ -6,3 +6,5 @@ oneLineDescription: Manipulate imagery with a shader.
 
 Filter shaders are a way to apply an effect to anything that
 is on the canvas. In this example, the effect is applied to a video.
+
+Contributors: <a href="https://github.com/davepagurek" target="_blank">Dave Pagurek</a>

--- a/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/description.mdx
+++ b/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/description.mdx
@@ -6,3 +6,5 @@ oneLineDescription: Use a shader to adjust shape vertices.
 
 Shaders can adjust the positions of the vertices of shapes.
 This lets you distort and animate 3D models.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/davepagurek" target="_blank">Dave Pagurek</a>

--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/description.mdx
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/description.mdx
@@ -12,3 +12,5 @@ to apply a blur. On a real camera, objects appear blurred if they
 are closer or farther than the lens's focus. This simulates that
 effect. First, the sketch renders five spheres to the framebuffer.
 Then, it renders the framebuffer to the canvas using the blur shader.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/davepagurek" target="_blank">Dave Pagurek</a>

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
@@ -10,3 +10,5 @@ function can be used to create a new p5.Graphics object, which can serve as
 an off-screen graphics buffer within the canvas. Off-screen buffers can have
 different dimensions and properties than their current display surface, even
 though they appear to be existing in the same space.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/01_Multiple_Canvases/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/01_Multiple_Canvases/description.mdx
@@ -14,3 +14,5 @@ To use instance mode, a function must be defined with a parameter representing
 the p5 instance (labeled p in this example). All the p5 functions and variables
 that are typically global will belong to this parameter within this function's
 scope. Passing the function into the p5 constructor, runs it.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/02_Shader_As_A_Texture/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/02_Shader_As_A_Texture/description.mdx
@@ -8,3 +8,5 @@ Shaders can be applied to 2D/3D shapes as textures.
 
 To learn more about using shaders in p5.js:
 <a href="https://itp-xstory.github.io/p5js-shaders/">p5.js Shaders</a>
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>

--- a/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/description.mdx
@@ -9,3 +9,5 @@ to simulate the motion of falling snowflakes. This program defines a
 snowflake
 <a href="https://p5js.org/reference/#/p5/class">class</a>
 and uses an array to hold the snowflake objects.
+
+Contributors: <a href="https://github.com/aatishb" target="_blank">Aatish Bhatia</a>, <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>

--- a/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
@@ -9,3 +9,5 @@ Using a
 you can create a collection of circles that move within the canvas in 
 response to the tilt of a mobile device. You must open this page on a mobile 
 device to display the sketch.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/katlich112358" target="_blank">Kathryn Lichlyter</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>

--- a/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
@@ -14,3 +14,5 @@ connecting each of the particles. When the user clicks the mouse, the
 sketch creates a new instance of the Path class. When the user drags
 the mouse, the sketch adds a new instance of the Particle class to
 the current path.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/JithinKS97" target="_blank">Jithin KS</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>

--- a/src/content/examples/en/13_Classes_And_Objects/03_Flocking/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/03_Flocking/description.mdx
@@ -10,3 +10,5 @@ Full discussion of the implementation can be found in the
 book by Daniel Shiffman. The simulation is based on the research of
 <a href="http://www.red3d.com/cwr/">Craig Reynolds</a>, who
 used the term 'boid' to represent a bird-like object.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/keshavg2" target="_blank">Keshav Gupta</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>

--- a/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
@@ -19,3 +19,5 @@ Tabular Data examples for Processing written in Java. It uses a
 to organize data for a bubble. The visitor can add new bubbles, and their data 
 will be saved in local storage. If the visitor revisits the sketch, it will
 reload the same bubbles.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/hydrosquall" target="_blank">Cameron Yick</a>

--- a/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
@@ -13,3 +13,5 @@ written in Java. It uses a
 to organize data for a bubble. When the sketch starts, it
 loads the data for two bubbles from a JSON file. The visitor can add
 new bubbles, download an updated JSON file, and load in a JSON file.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/hydrosquall" target="_blank">Cameron Yick</a>

--- a/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
@@ -13,3 +13,6 @@ example for Processing. It uses a class to organize data representing
 a bubble. When the sketch starts, it loads the data for four bubbles
 from a CSV file. The visitor can add new bubbles, download an updated
 CSV file, and load in a CSV file.
+
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/sm7515" target="_blank">sm7515</a>

--- a/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
@@ -16,3 +16,5 @@ and the vector methods
 and
 <a href="https://p5js.org/reference/#/p5.Vector/dot">dot()</a>
 for the vector calculations.
+
+Contributors: <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/AnimeshSinha1309" target="_blank">Animesh Sinha</a>, <a href="https://github.com/davidblitz" target="_blank">davidblitz</a>

--- a/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
@@ -10,3 +10,5 @@ with curves using
 <a href="https://p5js.org/reference/#/p5/curveVertex">curveVertex()</a>
 and
 <a href="https://p5js.org/reference/#/p5/curveTightness">curveTightness()</a>.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/keshavg2" target="_blank">Keshav Gupta</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>

--- a/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
@@ -14,3 +14,5 @@ The force calculations are performed using the
 class, including the
 <a href="https://p5js.org/reference/#/p5/createVector">createVector()</a>
 function to create vectors.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/keshavg2" target="_blank">Keshav Gupta</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>

--- a/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
@@ -21,3 +21,5 @@ positions and velocities are performed with p5.Vector methods.
 The particle system is implemented as a
 <a href="https://p5js.org/reference/#/p5/class">class</a>, which contains an array of
 objects (of class Particle).
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/keshavg2" target="_blank">Keshav Gupta</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>

--- a/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/description.mdx
@@ -20,3 +20,5 @@ to the next generation.</li>
 These rules generate complex interactions. Click the canvas to start
 the simulation with randomized cells. Clicking the canvas again will
 restart it.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/keshavg2" target="_blank">Keshav Gupta</a>, <a href="https://github.com/lmccart" target="_blank">Lauren McCarthy</a>, <a href="https://github.com/crh82" target="_blank">crh82</a>

--- a/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/description.mdx
@@ -7,3 +7,5 @@ oneLineDescription: Visualize a mathematical set that produces fractal structure
 Colorful rendering of the Mandelbrot set
 based on Daniel Shiffman's
 <a href="https://processing.org/examples/mandelbrot.html">Mandelbrot Example</a> for Processing.
+
+Contributors: <a href="https://github.com/calebfoss" target="_blank">Caleb Foss</a>, <a href="https://github.com/dkessner" target="_blank">Darren Kessner</a>, <a href="https://github.com/ihsavru" target="_blank">Urvashi</a>


### PR DESCRIPTION
I used the Github API to pull the blame for each example with Github username data. I then mapped that data to links and added them to the descriptions for each example. Finally, I made some manual tweaks based on contributors that were missing from the blame, such as @Malayvasa who contributed examples via p5 editor links.