### PR TITLE
changes alt text color to black when both monochrome + dark mode enabled

### DIFF
--- a/styles/global.scss
+++ b/styles/global.scss
@@ -508,6 +508,10 @@ input[type="search"]::-webkit-search-results-decoration {
   display: -webkit-box; // Needs webkit box to support line-clamp
 }
 
+.dark-theme.monochrome-theme .renderable-alt{
+  color: var(--type-black); 
+}
+
 .skip-to-main {
   position: absolute;
   left: -1000px;


### PR DESCRIPTION
Resolves #468

changes alt text color to black when both monochrome + dark mode is enabled in global.scss under /**SPECIAL ELEMENTS**/