### PR TITLE
Add alt text to example page thumbnails

### DIFF
--- a/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/01_Shapes_And_Color-00_Shape_Primitives-thumbnail.png"
-featuredImageAlt: A few basic shapes drawn in white and black over a grey background
+featuredImageAlt: A few basic shapes drawn in white and black over a grey background.
 title: Shape Primitives
 oneLineDescription: Draw 2D shapes.
 relatedReference:

--- a/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/01_Shapes_And_Color-01_Color-thumbnail.png"
-featuredImageAlt: A few basic shapes drawn in different colors over a blue background
+featuredImageAlt: A few basic shapes drawn in different colors over a blue background.
 title: Color
 oneLineDescription: Add color to your sketch.
 ---

--- a/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/02_Animation_And_Variables-00_Drawing_Lines-thumbnail.png"
+featuredImageAlt: A squiggly rainbow line on a black background
 title: Drawing Lines
 oneLineDescription: Draw with the mouse.
 ---

--- a/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/02_Animation_And_Variables-00_Drawing_Lines-thumbnail.png"
-featuredImageAlt: A squiggly rainbow line on a black background
+featuredImageAlt: A squiggly rainbow line on a black background.
 title: Drawing Lines
 oneLineDescription: Draw with the mouse.
 ---

--- a/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/02_Animation_And_Variables-01_Animation_With_Events-thumbnail.png"
-featuredImageAlt: A small green circle on a black background
+featuredImageAlt: A small green circle on a black background.
 title: Animation with Events
 oneLineDescription: Pause and resume animation.
 ---

--- a/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/02_Animation_And_Variables-01_Animation_With_Events-thumbnail.png"
+featuredImageAlt: A small green circle on a black background
 title: Animation with Events
 oneLineDescription: Pause and resume animation.
 ---

--- a/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/02_Animation_And_Variables-02_Mobile_Device_Movement-thumbnail.jpg"
-featuredImageAlt: White circles on a black background, with varying degrees of transparency
+featuredImageAlt: White circles on a black background, with varying degrees of transparency.
 title: Mobile Device Movement
 oneLineDescription: Animate based on device motion.
 featured: true

--- a/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/02_Animation_And_Variables-02_Mobile_Device_Movement-thumbnail.jpg"
+featuredImageAlt: White circles on a black background, with varying degrees of transparency
 title: Mobile Device Movement
 oneLineDescription: Animate based on device motion.
 featured: true

--- a/src/content/examples/en/02_Animation_And_Variables/03_Conditions/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/03_Conditions/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/02_Animation_And_Variables-03_Conditions-thumbnail.png"
+featuredImageAlt: A small black circle on a rainbow, lattice-shaped path, on top of a grey and white striped background.
 title: Conditions
 oneLineDescription: Use if and else statements to make decisions while your sketch runs.
 ---

--- a/src/content/examples/en/03_Imported_Media/00_Words/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/00_Words/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-00_Words-thumbnail.png"
+featuredImageAlt: Three columns of the words “ichi,” “ni,” “san,” and “shi” on a white background. The first column is right aligned, the middle column is center aligned, and the left column is left aligned.
 title: Words
 oneLineDescription: Load fonts and draw text.
 ---

--- a/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-01_Copy_Image_Data-thumbnail.png"
+featuredImageAlt: Black-and-white photograph of a parrot. A curvy line is drawn across the image; within the confines of that line, color is added to the photograph.
 title: Copy Image Data
 oneLineDescription: Paint from an image file onto the canvas.
 ---

--- a/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-02_Alpha_Mask-thumbnail.png"
+featuredImageAlt: Two leaf sprigs side by side on a white background. The right sprig is labeled "Mask." The left sprig is labeled "Masked Image," and uses the shape of the right sprig to mask a photograph of tulips.
 title: Alpha Mask
 oneLineDescription: Use one image to cut out a section of another image.
 ---

--- a/src/content/examples/en/03_Imported_Media/03_Image_Transparency/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/03_Image_Transparency/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-03_Image_Transparency-thumbnail.png"
+featuredImageAlt: An astronaut on a planet as the background with a slightly transparent version of this image overlaid and to the left.
 title: Image Transparency
 oneLineDescription: Make an image translucent on the canvas.
 ---

