### PR TITLE
Fix tables and lists in reference items

### DIFF
--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -90,7 +90,7 @@ const seenParams: Record<string, true> = {};
     <div class="col-span-9 xl:min-w-[1000px]">
       <div
         set:html={description}
-        class="[&_a]:text-type-magenta-dark [&_a]:!decoration-type-magenta-dark mb-xl reference-item"
+        class="[&_a]:text-type-magenta-dark [&_a]:!decoration-type-magenta-dark mb-xl reference-item rendered-markdown"
       />
       {
         examples && (

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -204,6 +204,7 @@ a {
 code {
   @extend .text-body-mono;
   font-size: inherit;
+  white-space: nowrap;
   background-color: var(--bg-gray-80);
   border-radius: 20px;
   padding: 0 var(--spacing-xxs);

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -75,6 +75,9 @@
   table {
     margin: var(--spacing-md) 0;
   }
+  td, th {
+    vertical-align: top;
+  }
 
   hr + h2,
   hr + h3,


### PR DESCRIPTION
I was looking into making a custom build of the site to show shader hooks docs on for people testing out the feature before it's merged and deployed.

I noticed a few little styling issues in reference pages:
- Lists don't have numbers or bullets
- Table cells aren't aligned to the top
![image](https://github.com/user-attachments/assets/c624dcf0-1ee8-49ea-a71e-951ed53f3dda)

This addresses those issues:
![image](https://github.com/user-attachments/assets/fcee787d-6ad0-4713-a991-777a05c243f8)
