### PR TITLE
Added top margin for h2 tag

### DIFF
--- a/styles/global.scss
+++ b/styles/global.scss
@@ -229,8 +229,8 @@ section,
 
   h2,
   .text-h2 {
-    margin-top: 0px;
-    margin-bottom: var(--gutter-md);
+    margin-top: var(--gutter-md);
+    margin-bottom: 0px;
   }
 
   h2,


### PR DESCRIPTION
**Added a top margin to the h2 tag in global.scss, which also fixed the other page's headings that still had issues.**

### **Before**

![before](https://github.com/user-attachments/assets/5880ba8a-fcc4-44b9-a9ac-198af3b1771c)

### **After**

![after](https://github.com/user-attachments/assets/f7dffdfb-7bf0-4d7b-b0d7-b5b9237f3820)