--- a/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-04_Create_Audio-thumbnail.jpg"
+featuredImageAlt: A close up of an audio player timestamp, reading "0:00 / 2"
 title: Audio Player
 oneLineDescription: Create a player for an audio file.
 ---

--- a/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-04_Create_Audio-thumbnail.jpg"
-featuredImageAlt: A close up of an audio player timestamp, reading "0:00 / 2"
+featuredImageAlt: A close up of an audio player timestamp, reading "0:00 / 2."
 title: Audio Player
 oneLineDescription: Create a player for an audio file.
 ---

--- a/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-05_Video-thumbnail.png"
-featuredImageAlt: A screenshot of a video of a hand, with the pointer finger touching a desk
+featuredImageAlt: A screenshot of a video of a hand, with the pointer finger touching a desk.
 title: Video Player
 oneLineDescription: Create a player for a video file.
 ---

--- a/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-05_Video-thumbnail.png"
+featuredImageAlt: A screenshot of a video of a hand, with the pointer finger touching a desk
 title: Video Player
 oneLineDescription: Create a player for a video file.
 ---

--- a/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-06_Video_Canvas-thumbnail.png"
-featuredImageAlt: Two overlaid screenshots of a video of a hand, with the pointer finger touching a desk. Text to the top right of the screenshot reads "Click the canvas to start and pause the video feed"
+featuredImageAlt: Two overlaid screenshots of a video of a hand, with the pointer finger touching a desk. Text to the top right of the screenshot reads "Click the canvas to start and pause the video feed."
 title: Video on Canvas
 oneLineDescription: Display and stylize a video on the canvas.
 ---

--- a/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-06_Video_Canvas-thumbnail.png"
+featuredImageAlt: Two overlaid screenshots of a video of a hand, with the pointer finger touching a desk. Text to the top right of the screenshot reads "Click the canvas to start and pause the video feed"
 title: Video on Canvas
 oneLineDescription: Display and stylize a video on the canvas.
 ---

--- a/src/content/examples/en/03_Imported_Media/07_Video_Capture/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/07_Video_Capture/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/03_Imported_Media-07_Video_Capture-thumbnail.png"
+featuredImageAlt: An inverse, black and white photograph of trees.
 title: Video Capture
 oneLineDescription: Display a live video feed from a camera.
 ---

--- a/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/04_Input_Elements-00_Image_Drop-thumbnail.png"
+featuredImageAlt: A grey background with white text reading "Drag an image file onto the canvas"
 title: Image Drop
 oneLineDescription: Display an image that the page visitor dragged and dropped.
 ---

--- a/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/04_Input_Elements-00_Image_Drop-thumbnail.png"
-featuredImageAlt: A grey background with white text reading "Drag an image file onto the canvas"
+featuredImageAlt: A grey background with white text reading "Drag an image file onto the canvas."
 title: Image Drop
 oneLineDescription: Display an image that the page visitor dragged and dropped.
 ---

--- a/src/content/examples/en/04_Input_Elements/01_Input_Button/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/01_Input_Button/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/04_Input_Elements-01_Input_Button-thumbnail.png"
+featuredImageAlt: An input field with a submit button, labeled "Hello, p5!"
 title: Input and Button
 oneLineDescription: Use text input from the page visitor.
 ---

--- a/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/04_Input_Elements-02_DOM_Form_Elements-thumbnail.png"
+featuredImageAlt: A survey on a yellow background, consisting of an input field, radio buttons, and a dropdown
 title: Form Elements
 oneLineDescription: Create a form and respond to the results.
 ---

--- a/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/04_Input_Elements-02_DOM_Form_Elements-thumbnail.png"
-featuredImageAlt: A survey on a yellow background, consisting of an input field, radio buttons, and a dropdown
+featuredImageAlt: A survey on a yellow background, consisting of an input field, radio buttons, and a dropdown.
 title: Form Elements
 oneLineDescription: Create a form and respond to the results.
 ---

--- a/src/content/examples/en/05_Transformation/00_Translate/description.mdx
+++ b/src/content/examples/en/05_Transformation/00_Translate/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/05_Transformation-00_Translate-thumbnail.png"
+featuredImageAlt: Green and blue geometric shapes on a black background.
 title: Translate
 oneLineDescription: Move the coordinate system origin.
 ---

