### PR TITLE
Correct some Korean translations

### DIFF
--- a/src/content/reference/ko/p5/arc.mdx
+++ b/src/content/reference/ko/p5/arc.mdx
@@ -1,5 +1,5 @@
 ---
-title: 호(아치형 선)
+title: arc
 module: 도형
 submodule: 2D 기본
 file: src/core/shape/2d_primitives.js

--- a/src/content/reference/ko/p5/circle.mdx
+++ b/src/content/reference/ko/p5/circle.mdx
@@ -1,12 +1,12 @@
 ---
-title: 원
+title: circle
 module: 도형
 submodule: 2D 기본
 file: src/core/shape/2d_primitives.js
 description: "\n<p>원을 그립니다.</p>\n\n\n<p>원은<code>x</code>, <code>y</code>로 정의되는 둥근 모양입니다,\n그리고<code>d</code>는 원의 지름입니다. \n\n\n매개변수. <code>x</code> 와 <code>y</code>는 중심위치를 설정합니다.\n<code>d</code> \n\n\n가 폭과 높이(지름)을 설정합니다. 원의 가장자리에 있는 모든 점은\n\n\n중심에서 동일한 거리입니다, <code>d</code>, 참조하세요.\n\n\n<a href=\"/reference/p5/ellipseMode\">ellipseMode()</a>ellipseMode설정 방법\n\n\n위치.</p>"
 line: '490'
 isConstructor: false
-itemtype: 매서드(method)
+itemtype: method
 example:
   - |-
 

--- a/src/content/reference/ko/p5/ellipse.mdx
+++ b/src/content/reference/ko/p5/ellipse.mdx
@@ -1,12 +1,12 @@
 ---
-title: 타원(ellipse)
+title: ellipse
 module: 도형
 submodule: 2D 기본
 file: src/core/shape/2d_primitives.js
 description: "\n<p>타원(Oval)을 그립니다.</p>\n\n\n<p>타원은 <code>x</code>, <code>y</code>로 정의되는 둥근 모양입니다,\n<code>w</code>, 그리고\n\n\n<code>h</code> 매개변수.\n<code>x</code> 와 <code>y</code> 가 위치를 설정합니다,\n그 중심에 <code>w</code> 와\n\n\n<code>h</code> 는 폭과 높이를 설정합니다. 참조하세요.\n\n<a href=\"/reference/p5/ellipseMode\">ellipseMode()</a> 타원모드(ellipseMode)의 위치 설정방법\n\n\n</p>\n\n\n<p>높이가 설정되지 않은 경우에 너비의 값은 너비와 높이의 값에 모두 사용됩니다. \n\n\n만약 음수 높이 또는 너비가 지정되면, 이에 대한 절대값을 사용합니다.\n\n</p>\n\n\n<p>다섯 번째 매개변수인, <code>detail</code>,도 선택사항이며, 개수를 결정합니다.\n\n\n꼭지점은 WebGL 모드에서 타원을 그리는 데 사용됩니다. 기본값은\n\n\n25입니다.</p>"
 line: '373'
 isConstructor: false
-itemtype: 매서드(method)
+itemtype: method
 example:
   - |-
 


### PR DESCRIPTION
I fixed some korean translation.

Some titles are wrong. They might be name of function and so shouldn't be translated. 
Also, `itemtype` in frontmatter shouldn't be translated. 