### PR TITLE
Fix Empty examples are shown on several reference pages

### DIFF
--- a/src/content/reference/en/p5.Envelope/set.mdx
+++ b/src/content/reference/en/p5.Envelope/set.mdx
@@ -9,7 +9,7 @@ line: 4833
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div><code>
     let attackTime;

--- a/src/content/reference/en/p5.MonoSynth/play.mdx
+++ b/src/content/reference/en/p5.MonoSynth/play.mdx
@@ -10,7 +10,7 @@ line: 11379
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div><code>
     let monoSynth;

--- a/src/content/reference/en/p5.NumberDict/add.mdx
+++ b/src/content/reference/en/p5.NumberDict/add.mdx
@@ -10,7 +10,7 @@ line: 439
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div class='norender'>
     <code>

--- a/src/content/reference/en/p5.NumberDict/div.mdx
+++ b/src/content/reference/en/p5.NumberDict/div.mdx
@@ -10,7 +10,7 @@ line: 516
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div class='norender'>
     <code>

--- a/src/content/reference/en/p5.NumberDict/mult.mdx
+++ b/src/content/reference/en/p5.NumberDict/mult.mdx
@@ -10,7 +10,7 @@ line: 489
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div class='norender'>
     <code>

--- a/src/content/reference/en/p5.NumberDict/sub.mdx
+++ b/src/content/reference/en/p5.NumberDict/sub.mdx
@@ -12,7 +12,7 @@ line: 466
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div class='norender'>
     <code>

--- a/src/content/reference/en/p5.PolySynth/noteRelease.mdx
+++ b/src/content/reference/en/p5.PolySynth/noteRelease.mdx
@@ -11,7 +11,7 @@ line: 12021
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div><code>
     let polySynth = new p5.PolySynth();

--- a/src/content/reference/en/p5.SoundFile/rate.mdx
+++ b/src/content/reference/en/p5.SoundFile/rate.mdx
@@ -10,7 +10,7 @@ line: 2146
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div><code>
     let mySound;

--- a/src/content/reference/en/p5/background.mdx
+++ b/src/content/reference/en/p5/background.mdx
@@ -63,7 +63,7 @@ line: 414
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div>
     <code>

--- a/src/content/reference/en/p5/line.mdx
+++ b/src/content/reference/en/p5/line.mdx
@@ -94,7 +94,7 @@ example:
     }
     </code>
     </div>
-  - |
+  - |-
 
     <div>
     <code>

--- a/src/content/reference/es/p5/background.mdx
+++ b/src/content/reference/es/p5/background.mdx
@@ -14,7 +14,7 @@ line: 414
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div>
     <code>

--- a/src/content/reference/es/p5/line.mdx
+++ b/src/content/reference/es/p5/line.mdx
@@ -81,7 +81,7 @@ example:
     }
     </code>
     </div>
-  - |
+  - |-
     <div>
     <code>
     function setup() {

--- a/src/content/reference/hi/p5/background.mdx
+++ b/src/content/reference/hi/p5/background.mdx
@@ -19,7 +19,7 @@ line: 414
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div>
     <code>

--- a/src/content/reference/hi/p5/line.mdx
+++ b/src/content/reference/hi/p5/line.mdx
@@ -76,7 +76,7 @@ example:
     }
     </code>
     </div>
-  - |
+  - |-
 
     <div>
     <code>

--- a/src/content/reference/ko/p5/background.mdx
+++ b/src/content/reference/ko/p5/background.mdx
@@ -63,7 +63,7 @@ line: 414
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div>
     <code>

--- a/src/content/reference/ko/p5/line.mdx
+++ b/src/content/reference/ko/p5/line.mdx
@@ -93,7 +93,7 @@ example:
     }
     </code>
     </div>
-  - |
+  - |-
 
     <div>
     <code>

--- a/src/content/reference/zh-Hans/p5/background.mdx
+++ b/src/content/reference/zh-Hans/p5/background.mdx
@@ -18,7 +18,7 @@ line: 414
 isConstructor: false
 itemtype: method
 example:
-  - |
+  - |-
 
     <div>
     <code>

--- a/src/content/reference/zh-Hans/p5/line.mdx
+++ b/src/content/reference/zh-Hans/p5/line.mdx
@@ -79,7 +79,7 @@ example:
     }
     </code>
     </div>
-  - |
+  - |-
 
     <div>
     <code>


### PR DESCRIPTION
resolves #559

## Changes
Corrected separator strings in some reference page examples.