### PR TITLE
fix jumpTo menu order in tutorial pages.

### DIFF
--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -377,7 +377,7 @@ export const generateJumpToState = async (
       category === getExampleCategory(currentEntrySlug)
     ) {
       // Get all entries in the current category
-      const currentCategoryEntries = localeEntries.filter(
+      let currentCategoryEntries = localeEntries.filter(
         (entry) =>
           category ===
           (collectionType === "examples"
@@ -385,6 +385,14 @@ export const generateJumpToState = async (
             : // @ts-expect-error - We know that the category exists because of the collection type
               entry.data.category ?? ""),
       );
+
+      if (collectionType === "tutorials") {
+        currentCategoryEntries = currentCategoryEntries.sort(
+          (a, b) =>
+            ((a.data as any).categoryIndex ?? 1000) -
+            ((b.data as any).categoryIndex ?? 1000),
+        );
+      }
 
       // Add the entries in the category to the jumpToLinks
       categoryLinks.push(


### PR DESCRIPTION
ideas for  #567

This is an improvement idea that we tried in the Japanese version.
https://p5js-ja.pages.dev/tutorials/setting-up-your-environment/

However, this implementation may not be the best due to my lack of study:.
- I am changing constants to variables.
- TypeScript type safety is not observed.

You may want to consider another better implementation.

I hope this helps you.