### PR TITLE
Fix example category link in the jumpTo on the example detail page.

### DIFF
--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -367,7 +367,10 @@ export const generateJumpToState = async (
     const categoryLinks = [] as JumpToLink[];
     categoryLinks.push({
       label: getCategoryLabel(category),
-      url: `/${collectionType}#${category}`,
+      url:
+        collectionType === "examples"
+          ? `/${collectionType}#${getCategoryLabel(category).toLocaleLowerCase()}`
+          : `/${collectionType}#${category}`,
       current: false,
     });
 

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -365,12 +365,13 @@ export const generateJumpToState = async (
   // Loop through each category and add entries to the jumpToLinks
   for (const category of categories ?? []) {
     const categoryLinks = [] as JumpToLink[];
+    const categoryLabel = getCategoryLabel(category);
     categoryLinks.push({
-      label: getCategoryLabel(category),
+      label: categoryLabel,
       url:
         collectionType === "examples"
-          ? `/${collectionType}#${getCategoryLabel(category).toLocaleLowerCase()}`
-          : `/${collectionType}#${category}`,
+          ? `/${collectionType}/#${categoryLabel.toLowerCase()}`
+          : `/${collectionType}/#${category}`,
       current: false,
     });
 


### PR DESCRIPTION
(Relation #585, #586)

Example Category link broken after merge #586.

Details:
Before merge #586, there was no problem in English. 
But after merged #586, the problem was discovered because #ID and id attribute were created with different rules.

- Category's id attribute in parent page was created with "name.toLowerCase()".
https://github.com/processing/p5.js-website/blob/d24bb80293c026f1bb688f3b4c2acdcf3a358bc6/src/layouts/ExamplesLayout.astro#L45

- jumpTo Category's #ID was created with "category".

Changes:
- jumpTo Category's #ID is created with "name" and ".toLowerCase()".
