### PR TITLE
Fix text stroke color not the same as the fill color

### DIFF
--- a/styles/global.scss
+++ b/styles/global.scss
@@ -186,7 +186,7 @@ h4 {
 body {
   background-color: var(--bg-color);
   color: var(--type-color);
-  -webkit-text-stroke-color: var(--type-color);
+  -webkit-text-stroke-color: currentcolor;
   @extend .text-body;
   font-weight: 400;
 }
@@ -315,7 +315,6 @@ pre.code-box,
 .sidebar {
   background-color: var(--sidebar-bg-color);
   color: var(--sidebar-type-color);
-  -webkit-text-stroke-color: var(--sidebar-type-color);
 }
 
 /** LAYOUT **/


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/518

It looks like we add a stroke to text to make it bolder. There were a few cases where we would update the fill color of text but not the stroke color, leading to a slight different-colored halo around text. It was happening in links before, see below:

Before:
<img width="1223" alt="image" src="https://github.com/user-attachments/assets/cadd55b4-028b-48ce-b296-df16c8d8c66a">


After:
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/4fb4cda8-f5b9-4b97-b8fe-e75a6e6beff5">

That said, it looks like this text stroke may be the cause of https://github.com/processing/p5.js-website/issues/473. I'm not sure how standard this property is, and whether it's a good idea to be using it across the board on body text like this. Possibly a sign that we should just be using a thicker font instead?