### PR TITLE
Fixed broken links for string in Variables and Change  Tutorial page

### DIFF
--- a/src/content/tutorials/en/variables-and-change.mdx
+++ b/src/content/tutorials/en/variables-and-change.mdx
@@ -128,10 +128,10 @@ In the template above, you use [`mouseX`](/reference/p5/mouseX) and [`mouseY`](/
 
 In [Get Started,](/tutorials/get-started) you learned that strings are [data types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures) that are always surrounded by quotation marks (`""`). To use variables and strings together, we can use [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to help us! Template literals begin and end with backticks (`\`\``) instead of quotation marks (`""`). You can type any character in between the backticks to generate a string like in [this example](https://editor.p5js.org/Msqcoding/sketches/pfSJLvxOB). You can include a variable in the string using the `${}` placeholder, and by placing the name of the variable inside the curly brackets like in [this example](https://editor.p5js.org/Msqcoding/sketches/8sM-h5Hd9).
 
-Visit [string interpolation](https://www.geeksforgeeks.org/string-interpolation-in-javascript/) (example 2),  [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals), or the p5.js reference page for [string](/reference/p5/string) to learn more!
+Visit [string interpolation](https://www.geeksforgeeks.org/string-interpolation-in-javascript/) (example 2),  [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals), or the p5.js reference page for [string](/reference/p5/String) to learn more!
 
 <Callout title="Note">
-Variables with [numbers](/reference/p5/number) in them can be used as arguments where numbers are required. If a variable that stores a [string](/reference/p5/string) is used where a number should be, the console will show an error message like `“...was expecting Number for the first parameter, received string instead.”` Visit the Error Messages section in the [Field Guide to Debugging](/tutorials/field-guide-to-debugging) for some common errors and how to fix them!
+Variables with [numbers](/reference/p5/number) in them can be used as arguments where numbers are required. If a variable that stores a [string](/reference/p5/String) is used where a number should be, the console will show an error message like `“...was expecting Number for the first parameter, received string instead.”` Visit the Error Messages section in the [Field Guide to Debugging](/tutorials/field-guide-to-debugging) for some common errors and how to fix them!
 </Callout>
 
 
@@ -276,7 +276,7 @@ In the code above, the cloud is drawn using [`ellipse()`](/reference/p5/ellipse)
 
 ##### Custom Variables
 
-Custom variables store values, like [numbers](/reference/p5/number) or [strings](/reference/p5/string), that can change later. Since custom variables store values that can change, we can use them to change the x- or y-coordinates and size of shapes on the canvas. When the x- or y-coordinate of a shape changes, it appears to be moving. In this step:
+Custom variables store values, like [numbers](/reference/p5/number) or [strings](/reference/p5/String), that can change later. Since custom variables store values that can change, we can use them to change the x- or y-coordinates and size of shapes on the canvas. When the x- or y-coordinate of a shape changes, it appears to be moving. In this step:
 
 - you placed a white cloud on the canvas using [`ellipse()`](/reference/p5/ellipse) with the number 50 as an x-coordinate;
 - you *declared* a custom variable named `cloudOneX` before [`setup();`](/reference/p5/setup)
@@ -297,7 +297,7 @@ A *variable’s scope* describes where the variable can be used in a program. It
 
 Variables declared inside of other functions (like [`draw()`](/reference/p5/draw) and [`setup()`](/reference/p5/setup)) have *local scope* – which means they can only be used within the block or function where they are declared. Variables declared in [`setup()`](/reference/p5/setup) cannot be used in [`draw()`](/reference/p5/draw) or any other function, and variables defined in [`draw()`](/reference/p5/draw) cannot be used in [`setup()`](/reference/p5/setup). View [this example](https://editor.p5js.org/p5Master718/sketches/aa8bBwGHb) of global and local variable scope.
 
-Visit these p5.js reference pages to learn more about declaring, initializing, and using custom variables: [`let`](/reference/p5/let), [numbers](/reference/p5/number), & [strings](/reference/p5/string).
+Visit these p5.js reference pages to learn more about declaring, initializing, and using custom variables: [`let`](/reference/p5/let), [numbers](/reference/p5/number), & [strings](/reference/p5/String).
 
 
 ##### Using Variables for Animation


### PR DESCRIPTION
Resolves #505 

### **Before**


https://github.com/user-attachments/assets/aed72c95-0f4d-4885-9c57-2eb2832fb6a2


### **After**


https://github.com/user-attachments/assets/a74291e2-4ccc-4d23-865c-2d7b19a0985e