--- a/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
+++ b/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/05_Transformation-01_Rotate-thumbnail.png"
+featuredImageAlt: Line segments rotated around center of canvas
 title: Rotate
 oneLineDescription: Rotate the coordinate system.
 ---

--- a/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
+++ b/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/05_Transformation-01_Rotate-thumbnail.png"
-featuredImageAlt: Line segments rotated around center of canvas
+featuredImageAlt: Line segments rotated around center of canvas.
 title: Rotate
 oneLineDescription: Rotate the coordinate system.
 ---

--- a/src/content/examples/en/05_Transformation/02_Scale/description.mdx
+++ b/src/content/examples/en/05_Transformation/02_Scale/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/05_Transformation-02_Scale-thumbnail.png"
+featuredImageAlt: Solid rectangles stacked on top of one another
 title: Scale
 oneLineDescription: Modify the coordinate system scale.
 ---

--- a/src/content/examples/en/05_Transformation/02_Scale/description.mdx
+++ b/src/content/examples/en/05_Transformation/02_Scale/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/05_Transformation-02_Scale-thumbnail.png"
-featuredImageAlt: Solid rectangles stacked on top of one another
+featuredImageAlt: Solid rectangles stacked on top of one another.
 title: Scale
 oneLineDescription: Modify the coordinate system scale.
 ---

--- a/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-00_Interpolate-thumbnail.png"
-featuredImageAlt: A small white circle on a grey background
+featuredImageAlt: A small white circle on a grey background.
 title: Linear Interpolation
 oneLineDescription: Convert a number between 0 and 1 to another range.
 ---

--- a/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-00_Interpolate-thumbnail.png"
+featuredImageAlt: A small white circle on a grey background
 title: Linear Interpolation
 oneLineDescription: Convert a number between 0 and 1 to another range.
 ---

--- a/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-01_Map-thumbnail.png"
+featuredImageAlt: A large yellow circle on a black background
 title: Map
 oneLineDescription: Convert a number from one range to another range.
 ---

--- a/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-01_Map-thumbnail.png"
-featuredImageAlt: A large yellow circle on a black background
+featuredImageAlt: A large yellow circle on a black background.
 title: Map
 oneLineDescription: Convert a number from one range to another range.
 ---

--- a/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-02_Random-thumbnail.png"
+featuredImageAlt: A small purple circle on a black background
 title: Random
 oneLineDescription: Get random numbers.
 ---

--- a/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-02_Random-thumbnail.png"
-featuredImageAlt: A small purple circle on a black background
+featuredImageAlt: A small purple circle on a black background.
 title: Random
 oneLineDescription: Get random numbers.
 ---

--- a/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-03_Constrain-thumbnail.png"
-featuredImageAlt: A small white circle in a pink rectangle
+featuredImageAlt: A small white circle in a pink rectangle.
 title: Constrain
 oneLineDescription: Keep a number within a range.
 ---

--- a/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-03_Constrain-thumbnail.png"
+featuredImageAlt: A small white circle in a pink rectangle
 title: Constrain
 oneLineDescription: Keep a number within a range.
 ---

--- a/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-04_Clock-thumbnail.png"
+featuredImageAlt: A pink clock on a grey background
 title: Clock
 oneLineDescription: Get the current time.
 ---

--- a/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/06_Calculating_Values-04_Clock-thumbnail.png"
-featuredImageAlt: A pink clock on a grey background
+featuredImageAlt: A pink clock on a grey background.
 title: Clock
 oneLineDescription: Get the current time.
 ---

--- a/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
+++ b/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-00_Color_Interpolation-thumbnail.png"
+featuredImageAlt: Horizontal stripes fading between light green at the top and dark blue at the bottom
 title: Color Interpolation
 oneLineDescription: Fade between two colors.
 ---

--- a/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
+++ b/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-00_Color_Interpolation-thumbnail.png"
-featuredImageAlt: Horizontal stripes fading between light green at the top and dark blue at the bottom
+featuredImageAlt: Horizontal stripes fading between light green at the top and dark blue at the bottom.
 title: Color Interpolation
 oneLineDescription: Fade between two colors.
 ---

