### PR TITLE
Fix #509, fixed all broken links for this issue

### DIFF
--- a/src/content/contributor-docs/en/contributing_to_the_p5js_reference.mdx
+++ b/src/content/contributor-docs/en/contributing_to_the_p5js_reference.mdx
@@ -305,7 +305,7 @@ Finally, for every example you add, you are required to use the p5.js function `
 * </div>
 ```
 
-For more on `describe()` visit the [web accessibility contributor documentation](https://p5js.org/contributor-docs/#/web_accessibility?id=user-generated-accessible-canvas-descriptions).
+For more on `describe()` visit the [web accessibility contributor documentation](https://p5js.org/contribute/web_accessibility/).
 
 With all the above you should have most of the tools needed to write and edit p5.js reference comments. However, there are a few more specialized usage of JSDoc style reference comments that you may come across in p5.js. These are situationally useful and not something that you need often.
 
@@ -402,4 +402,4 @@ This will launch a live preview of the rendered reference that will update each 
 
 For additional details about the reference system, you can checkout the documentation for [JSDoc](https://jsdoc.app/) and [YUIDoc](https://yui.github.io/yuidoc/).
 
-For examples of issues related to the reference, have a look at [#6519](https://github.com/processing/p5.js/issues/6519) and [#6045](https://github.com/processing/p5.js/issues/6045). The [contributor guidelines](https://github.com/processing/p5.js/blob/main/contributor_docs/contributor_guidelines/) document is also a good place to start.
+For examples of issues related to the reference, have a look at [#6519](https://github.com/processing/p5.js/issues/6519) and [#6045](https://github.com/processing/p5.js/issues/6045). The [contributor guidelines](https://p5js.org/contribute/contributor_guidelines/) document is also a good place to start.


### PR DESCRIPTION
Fixed the web accessibility contribution documentation link and contributor guidelines link in [Contributing to the p5.js Reference](https://p5js.org/contribute/contributing_to_the_p5js_reference/).

### **Before**


https://github.com/user-attachments/assets/2c3a5432-0dd0-4e83-a831-61589a0c7551


### **After**


https://github.com/user-attachments/assets/c4362ed1-ffa4-4b4a-9ca3-650a7ee2298c

