### PR TITLE
fix: Correct typo, improve createRadio() method description, and simplify input tag

### DIFF
--- a/src/content/reference/en/p5/createRadio.mdx
+++ b/src/content/reference/en/p5/createRadio.mdx
@@ -10,8 +10,7 @@ description: >
 
   <code>let myRadio = createSelect('food')</code>, then each radio option will
 
-  have <code>"food"</code> as its <code>name</code> parameter: <code><input
-  name="food"></input></code>.
+  have <code>"food"</code> as its <code>name</code> parameter: <code><input name="food"></code>.
 
   If an existing <code><div></div></code> or <code><span></span></code>
 
@@ -28,7 +27,7 @@ description: >
   <ul>
 
   <li><code>myRadio.option(value, [label])</code> adds an option to the menu.
-  The first paremeter, <code>value</code>, is a string that sets the option's
+  The first parameter, <code>value</code>, is a string that sets the option's
   value and label. The second parameter, <code>label</code>, is optional. If
   provided, it sets the label displayed for the <code>value</code>. If an option
   with <code>value</code> already exists, its label is changed and its value is
@@ -45,9 +44,7 @@ description: >
   href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/"
   target="_blank"><code>HTMLInputElement</code></a>.</li>
 
-  <li><code>myRadio.disable(shouldDisable)</code> enables the entire radio
-  button if <code>true</code> is passed and disables it if <code>false</code> is
-  passed.</li>
+  <li><code>myRadio.disable(shouldDisable)</code> Disables the radio button if <code>true</code> is passed and enables it if <code>false</code> is passed.</li>
 
   </ul>
 line: 1440


### PR DESCRIPTION
### Related Issue
Fixes #595 - Mispelling in Docs: Reference > createRadio()

### Summary
- Corrected a typo in the documentation: changed "paremeter" to "parameter" in the description of the `myRadio.option()` method.
- Improved the description of the `myRadio.disable()` method:
  - Changed "enables the entire radio button if true is passed and disables it if false is passed." to "Disables the radio button if true is passed, and enables it if false is passed."
- Simplified the HTML tag example in the documentation:
  - Changed `<input name="food"></input>` to `<input name="food">` since `<input>` is a self-closing tag.

### Motivation
These changes enhance the readability, accuracy, and compliance with HTML standards in the `createRadio` documentation, making it easier for developers to understand and use this method.

### Additional Notes
Please review these changes to ensure they align with the project's documentation style.