--- a/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
+++ b/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-01_Color_Wheel-thumbnail.png"
+featuredImageAlt: Small circles, each with a different color, arranged in a circular path, displaying hues across the color spectrum
 title: Color Wheel
 oneLineDescription: Create a visualization of the color spectrum.
 ---

--- a/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
+++ b/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-01_Color_Wheel-thumbnail.png"
-featuredImageAlt: Small circles, each with a different color, arranged in a circular path, displaying hues across the color spectrum
+featuredImageAlt: Small circles, each with a different color, arranged in a circular path, displaying hues across the color spectrum.
 title: Color Wheel
 oneLineDescription: Create a visualization of the color spectrum.
 ---

--- a/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
+++ b/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-02_Bezier-thumbnail.png"
+featuredImageAlt: Ten rainbow-colored lines in a bezier curve formation
 title: Bezier
 oneLineDescription: Draw a set of curves.
 ---

--- a/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
+++ b/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-02_Bezier-thumbnail.png"
-featuredImageAlt: Ten rainbow-colored lines in a bezier curve formation
+featuredImageAlt: Ten rainbow-colored lines in a bezier curve formation.
 title: Bezier
 oneLineDescription: Draw a set of curves.
 ---

--- a/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
+++ b/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-03_Kaleidoscope-thumbnail.png"
-featuredImageAlt: Dark grey canvas that reflects the lines drawn within it in symmetrical sections
+featuredImageAlt: Dark grey canvas that reflects the lines drawn within it in symmetrical sections.
 title: Kaleidoscope
 oneLineDescription: Draw mirrored designs with the mouse.
 ---

--- a/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
+++ b/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-03_Kaleidoscope-thumbnail.png"
+featuredImageAlt: Dark grey canvas that reflects the lines drawn within it in symmetrical sections
 title: Kaleidoscope
 oneLineDescription: Draw mirrored designs with the mouse.
 ---

--- a/src/content/examples/en/07_Repetition/04_Noise/description.mdx
+++ b/src/content/examples/en/07_Repetition/04_Noise/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-04_Noise-thumbnail.png"
+featuredImageAlt: Black and white abstract noise texture
 title: Noise
 oneLineDescription: Generate naturalistic textures using Perlin noise.
 ---

--- a/src/content/examples/en/07_Repetition/04_Noise/description.mdx
+++ b/src/content/examples/en/07_Repetition/04_Noise/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-04_Noise-thumbnail.png"
-featuredImageAlt: Black and white abstract noise texture
+featuredImageAlt: Black and white abstract noise texture.
 title: Noise
 oneLineDescription: Generate naturalistic textures using Perlin noise.
 ---

--- a/src/content/examples/en/07_Repetition/05_Recursive_Tree/description.mdx
+++ b/src/content/examples/en/07_Repetition/05_Recursive_Tree/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-05_Recursive_Tree-thumbnail.png"
+featuredImageAlt: A rainbow fractal tree on a black background
 title: Recursive Tree
 oneLineDescription: Draw a tree using a function that calls itself.
 ---

--- a/src/content/examples/en/07_Repetition/05_Recursive_Tree/description.mdx
+++ b/src/content/examples/en/07_Repetition/05_Recursive_Tree/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/07_Repetition-05_Recursive_Tree-thumbnail.png"
-featuredImageAlt: A rainbow fractal tree on a black background
+featuredImageAlt: A rainbow fractal tree on a black background.
 title: Recursive Tree
 oneLineDescription: Draw a tree using a function that calls itself.
 ---

--- a/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
+++ b/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/08_Listing_Data_with_Arrays-00_Random_Poetry-thumbnail.png"
-featuredImageAlt: A random series of words related to p5.js scattered on a maroon background
+featuredImageAlt: A random series of words related to p5.js scattered on a maroon background.
 title: Random Poetry
 oneLineDescription: Generate a poem with words randomly selected from a bank.
 ---

--- a/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
+++ b/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/08_Listing_Data_with_Arrays-00_Random_Poetry-thumbnail.png"
+featuredImageAlt: A random series of words related to p5.js scattered on a maroon background
 title: Random Poetry
 oneLineDescription: Generate a poem with words randomly selected from a bank.
 ---

