### PR TITLE
Fix: The “Related Reference” section title of the example pages for i18n

### DIFF
--- a/src/layouts/ExampleLayout.astro
+++ b/src/layouts/ExampleLayout.astro
@@ -70,7 +70,7 @@ const { Content } = await example.render();
     {
       relatedReferences.length > 0 ? (
         <RelatedItems
-          title={t("Related Reference") as string}
+          title={t("Related References") as string}
           items={relatedReferences}
         />
       ) : null


### PR DESCRIPTION
The “Related Reference” section title of the example pages has been revised to include internationalized words as well as other pages.

Changes:
"Related Reference" to "Related References"