### PR TITLE
Changes button link hover text color to black when both monochrome + …

### DIFF
--- a/src/components/LinkButton/index.astro
+++ b/src/components/LinkButton/index.astro
@@ -20,7 +20,7 @@ switch (variant) {
 ---
 
 <a
-  class={"button-link outline outline-1 outline-type-color py-2 px-4 flex flex-nowrap w-fit items-center justify-between rounded-full hover:bg-sidebar-type-color hover:text-sidebar-bg-color hover:no-underline " +
+  class={"button-link outline outline-1 outline-type-color py-2 px-4 flex flex-nowrap w-fit items-center justify-between rounded-full hover:bg-sidebar-type-color hover:text-bg-color hover:no-underline " +
     Astro.props.class}
   href={url}
 >

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -210,7 +210,7 @@
   border: 1px solid var(--sidebar-type-color);
   &:hover {
     background-color: var(--sidebar-type-color);
-    color: var(--sidebar-bg-color);
+    color: var(--bg-color);
     text-decoration: none;
   }
   font-size: 1.5rem;

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -31,7 +31,7 @@
     }
     color: var(--sidebar-type-color);
     &:hover {
-      color: var(--sidebar-bg-color);
+      color: var(--bg-color);
     }
   }
 


### PR DESCRIPTION
…dark mode are enabled.

Resolves #496

This PR updates the text color of the link button component's hover states to use the site background color to maintain readability across monochrome mode, dark mode, and cases when monochrome and dark mode are active.