--- a/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/09_Angles_And_Motion-00_Sine_Cosine-thumbnail.png"
+featuredImageAlt: A point on the unit circle, together with the corresponding sine and cosine values on their graphs.
 title: Sine and Cosine
 oneLineDescription: Animate circular, back and forth, and wave motion.
 featured: true

--- a/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/09_Angles_And_Motion-01_Aim-thumbnail.png"
+featuredImageAlt: Two eyes on a black background
 title: Aim
 oneLineDescription: Rotate toward a point.
 ---

--- a/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/09_Angles_And_Motion-01_Aim-thumbnail.png"
-featuredImageAlt: Two eyes on a black background
+featuredImageAlt: Two eyes on a black background.
 title: Aim
 oneLineDescription: Rotate toward a point.
 ---

--- a/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/09_Angles_And_Motion-02_Triangle_Strip-thumbnail.png"
+featuredImageAlt: Rainbow ring made up of triangles whose vertices lie on two concentric circles
 title: Triangle Strip
 oneLineDescription: Split a ring into triangles.
 ---

--- a/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/09_Angles_And_Motion-02_Triangle_Strip-thumbnail.png"
-featuredImageAlt: Rainbow ring made up of triangles whose vertices lie on two concentric circles
+featuredImageAlt: Rainbow ring made up of triangles whose vertices lie on two concentric circles.
 title: Triangle Strip
 oneLineDescription: Split a ring into triangles.
 ---

--- a/src/content/examples/en/10_Games/00_Circle_Clicker/description.mdx
+++ b/src/content/examples/en/10_Games/00_Circle_Clicker/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/10_Games-00_Circle_Clicker-thumbnail.png"
-featuredImageAlt: Large purple circle on a grey background
+featuredImageAlt: Large purple circle on a grey background.
 title: Circle Clicker
 oneLineDescription: Make a game about clicking a circle quickly and save the high score.
 ---

--- a/src/content/examples/en/10_Games/00_Circle_Clicker/description.mdx
+++ b/src/content/examples/en/10_Games/00_Circle_Clicker/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/10_Games-00_Circle_Clicker-thumbnail.png"
+featuredImageAlt: Large purple circle on a grey background
 title: Circle Clicker
 oneLineDescription: Make a game about clicking a circle quickly and save the high score.
 ---

--- a/src/content/examples/en/10_Games/01_Ping_Pong/description.mdx
+++ b/src/content/examples/en/10_Games/01_Ping_Pong/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/10_Games-01_Ping_Pong-thumbnail.png"
-featuredImageAlt: Two narrow white rectangles and a white square representing the paddles and ball in a game of ping pong
+featuredImageAlt: Two narrow white rectangles and a white square representing the paddles and ball in a game of ping pong.
 title: Ping Pong
 oneLineDescription: Make a game inspired by Atari's Pong.
 ---

--- a/src/content/examples/en/10_Games/01_Ping_Pong/description.mdx
+++ b/src/content/examples/en/10_Games/01_Ping_Pong/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/10_Games-01_Ping_Pong-thumbnail.png"
+featuredImageAlt: Two narrow white rectangles and a white square representing the paddles and ball in a game of ping pong
 title: Ping Pong
 oneLineDescription: Make a game inspired by Atari's Pong.
 ---

--- a/src/content/examples/en/10_Games/02_Snake/description.mdx
+++ b/src/content/examples/en/10_Games/02_Snake/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/10_Games-02_Snake-thumbnail.png"
+featuredImageAlt: A narrow green L shape and a red square representing the snake and fruit in the arcade game Snake
 title: Snake
 oneLineDescription: Make a game based on Snake arcade games.
 ---

--- a/src/content/examples/en/10_Games/02_Snake/description.mdx
+++ b/src/content/examples/en/10_Games/02_Snake/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/10_Games-02_Snake-thumbnail.png"
-featuredImageAlt: A narrow green L shape and a red square representing the snake and fruit in the arcade game Snake
+featuredImageAlt: A narrow green L shape and a red square representing the snake and fruit in the arcade game Snake.
 title: Snake
 oneLineDescription: Make a game based on Snake arcade games.
 ---

