### PR TITLE
Fixed inline code rendering issue in `curveVertex`

### DIFF
--- a/src/content/reference/en/p5/curveVertex.mdx
+++ b/src/content/reference/en/p5/curveVertex.mdx
@@ -31,17 +31,28 @@ description: >
 
   <a href="/reference/p5/endShape">endShape()</a> in order to draw a curve:</p>
 
-  <p>
-  <code>beginShape();</code><br>
-  <code>// Add the first control point.</code><br>
-  <code>curveVertex(84, 91);</code><br>
-  <code>// Add the anchor points to draw between.</code><br>
-  <code>curveVertex(68, 19);</code><br>
-  <code>curveVertex(21, 17);</code><br>
-  <code>// Add the second control point.</code><br>
-  <code>curveVertex(32, 91);</code><br>
-  <code>endShape();</code><br>
-  </p>
+  <pre><code>beginShape();
+
+
+  // Add the first control point.
+
+  curveVertex(84, 91);
+
+
+  // Add the anchor points to draw between.
+
+  curveVertex(68, 19);
+
+  curveVertex(21, 17);
+
+  
+  // Add the second control point.
+
+  curveVertex(32, 91);
+
+
+  endShape();
+  </code></pre>
 
   <p>The code snippet above would only draw the curve between the anchor points,
 
@@ -52,20 +63,35 @@ description: >
 
   <code>curveVertex()</code> with the coordinates of the control points:</p>
 
-  <p>
-  <code>beginShape();</code><br>
-  <code>// Add the first control point and draw a segment to it.</code><br>
-  <code>curveVertex(84, 91);</code><br>
-  <code>curveVertex(84, 91);</code><br>
-  <code>// Add the anchor points to draw between.</code><br>
-  <code>curveVertex(68, 19);</code><br>
-  <code>curveVertex(21, 17);</code><br>
-  <code>// Add the second control point.</code><br>
-  <code>curveVertex(32, 91);</code><br>
-  <code>// Uncomment the next line to draw the segment to the second control point.</code><br>
-  <code>// curveVertex(32, 91);</code><br>
-  <code>endShape();</code><br>
-  </p>
+  <pre><code>beginShape();
+
+
+  // Add the first control point and draw a segment to it.
+
+  curveVertex(84, 91);
+
+  curveVertex(84, 91);
+
+
+  // Add the anchor points to draw between.
+
+  curveVertex(68, 19);
+
+  curveVertex(21, 17);
+
+
+  // Add the second control point.
+  
+  curveVertex(32, 91);
+
+
+  // Uncomment the next line to draw the segment to the second control point.
+
+  // curveVertex(32, 91);
+
+
+  endShape();
+  </code></pre>
 
   <p>The first two parameters, <code>x</code> and <code>y</code>, set the
   vertex’s location. For

--- a/src/content/reference/en/p5/curveVertex.mdx
+++ b/src/content/reference/en/p5/curveVertex.mdx
@@ -31,28 +31,17 @@ description: >
 
   <a href="/reference/p5/endShape">endShape()</a> in order to draw a curve:</p>
 
-  <code>
-
-  beginShape();
-
-
-  <p>// Add the first control point.
-
-  curveVertex(84, 91);</p>
-
-  <p>// Add the anchor points to draw between.
-
-  curveVertex(68, 19);
-
-  curveVertex(21, 17);</p>
-
-  <p>// Add the second control point.
-
-  curveVertex(32, 91);</p>
-
-  <p>endShape();
-
-  </p></code>
+  <p>
+  <code>beginShape();</code><br>
+  <code>// Add the first control point.</code><br>
+  <code>curveVertex(84, 91);</code><br>
+  <code>// Add the anchor points to draw between.</code><br>
+  <code>curveVertex(68, 19);</code><br>
+  <code>curveVertex(21, 17);</code><br>
+  <code>// Add the second control point.</code><br>
+  <code>curveVertex(32, 91);</code><br>
+  <code>endShape();</code><br>
+  </p>
 
   <p>The code snippet above would only draw the curve between the anchor points,
 
@@ -63,34 +52,20 @@ description: >
 
   <code>curveVertex()</code> with the coordinates of the control points:</p>
 
-  <code>
-
-  beginShape();
-
-
-  <p>// Add the first control point and draw a segment to it.
-
-  curveVertex(84, 91);
-
-  curveVertex(84, 91);</p>
-
-  <p>// Add the anchor points to draw between.
-
-  curveVertex(68, 19);
-
-  curveVertex(21, 17);</p>
-
-  <p>// Add the second control point.
-
-  curveVertex(32, 91);</p>
-
-  <p>// Uncomment the next line to draw the segment to the second control point.
-
-  // curveVertex(32, 91);</p>
-
-  <p>endShape();
-
-  </p></code>
+  <p>
+  <code>beginShape();</code><br>
+  <code>// Add the first control point and draw a segment to it.</code><br>
+  <code>curveVertex(84, 91);</code><br>
+  <code>curveVertex(84, 91);</code><br>
+  <code>// Add the anchor points to draw between.</code><br>
+  <code>curveVertex(68, 19);</code><br>
+  <code>curveVertex(21, 17);</code><br>
+  <code>// Add the second control point.</code><br>
+  <code>curveVertex(32, 91);</code><br>
+  <code>// Uncomment the next line to draw the segment to the second control point.</code><br>
+  <code>// curveVertex(32, 91);</code><br>
+  <code>endShape();</code><br>
+  </p>
 
   <p>The first two parameters, <code>x</code> and <code>y</code>, set the
   vertex’s location. For
@@ -399,3 +374,4 @@ chainable: true
 
 
 # curveVertex
+

--- a/src/content/reference/en/p5/normal.mdx
+++ b/src/content/reference/en/p5/normal.mdx
@@ -56,40 +56,37 @@ description: >
 
   again:</p>
 
-  <code>
+  <pre><code>beginShape();
 
-  beginShape();
+  // Set the vertex normal.
 
+  normal(-0.4, -0.4, 0.8);
 
-  <p>// Set the vertex normal.
+  // Add a vertex.
 
-  normal(-0.4, -0.4, 0.8);</p>
+  vertex(-30, -30, 0);
 
-  <p>// Add a vertex.
+  // Set the vertex normal.
 
-  vertex(-30, -30, 0);</p>
+  normal(0, 0, 1);
 
-  <p>// Set the vertex normal.
-
-  normal(0, 0, 1);</p>
-
-  <p>// Add vertices.
+  // Add vertices.
 
   vertex(30, -30, 0);
 
-  vertex(30, 30, 0);</p>
+  vertex(30, 30, 0);
 
-  <p>// Set the vertex normal.
+  // Set the vertex normal.
 
-  normal(0.4, -0.4, 0.8);</p>
+  normal(0.4, -0.4, 0.8);
 
-  <p>// Add a vertex.
+  // Add a vertex.
 
-  vertex(-30, 30, 0);</p>
+  vertex(-30, 30, 0);
 
-  <p>endShape();
+  endShape();
+  </code></pre>
 
-  </p></code>
 line: 2066
 isConstructor: false
 itemtype: method


### PR DESCRIPTION
Hello, this is my first PR here!

I noticed some inline code issues that might have popped up because of some porting issues from the old website. This is what it looked like:
![image](https://github.com/user-attachments/assets/00db01fb-14a6-46a1-a1af-f701ac3f2cff)

Here's what it looks like now:
![image](https://github.com/user-attachments/assets/ac176fa8-6898-486b-a14a-5e19fcd05689)

These were some special cases in the reference where it wasn't a code snippet but a multiline inline codes.
