### PR TITLE
Changing styling to highlight hover more clearly.

### DIFF
--- a/src/components/Dropdown/styles.module.scss
+++ b/src/components/Dropdown/styles.module.scss
@@ -14,6 +14,7 @@
   border: 1px solid var(--accent-type-color);
   background-color: var(--accent-color);
   color: var(--accent-type-color);
+  overflow: hidden;
 }
 
 .selected {
@@ -93,10 +94,16 @@
   }
 }
 
-li[aria-selected="false"]:hover .icon {
-  svg {
-    background: var(--accent-type-color);
-    border-radius: 2rem;
+.options {
+  li:hover {
+    background-color: var(--accent-type-color);
+    color: var(--accent-color);
+  }
+
+  li:first-child:hover~button,
+  li:first-child:hover~div {
+    background-color: var(--accent-type-color);
+    color: var(--accent-color);
   }
 }
 


### PR DESCRIPTION
**Home Page**: Dropdown Language Menu and Accessibility Menu
**Suggestion** for Improving the UI
**Description:** 
The active state and hover state for the radio buttons are the same. If one hovers on one of the options, one can't know if it is active or not. This is a suggestion on how this could be changed and make the UI more clear.

See screenshots below:

<img width="530" alt="Screenshot 2024-09-07 at 7 15 17 PM" src="https://github.com/user-attachments/assets/09cba7bb-c434-45f8-9f7c-3358e488f1ba">
<img width="478" alt="Screenshot 2024-09-07 at 7 15 51 PM" src="https://github.com/user-attachments/assets/c09583cc-ea3e-42fb-9da6-c7c28c75b0d1">