--- a/src/content/examples/en/11_3D/00_Geometries/description.mdx
+++ b/src/content/examples/en/11_3D/00_Geometries/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-00_Geometries-thumbnail.png"
+featuredImageAlt: Eight 3D shapes; a plane, box, cylinder, cone, torus, sphere, ellipsoid, and a model of an astronaut. The surface of the shapes are multicolored.
 title: Geometries
 oneLineDescription: Draw 3D shapes, including a custom model.
 ---

--- a/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
+++ b/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-01_Custom_Geometry-thumbnail.png"
-featuredImageAlt: A tiled plane of snake models
+featuredImageAlt: A tiled plane of snake models.
 title: Custom Geometry
 oneLineDescription: Generate a 3D shape programmatically.
 ---

--- a/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
+++ b/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-01_Custom_Geometry-thumbnail.png"
+featuredImageAlt: A tiled plane of snake models
 title: Custom Geometry
 oneLineDescription: Generate a 3D shape programmatically.
 ---

--- a/src/content/examples/en/11_3D/02_Materials/description.mdx
+++ b/src/content/examples/en/11_3D/02_Materials/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-02_Materials-thumbnail.png"
-featuredImageAlt: Astronaut 3D model on a black background
+featuredImageAlt: Astronaut 3D model on a black background.
 title: Materials
 oneLineDescription: Change 3D objects' color, texture, and how they respond to light.
 ---

--- a/src/content/examples/en/11_3D/02_Materials/description.mdx
+++ b/src/content/examples/en/11_3D/02_Materials/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-02_Materials-thumbnail.png"
+featuredImageAlt: Astronaut 3D model on a black background
 title: Materials
 oneLineDescription: Change 3D objects' color, texture, and how they respond to light.
 ---

--- a/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
+++ b/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-03_Orbit_Control-thumbnail.png"
-featuredImageAlt: A sphere of dark purple cubes on a light pink background
+featuredImageAlt: A sphere of dark purple cubes on a light pink background.
 title: Orbit Control
 oneLineDescription: Control the camera with the mouse.
 featured: true

--- a/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
+++ b/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-03_Orbit_Control-thumbnail.png"
+featuredImageAlt: A sphere of dark purple cubes on a light pink background
 title: Orbit Control
 oneLineDescription: Control the camera with the mouse.
 featured: true

--- a/src/content/examples/en/11_3D/04_Filter_Shader/description.mdx
+++ b/src/content/examples/en/11_3D/04_Filter_Shader/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-04_Filter_Shader-thumbnail.png"
+featuredImageAlt: A screenshot of a video of a city crosswalk, with offset colors
 title: Filter Shader
 oneLineDescription: Manipulate imagery with a shader.
 ---

--- a/src/content/examples/en/11_3D/04_Filter_Shader/description.mdx
+++ b/src/content/examples/en/11_3D/04_Filter_Shader/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-04_Filter_Shader-thumbnail.png"
-featuredImageAlt: A screenshot of a video of a city crosswalk, with offset colors
+featuredImageAlt: A screenshot of a video of a city crosswalk, with offset colors.
 title: Filter Shader
 oneLineDescription: Manipulate imagery with a shader.
 ---

--- a/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/description.mdx
+++ b/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-05_Adjusting_Positions_With_A_Shader-thumbnail.png"
+featuredImageAlt: A red-to-blue waving ribbon on a white background
 title: Adjusting Positions with a Shader
 oneLineDescription: Use a shader to adjust shape vertices.
 ---

--- a/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/description.mdx
+++ b/src/content/examples/en/11_3D/05_Adjusting_Positions_With_A_Shader/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-05_Adjusting_Positions_With_A_Shader-thumbnail.png"
-featuredImageAlt: A red-to-blue waving ribbon on a white background
+featuredImageAlt: A red-to-blue waving ribbon on a white background.
 title: Adjusting Positions with a Shader
 oneLineDescription: Use a shader to adjust shape vertices.
 ---

