### PR TITLE
Update h4 styles

### DIFF
--- a/src/components/EducationResource/index.astro
+++ b/src/components/EducationResource/index.astro
@@ -22,7 +22,7 @@ const authorHTML = (await Astro.slots.render("author")).replace(/\<p[^\>]*\>/gm,
   </div>
   <div class="rendered-markdown">
     <div class="text-sm">
-      <h4 set:html={authorHTML} />
+      <div set:html={authorHTML} />
       <slot name="description" />
     </div>
     <div class="text-sm leading-8 [&_a]:whitespace-nowrap [&_a]:rounded-full [&_a]:mr-1 [&_a]:py-1 [&_a]:px-2 [&_a]:outline [&_a]:outline-1 [&_a]:outline-[var(--type-magenta-dark)]">

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -142,7 +142,7 @@ const seenParams: Record<string, true> = {};
                     seenParams[param.name] = true;
                     return (
                       <div class="grid grid-cols-6 gap-gutter-md text-body">
-                        <h4 class="col-span-1">{param.name}</h4>
+                        <span class="col-span-1">{param.name}</span>
                         <div
                           class="col-span-5 [&_p]:m-0 [&_p]:inline [&_a]:underline"
                         >

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -114,6 +114,21 @@ h3 {
   }
 }
 
+.text-h4,
+h4 {
+  font-size: 1.25rem;
+  line-height: 1.167;
+  -webkit-text-stroke-width: 0.1px;
+  font-family: var(--font-sans);
+  margin-top: var(--spacing-md);
+
+  @media (min-width: $breakpoint-tablet) {
+    font-size: 1.5rem;
+    line-height: 1.1333;
+    -webkit-text-stroke-width: 0.15px;
+  } 
+}
+
 .text-body-large {
   font-size: 1.25rem;
   line-height: 1.2;


### PR DESCRIPTION
<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td>
<img width="842" alt="image" src="https://github.com/processing/p5.js-website/assets/5315059/c30ca035-9103-43c2-97a5-bafbc65b9a5a">
</td>
<td>
<img width="864" alt="image" src="https://github.com/processing/p5.js-website/assets/5315059/5de667e2-84b5-4f09-ad65-bee655d58cff">
</td>
</tr>
</table>

Other spots that used h4 have been updated to look the same as before (and it seems to be just these two cases according to this search https://github.com/search?q=repo%3Aprocessing%2Fp5.js-website%20h4&type=code):
- The param name in the list of parameters in a reference page:

  <img width="908" alt="image" src="https://github.com/processing/p5.js-website/assets/5315059/2ee1fddc-d344-4073-a327-6417874fc685">
- The author on education resources entries:
  <img width="980" alt="image" src="https://github.com/processing/p5.js-website/assets/5315059/da7ae89a-d444-478c-ad87-86235888601e">

