### PR TITLE
Fix escaping in code blocks

### DIFF
--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -233,6 +233,10 @@ export const escapeCodeTagsContent = (htmlString: string): string => {
   const $ = load(htmlString);
   // Loop through all <code> tags
   $("code").each(function () {
+    // Don't escape code in multiline blocks, as these will already
+    // be escaped
+    if ($(this).parent().prop('tagName') === 'PRE') return;
+
     // Get the current text and HTML inside the <code> tag
     const currentHtml = $(this).html() ?? "";
     // Use he to escape HTML entities


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/447

This prevents code blocks (as opposed to inline blocks) from double-escaping their special characters, causing what used to render as an `&lt;` to render as a `<`.

<img width="1292" alt="image" src="https://github.com/user-attachments/assets/74997f96-ca76-40df-b2cf-3f34c797d014">