--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/description.mdx
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/11_3D-06_Framebuffer_Blur-thumbnail.png"
+featuredImageAlt: A row of five orange spheres. The closest and farthest spheres from the camera appear blurred.
 title: Framebuffer Blur
 oneLineDescription: Simulate a camera's depth of field.
 ---

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/12_Advanced_Canvas_Rendering-00_Create_Graphics-thumbnail.png"
-featuredImageAlt: Black canvas with a very dark grey rectangle in the middle. A white circle is at the edge of the rectangle
+featuredImageAlt: Black canvas with a very dark grey rectangle in the middle. A white circle is at the edge of the rectangle.
 title: Create Graphics
 oneLineDescription: Draw imagery off-screen.
 ---

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/12_Advanced_Canvas_Rendering-00_Create_Graphics-thumbnail.png"
+featuredImageAlt: Black canvas with a very dark grey rectangle in the middle. A white circle is at the edge of the rectangle
 title: Create Graphics
 oneLineDescription: Draw imagery off-screen.
 ---

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/01_Multiple_Canvases/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/01_Multiple_Canvases/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/12_Advanced_Canvas_Rendering-01_Multiple_Canvases-thumbnail.png"
+featuredImageAlt: Two curving lines made of repeating white circles and squares with black outlines, on a black and white background.
 title: Multiple Canvases
 oneLineDescription: Use Instance Mode to put multiple canvases on the page.
 ---

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/02_Shader_As_A_Texture/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/02_Shader_As_A_Texture/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/12_Advanced_Canvas_Rendering-02_Shader_As_A_Texture-thumbnail.png"
+featuredImageAlt: Two spheres broken up into a square grid with a gradient in each grid.
 title: Shader as a Texture
 oneLineDescription: Generate a texture for a 3D shape using a shader.
 ---

--- a/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/13_Classes_And_Objects-00_Snowflakes-thumbnail.png"
+featuredImageAlt: Snowflakes falling on a black background.
 title: Snowflakes
 oneLineDescription: Animate snowfall.
 ---

--- a/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/13_Classes_And_Objects-01_Shake_Ball_Bounce-thumbnail.png"
+featuredImageAlt: Twenty white circles on a black background
 title: Shake Ball Bounce
 oneLineDescription: Animate ball movement based on mobile device motion.
 ---

--- a/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/13_Classes_And_Objects-01_Shake_Ball_Bounce-thumbnail.png"
-featuredImageAlt: Twenty white circles on a black background
+featuredImageAlt: Twenty white circles on a black background.
 title: Shake Ball Bounce
 oneLineDescription: Animate ball movement based on mobile device motion.
 ---

--- a/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/13_Classes_And_Objects-02_Connected_Particles-thumbnail.png"
-featuredImageAlt: A pattern of multicolored circles outlined in white and connected by white lines, on a black background
+featuredImageAlt: A pattern of multicolored circles outlined in white and connected by white lines, on a black background.
 title: Connected Particles
 oneLineDescription: Draw circles and connecting lines using the mouse.
 ---

--- a/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/13_Classes_And_Objects-02_Connected_Particles-thumbnail.png"
-featuredImageAlt: A pattern of multicolored circles outlined in white and connected by white lines, on a black background.
+featuredImageAlt: A pattern of multicolored circles connected by white lines, on a black background.
 title: Connected Particles
 oneLineDescription: Draw circles and connecting lines using the mouse.
 ---

--- a/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/13_Classes_And_Objects-02_Connected_Particles-thumbnail.png"
+featuredImageAlt: A pattern of multicolored circles outlined in white and connected by white lines, on a black background
 title: Connected Particles
 oneLineDescription: Draw circles and connecting lines using the mouse.
 ---

--- a/src/content/examples/en/13_Classes_And_Objects/03_Flocking/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/03_Flocking/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/13_Classes_And_Objects-03_Flocking-thumbnail.png"
+featuredImageAlt: A group of bird-like objects, represented by rainbow triangles, modeling flocking behavior.
 title: Flocking
 oneLineDescription: Simulate bird flocking behavior.
 ---

--- a/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/14_Loading_And_Saving_Data-00_Local_Storage-thumbnail.png"
-featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles"
+featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles."
 title: Local Storage
 oneLineDescription: Save data from the browser on the device.
 ---

--- a/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/14_Loading_And_Saving_Data-00_Local_Storage-thumbnail.png"
+featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles"
 title: Local Storage
 oneLineDescription: Save data from the browser on the device.
 ---

--- a/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/14_Loading_And_Saving_Data-01_JSON-thumbnail.png"
+featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles"
 title: JSON
 oneLineDescription: Store data in JavaScript object notation.
 ---

