### PR TITLE
Use jsdelivr as CDN

### DIFF
--- a/src/globals/globals.ts
+++ b/src/globals/globals.ts
@@ -14,7 +14,7 @@ export const sketchesPerPage = 12 as const;
 export const eventsPerPage = 12 as const;
 
 export const cdnLibraryUrl =
-  `https://cdnjs.cloudflare.com/ajax/libs/p5.js/${p5Version}/p5.min.js` as const;
+  `https://cdn.jsdelivr.net/npm/p5@${p5Version}/lib/p5.min.js` as const;
 export const fullDownloadUrl =
   `https://github.com/processing/p5.js/releases/download/v${p5Version}/p5.zip` as const;
 export const libraryDownloadUrl =

--- a/test/mocks/server.ts
+++ b/test/mocks/server.ts
@@ -16,6 +16,11 @@ const handlers = [
       readFileSync("./assets/p5.min.js", { encoding: "utf-8" }),
     );
   }),
+  http.get("https://cdn.jsdelivr.net/npm/p5*", () => {
+    return HttpResponse.text(
+      readFileSync("./assets/p5.min.js", { encoding: "utf-8" }),
+    );
+  }),
 ];
 
 /**


### PR DESCRIPTION
This branches off of https://github.com/processing/p5.js-website/pull/578 and uses a different CDN provider that has the new p5 version. Feel free to close this if we want to wait.