--- a/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/14_Loading_And_Saving_Data-01_JSON-thumbnail.png"
-featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles"
+featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles."
 title: JSON
 oneLineDescription: Store data in JavaScript object notation.
 ---

--- a/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/14_Loading_And_Saving_Data-02_Table-thumbnail.png"
+featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles"
 title: Table
 oneLineDescription: Store data as comma-separated values.
 ---

--- a/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/14_Loading_And_Saving_Data-02_Table-thumbnail.png"
-featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles"
+featuredImageAlt: Black outlines of circles on a white background. Text below the circles reads "Click and drag to add bubbles."
 title: Table
 oneLineDescription: Store data as comma-separated values.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-00_Non_Orthogonal_Reflection-thumbnail.png"
+featuredImageAlt: A small green circle hovering over a yellow tilted plane at the bottom of the canvas
 title: Non-Orthogonal Reflection
 oneLineDescription: Simulate a ball bouncing on a slanted surface.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-00_Non_Orthogonal_Reflection-thumbnail.png"
-featuredImageAlt: A small green circle hovering over a yellow tilted plane at the bottom of the canvas
+featuredImageAlt: A small green circle hovering over a yellow tilted plane at the bottom of the canvas.
 title: Non-Orthogonal Reflection
 oneLineDescription: Simulate a ball bouncing on a slanted surface.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-01_Soft_Body-thumbnail.png"
-featuredImageAlt: A yellow pentagon on a black background
+featuredImageAlt: A yellow pentagon on a black background.
 title: Soft Body
 oneLineDescription: Simulate the physics of a soft body accelerating toward the mouse.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-01_Soft_Body-thumbnail.png"
+featuredImageAlt: A yellow pentagon on a black background
 title: Soft Body
 oneLineDescription: Simulate the physics of a soft body accelerating toward the mouse.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-02_Forces-thumbnail.png"
-featuredImageAlt: 9 multicolored circles at varying heights on a grey background
+featuredImageAlt: 9 multicolored circles at varying heights on a grey background.
 title: Forces
 oneLineDescription: Simulate forces on multiple bodies as they move through liquid.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-02_Forces-thumbnail.png"
+featuredImageAlt: 9 multicolored circles at varying heights on a grey background
 title: Forces
 oneLineDescription: Simulate forces on multiple bodies as they move through liquid.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-03_Smoke_Particle_System-thumbnail.png"
+featuredImageAlt: Rainbow colored smoke angled towards the right of the canvas, with a white arrow above the smoke pointing right.
 title: Smoke Particles
 oneLineDescription: Simulate smoke with a particle system.
 featured: true

--- a/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-04_Game_Of_Life-thumbnail.png"
+featuredImageAlt: Grid of squares made of black lines on a white background. Some squares are filled in with solid black
 title: Game of Life
 oneLineDescription: Recreate John Conway's cellular automaton.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/04_Game_Of_Life/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-04_Game_Of_Life-thumbnail.png"
-featuredImageAlt: Grid of squares made of black lines on a white background. Some squares are filled in with solid black
+featuredImageAlt: Grid of squares made of black lines on a white background. Some squares are filled in with solid black.
 title: Game of Life
 oneLineDescription: Recreate John Conway's cellular automaton.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/description.mdx
@@ -1,6 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-05_Mandelbrot-thumbnail.png"
-featuredImageAlt: Colorful rendering of the Mandelbrot set
+featuredImageAlt: Colorful rendering of the Mandelbrot set.
 title: Mandelbrot Set
 oneLineDescription: Visualize a mathematical set that produces fractal structures.
 ---

--- a/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/05_Mandelbrot/description.mdx
@@ -1,5 +1,6 @@
 ---
 featuredImage: "../../../images/featured/15_Math_And_Physics-05_Mandelbrot-thumbnail.png"
+featuredImageAlt: Colorful rendering of the Mandelbrot set
 title: Mandelbrot Set
 oneLineDescription: Visualize a mathematical set that produces fractal structures.
 ---


### PR DESCRIPTION
Resolves #380 

Added English alt text to all thumbnails on /examples, using existing canvas descriptions wherever possible. 

These still need to be translated to the other supported languages.

<img width="1188" alt="alt-text" src="https://github.com/user-attachments/assets/b5596442-8ead-4924-8db9-a358b203762d">
