### PR TITLE
Fix broken links in example pages.

### DIFF
--- a/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx
@@ -10,11 +10,11 @@ relatedReference:
 
 This program demonstrates the use of the basic shape
 primitive functions
-<a href="https://p5js.org/reference/#/p5/square" target="_blank">square()</a>,
-<a href="https://p5js.org/reference/#/p5/rect" target="_blank">rect()</a>,
-<a href="https://p5js.org/reference/#/p5/ellipse" target="_blank">ellipse()</a>,
-<a href="https://p5js.org/reference/#/p5/circle" target="_blank">circle()</a>,
-<a href="https://p5js.org/reference/#/p5/arc" target="_blank">arc()</a>,
-<a href="https://p5js.org/reference/#/p5/line" target="_blank">line()</a>,
-<a href="https://p5js.org/reference/#/p5/triangle" target="_blank">triangle()</a>,
-and <a href="https://p5js.org/reference/#/p5/quad" target="_blank">quad()</a>.
+<a href="https://p5js.org/reference/p5/square" target="_blank">square()</a>,
+<a href="https://p5js.org/reference/p5/rect" target="_blank">rect()</a>,
+<a href="https://p5js.org/reference/p5/ellipse" target="_blank">ellipse()</a>,
+<a href="https://p5js.org/reference/p5/circle" target="_blank">circle()</a>,
+<a href="https://p5js.org/reference/p5/arc" target="_blank">arc()</a>,
+<a href="https://p5js.org/reference/p5/line" target="_blank">line()</a>,
+<a href="https://p5js.org/reference/p5/triangle" target="_blank">triangle()</a>,
+and <a href="https://p5js.org/reference/p5/quad" target="_blank">quad()</a>.

--- a/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
@@ -7,14 +7,14 @@ oneLineDescription: Add color to your sketch.
 
 This expands on the Shape Primitives example by adding
 color.
-<a href="https://p5js.org/reference/#/p5/background" target="_blank">background()</a>
+<a href="https://p5js.org/reference/p5/background" target="_blank">background()</a>
 fills the canvas with one color,
-<a href="https://p5js.org/reference/#/p5/stroke" target="_blank">stroke()</a>
+<a href="https://p5js.org/reference/p5/stroke" target="_blank">stroke()</a>
 sets the color for drawing lines, and
-<a href="https://p5js.org/reference/#/p5/fill" target="_blank">fill()</a>
+<a href="https://p5js.org/reference/p5/fill" target="_blank">fill()</a>
 sets the color for the inside of shapes.
-<a href="https://p5js.org/reference/#/p5/noFill" target="_blank">noStroke()</a> and
-<a href="https://p5js.org/reference/#/p5/noFill" target="_blank">noFill()</a>
+<a href="https://p5js.org/reference/p5/noFill" target="_blank">noStroke()</a> and
+<a href="https://p5js.org/reference/p5/noFill" target="_blank">noFill()</a>
 turn off line color and inner color, respectively.
 
 Colors can be represented in many different ways. This example demonstrates several options.

--- a/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx
@@ -9,15 +9,15 @@ Click and drag the mouse to draw a line.
 
 This example demonstrates the use of several built-in
 variables.
-<a href="https://p5js.org/reference/#/p5/mouseX">mouseX</a>
+<a href="https://p5js.org/reference/p5/mouseX">mouseX</a>
 and
-<a href="https://p5js.org/reference/#/p5/mouseY">mouseY</a>
+<a href="https://p5js.org/reference/p5/mouseY">mouseY</a>
 store the current mouse position, while the
 previous mouse position is represented by
-<a href="https://p5js.org/reference/#/p5/pmouseX">pmouseX</a>
+<a href="https://p5js.org/reference/p5/pmouseX">pmouseX</a>
 and
-<a href="https://p5js.org/reference/#/p5/pmouseY">pmouseY</a>.
+<a href="https://p5js.org/reference/p5/pmouseY">pmouseY</a>.
  *
 This example also shows the use of
-<a href="https://p5js.org/reference/#/p5/colorMode">colorMode</a> with HSB
+<a href="https://p5js.org/reference/p5/colorMode">colorMode</a> with HSB
 (hue-saturation-brightness), so that the first variable sets the hue.

--- a/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/01_Animation_With_Events/description.mdx
@@ -6,9 +6,9 @@ oneLineDescription: Pause and resume animation.
 ---
 
 This example demonstrates the use of
-<a href="https://p5js.org/reference/#/p5/loop">loop()</a>
+<a href="https://p5js.org/reference/p5/loop">loop()</a>
 and
-<a href="https://p5js.org/reference/#/p5/noLoop">noLoop()</a>
+<a href="https://p5js.org/reference/p5/noLoop">noLoop()</a>
 to pause and resume the animation.
 
 Clicking the mouse toggles the animation loop. If the animation
@@ -17,5 +17,5 @@ Note: the user must click to set the focus on the canvas for
 key presses to be registered.
 
 Advancing a single frame is accomplished by calling the
-<a href="https://p5js.org/reference/#/p5/redraw">redraw()</a>
+<a href="https://p5js.org/reference/p5/redraw">redraw()</a>
 function, which results in a single call to the draw() function.

--- a/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/02_Mobile_Device_Movement/description.mdx
@@ -6,11 +6,11 @@ oneLineDescription: Animate based on device motion.
 featured: true
 ---
 
-The <a href="https://p5js.org/reference/#/p5/deviceMoved" target="_blank">deviceMoved()</a>
+The <a href="https://p5js.org/reference/p5/deviceMoved" target="_blank">deviceMoved()</a>
 function runs when the mobile device displaying the sketch moves.
 In this example, the
-<a href="https://p5js.org/reference/#/p5/accelerationX" target="_blank">accelerationX</a>,
-<a href="https://p5js.org/reference/#/p5/accelerationY" target="_blank">accelerationY</a>,
-and <a href="https://p5js.org/reference/#/p5/accelerationZ" target="_blank">accelerationZ</a>
+<a href="https://p5js.org/reference/p5/accelerationX" target="_blank">accelerationX</a>,
+<a href="https://p5js.org/reference/p5/accelerationY" target="_blank">accelerationY</a>,
+and <a href="https://p5js.org/reference/p5/accelerationZ" target="_blank">accelerationZ</a>
 values set the position and size of a circle.
 This only works for mobile devices.

--- a/src/content/examples/en/02_Animation_And_Variables/03_Conditions/description.mdx
+++ b/src/content/examples/en/02_Animation_And_Variables/03_Conditions/description.mdx
@@ -10,7 +10,7 @@ If and else statements allow a
 to run only when a certain condition is true. This example only
 animates when the mouse is held down. This is because of the if
 statement on line 59. You can read more about if and else statements
-<a href="https://p5js.org/reference/#/p5/if-else">in the p5 reference</a>
+<a href="https://p5js.org/reference/p5/if">in the p5 reference</a>
 or <a href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/conditionals" target="_blank">on MDN</a>.
 
 Comparison operators help to form conditions by comparing two

--- a/src/content/examples/en/03_Imported_Media/00_Words/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/00_Words/description.mdx
@@ -5,8 +5,8 @@ title: Words
 oneLineDescription: Load fonts and draw text.
 ---
 
-The <a href="https://p5js.org/reference/#/p5/text" target="_blank">text()</a> function is used for inserting text into the canvas.
-You can change the font and text size using the <a href="https://p5js.org/reference/#/p5/loadFont" target="_blank">loadFont()</a>
-and <a href="https://p5js.org/reference/#/p5/fontSize" target="_blank">fontSize()</a> functions.
-The text can be aligned left, center, or right with the <a href="https://p5js.org/reference/#/p5/textAlign" target="_blank">textAlign()</a>
-function, and, like shapes, text can be colored with <a href="https://p5js.org/reference/#/p5/fill" target="_blank">fill()</a>.
+The <a href="https://p5js.org/reference/p5/text" target="_blank">text()</a> function is used for inserting text into the canvas.
+You can change the font and text size using the <a href="https://p5js.org/reference/p5/loadFont" target="_blank">loadFont()</a>
+and <a href="https://p5js.org/reference/p5/fontSize" target="_blank">fontSize()</a> functions.
+The text can be aligned left, center, or right with the <a href="https://p5js.org/reference/p5/textAlign" target="_blank">textAlign()</a>
+function, and, like shapes, text can be colored with <a href="https://p5js.org/reference/p5/fill" target="_blank">fill()</a>.

--- a/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/01_Copy_Image_Data/description.mdx
@@ -5,6 +5,6 @@ title: Copy Image Data
 oneLineDescription: Paint from an image file onto the canvas.
 ---
 
-Using the <a href="https://p5js.org/reference/#/p5/copy" target="_blank">copy()</a> 
+Using the <a href="https://p5js.org/reference/p5/copy" target="_blank">copy()</a> 
 method, you can simulate coloring an image in by copying an image of the colored 
 image on top of the black-and-white image wherever the cursor is dragged.

--- a/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/02_Alpha_Mask/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Use one image to cut out a section of another image.
 ---
 
 Using the 
-<a href="https://p5js.org/reference/#/p5/mask" target="_blank">mask()</a> 
+<a href="https://p5js.org/reference/p5/mask" target="_blank">mask()</a> 
 method, you can create a mask for an image to specify the transparency in
 different parts of the image. To run this example locally, you will need two
 image files and a running 

--- a/src/content/examples/en/03_Imported_Media/03_Image_Transparency/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/03_Image_Transparency/description.mdx
@@ -7,7 +7,7 @@ oneLineDescription: Make an image translucent on the canvas.
 
 This program overlays one image over another by modifying the
 alpha value of the image with the
-<a href="https://p5js.org/reference/#/p5/tint" target="_blank">tint()</a>
+<a href="https://p5js.org/reference/p5/tint" target="_blank">tint()</a>
 function. Move the cursor left and right across the canvas to change the
 image's position. To run this example
 locally, you will need an image file and a running

--- a/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/04_Create_Audio/description.mdx
@@ -5,12 +5,12 @@ title: Audio Player
 oneLineDescription: Create a player for an audio file.
 ---
 
-<a href="https://p5js.org/reference/#/p5/createAudio" target="_blank">createAudio()</a>
+<a href="https://p5js.org/reference/p5/createAudio" target="_blank">createAudio()</a>
 creates an audio player. This example displays the player's controls
 and adjusts its speed. The playback speed is normal when the mouse
 is on the left edge of the window, and it gets faster as the mouse
 moves to the right. More information on using media elements such as
 audio players is on the
-<a href="https://p5js.org/reference/#/p5.MediaElement" target="_blank">p5.MediaElement</a>
+<a href="https://p5js.org/reference/p5/p5.MediaElement" target="_blank">p5.MediaElement</a>
 reference page. The audio file is a
 <a href="https://freesound.org/people/josefpres/sounds/711156/" target="_blank">public domain piano loop by Josef Pres</a>.

--- a/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/05_Video/description.mdx
@@ -5,8 +5,8 @@ title: Video Player
 oneLineDescription: Create a player for a video file.
 ---
 
-Using the <a href="https://p5js.org/reference/#/p5/noCanvas" target="_blank">noCanvas()</a>
-and <a href="https://p5js.org/reference/#/p5/createVideo" target="_blank">createVideo()</a> 
+Using the <a href="https://p5js.org/reference/p5/noCanvas" target="_blank">noCanvas()</a>
+and <a href="https://p5js.org/reference/p5/createVideo" target="_blank">createVideo()</a> 
 functions, you can upload a video into the 
 <a href="https://developer.mozilla.org/en-US/docs/Glossary/DOM" target="_blank">DOM</a> 
 without embedding the video within a canvas. For building a video embedded within the canvas element,

--- a/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/06_Video_Canvas/description.mdx
@@ -6,13 +6,13 @@ oneLineDescription: Display and stylize a video on the canvas.
 ---
 
 Using the 
-<a href="https://p5js.org/reference/#/p5/createVideo" target="_blank">createVideo()</a>
-and <a href="https://p5js.org/reference/#/p5/image" target="_blank">image()</a> 
+<a href="https://p5js.org/reference/p5/createVideo" target="_blank">createVideo()</a>
+and <a href="https://p5js.org/reference/p5/image" target="_blank">image()</a> 
 functions, you can upload a video into the canvas. Since the video capture is 
 passed through the
-<a href="https://p5js.org/reference/#/p5/image" target="_blank">image()</a> 
+<a href="https://p5js.org/reference/p5/image" target="_blank">image()</a> 
 constructor, you can add filters to the video capture using the 
-<a href="https://p5js.org/reference/#/p5/filter" target="_blank">filter()</a> 
+<a href="https://p5js.org/reference/p5/filter" target="_blank">filter()</a> 
 method. To run this example locally, you will need a running 
 <a href="https://github.com/processing/p5.js/wiki/Local-server">local server</a>.
 To build a video without embedding it within the canvas, visit the 

--- a/src/content/examples/en/03_Imported_Media/07_Video_Capture/description.mdx
+++ b/src/content/examples/en/03_Imported_Media/07_Video_Capture/description.mdx
@@ -6,13 +6,13 @@ oneLineDescription: Display a live video feed from a camera.
 ---
 
 Using the 
-<a href="https://p5js.org/reference/#/p5/createCapture" target="_blank">createCapture()</a>
-and <a href="https://p5js.org/reference/#/p5/image" target="_blank">image()</a> 
+<a href="https://p5js.org/reference/p5/createCapture" target="_blank">createCapture()</a>
+and <a href="https://p5js.org/reference/p5/image" target="_blank">image()</a> 
 functions, you can take a device's video capture and draw it in the canvas. 
 Since the video capture is passed through the
-<a href="https://p5js.org/reference/#/p5/image" target="_blank">image()</a> 
+<a href="https://p5js.org/reference/p5/image" target="_blank">image()</a> 
 constructor, you can add filters to the video capture with the 
-<a href="https://p5js.org/reference/#/p5/filter" target="_blank">filter()</a> 
+<a href="https://p5js.org/reference/p5/filter" target="_blank">filter()</a> 
 method. For different strategies for uploading, presenting, or styling videos, 
 visit the
 <a href="https://p5js.org/examples/dom-video.html" target="_blank">Video</a> and

--- a/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/00_Image_Drop/description.mdx
@@ -5,11 +5,11 @@ title: Image Drop
 oneLineDescription: Display an image that the page visitor dragged and dropped.
 ---
 
-<a href="https://p5js.org/reference/#/p5.Element/drop" target="_blank">drop()</a>
+<a href="https://p5js.org/reference/p5.Element/drop" target="_blank">drop()</a>
 is a p5.js element method that registers a callback every time a file is loaded 
 into the element. The uploaded file is created into a 
-<a href="https://p5js.org/reference/#/p5.File" target="_blank">p5.File</a> 
+<a href="https://p5js.org/reference/p5/p5.File" target="_blank">p5.File</a> 
 class. You can use the 
-<a href="https://p5js.org/reference/#/p5.Element/drop" target="_blank">drop()</a> 
+<a href="https://p5js.org/reference/p5.Element/drop" target="_blank">drop()</a> 
 callback to check the file type, then write conditional statements responding to 
 the file type.

--- a/src/content/examples/en/04_Input_Elements/01_Input_Button/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/01_Input_Button/description.mdx
@@ -6,8 +6,8 @@ oneLineDescription: Use text input from the page visitor.
 ---
 
 Using the 
-<a href="https://p5js.org/reference/#/p5.Element/createElement" target="_blank">createElement()</a>,
-<a href="https://p5js.org/reference/#/p5/createInput" target="_blank">createInput()</a>,
-and <a href="https://p5js.org/reference/#/p5.Element/createButton" target="_blank">createButton()</a> 
+<a href="https://p5js.org/reference/p5/createElement" target="_blank">createElement()</a>,
+<a href="https://p5js.org/reference/p5/createInput" target="_blank">createInput()</a>,
+and <a href="https://p5js.org/reference/p5/createButton" target="_blank">createButton()</a> 
 functions, you can take a string of text submitted via text input and display 
 it on your canvas.

--- a/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
+++ b/src/content/examples/en/04_Input_Elements/02_DOM_Form_Elements/description.mdx
@@ -7,9 +7,9 @@ oneLineDescription: Create a form and respond to the results.
 
 The <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model" target="_blank">Document Object Model</a>,
 or DOM, represents the resulting structure of the web page. Using p5.js's form elements,
-such as <a href="https://p5js.org/reference/#/p5/createInput" target="_blank">createInput()</a>,
-<a href="https://p5js.org/reference/#/p5/createSelect" target="_blank">createSelect()</a>,
-and <a href="https://p5js.org/reference/#/p5/createRadio" target="_blank">createRadio()</a>, you can build different ways to take information submitted through
+such as <a href="https://p5js.org/reference/p5/createInput" target="_blank">createInput()</a>,
+<a href="https://p5js.org/reference/p5/createSelect" target="_blank">createSelect()</a>,
+and <a href="https://p5js.org/reference/p5/createRadio" target="_blank">createRadio()</a>, you can build different ways to take information submitted through
 a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select" target="_blank">select</a>,
 <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input" target="_blank">input</a>,
 or <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio" target="_blank">radio button</a> and update the DOM based on the information.

--- a/src/content/examples/en/05_Transformation/00_Translate/description.mdx
+++ b/src/content/examples/en/05_Transformation/00_Translate/description.mdx
@@ -6,14 +6,14 @@ oneLineDescription: Move the coordinate system origin.
 ---
 
 The
-<a href="https://p5js.org/reference/#/p5/translate">translate()</a>
+<a href="https://p5js.org/reference/p5/translate">translate()</a>
 function moves the origin of the coordinate system to the specified
 location.
 
 The
-<a href="https://p5js.org/reference/#/p5/push">push()</a>
+<a href="https://p5js.org/reference/p5/push">push()</a>
 and
-<a href="https://p5js.org/reference/#/p5/pop">pop()</a>
+<a href="https://p5js.org/reference/p5/pop">pop()</a>
 functions save and restore the coordinate system and various
 other drawing settings, such as the fill color.
 

--- a/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
+++ b/src/content/examples/en/05_Transformation/01_Rotate/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Rotate the coordinate system.
 ---
 
 The
-<a href="https://p5js.org/reference/#/p5/rotate">rotate()</a>
+<a href="https://p5js.org/reference/p5/rotate">rotate()</a>
 function rotates the current coordinate system around the current
 origin.
 
@@ -15,7 +15,7 @@ In order to rotate around the center of the canvas, we must first
 translate the coordinate system, and then rotate around the new origin.
 
 The 
-<a href="https://p5js.org/reference/#/p5/push">push()</a>
+<a href="https://p5js.org/reference/p5/push">push()</a>
 and
-<a href="https://p5js.org/reference/#/p5/pop">pop()</a>
+<a href="https://p5js.org/reference/p5/pop">pop()</a>
 functions save and restore the coordinate system, respectively.

--- a/src/content/examples/en/05_Transformation/02_Scale/description.mdx
+++ b/src/content/examples/en/05_Transformation/02_Scale/description.mdx
@@ -6,14 +6,14 @@ oneLineDescription: Modify the coordinate system scale.
 ---
 
 The
-<a href="https://p5js.org/reference/#/p5/scale">scale()</a>
+<a href="https://p5js.org/reference/p5/scale">scale()</a>
 function scales the current coordinate system by the specified
 factor.
 
 The
-<a href="https://p5js.org/reference/#/p5/push">push()</a>
+<a href="https://p5js.org/reference/p5/push">push()</a>
 and
-<a href="https://p5js.org/reference/#/p5/pop">pop()</a>
+<a href="https://p5js.org/reference/p5/pop">pop()</a>
 functions save and restore the coordinate system, respectively.
 
 In this example, a square size 200 is drawn at the origin, with

--- a/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/00_Interpolate/description.mdx
@@ -10,7 +10,7 @@ calculates a value between two other values. For example, the number 5 is
 halfway between 0 and 10. Different types of interpolation use
 different rates of change between values. Linear interpolation,
 abbreviated as lerp, uses a constant rate of change. The
-<a href="https://p5js.org/reference/#/p5/lerp" target="_blank">lerp()</a>
+<a href="https://p5js.org/reference/p5/lerp" target="_blank">lerp()</a>
 function linearly interpolates between two numbers.
 
 Move the mouse across the screen and the symbol will follow.

--- a/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/01_Map/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Convert a number from one range to another range.
 ---
 
 The
-<a href="https://p5js.org/reference/#/p5/map" target="_blank">map()</a>
+<a href="https://p5js.org/reference/p5/map" target="_blank">map()</a>
 function converts a value from one range to another. In this example, map
 converts the cursor's horizontal position from a range of 0-720 to 0-360.
 The resulting value become the circle's hue. Map also converts the cursor's

--- a/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/02_Random/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Get random numbers.
 ---
 
 This example demonstrates the use of the
-<a href="https://p5js.org/reference/#/p5/random">random()</a>
+<a href="https://p5js.org/reference/p5/random">random()</a>
 function.
 
 When the user presses the mouse button, the position and color

--- a/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/03_Constrain/description.mdx
@@ -8,5 +8,5 @@ oneLineDescription: Keep a number within a range.
 This example draws a circle as the cursor's position but
 keeps the circle within a rectangle. It does so by passing the
 mouse's coordinates into the
-<a href="https://p5js.org/reference/#/p5/constrain" target="_blank">constrain()</a>
+<a href="https://p5js.org/reference/p5/constrain" target="_blank">constrain()</a>
 function.

--- a/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
+++ b/src/content/examples/en/06_Calculating_Values/04_Clock/description.mdx
@@ -6,11 +6,11 @@ oneLineDescription: Get the current time.
 ---
 
 The current time can be read with the
-<a href="https://p5js.org/reference/#/p5/second" target="_blank">second()</a>,
-<a href="https://p5js.org/reference/#/p5/minute" target="_blank">minute()</a>,
-and <a href="https://p5js.org/reference/#/p5/minute" target="_blank">hour()</a>
+<a href="https://p5js.org/reference/p5/second" target="_blank">second()</a>,
+<a href="https://p5js.org/reference/p5/minute" target="_blank">minute()</a>,
+and <a href="https://p5js.org/reference/p5/minute" target="_blank">hour()</a>
 functions. This example uses
-<a href="https://p5js.org/reference/#/p5/map" target="_blank">map()</a>
+<a href="https://p5js.org/reference/p5/map" target="_blank">map()</a>
 to calculate the angle of the hands. It then uses
-<a href="https://p5js.org/reference/#group-Transform" target="_blank">transformations</a>
+<a href="https://p5js.org/reference/#Transform" target="_blank">transformations</a>
 to set their position.

--- a/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
+++ b/src/content/examples/en/07_Repetition/00_Color_Interpolation/description.mdx
@@ -10,9 +10,9 @@ calculates a value between two other values. For example, the number 5 is
 halfway between 0 and 10. Different types of interpolation use
 different rates of change between values. Linear interpolation,
 abbreviated as lerp, uses a constant rate of change. The
-<a href="https://p5js.org/reference/#/p5/lerp" target="_blank">lerp()</a>
+<a href="https://p5js.org/reference/p5/lerp" target="_blank">lerp()</a>
 function linearly interpolates between two numbers. The
-<a href="https://p5js.org/reference/#/p5/lerpColor" target="_blank">lerpColor()</a>
+<a href="https://p5js.org/reference/p5/lerpColor" target="_blank">lerpColor()</a>
 function, demonstrated here, linearly interpolates between two colors.
 In this example, the stripeCount variable adjusts how many horizontal
 stripes appear. Setting the value to a higher number will look less

--- a/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
+++ b/src/content/examples/en/07_Repetition/01_Color_Wheel/description.mdx
@@ -7,11 +7,11 @@ oneLineDescription: Create a visualization of the color spectrum.
 
 This example illustrates the appearance of different
 hues. It uses a
-<a href="https://p5js.org/reference/#/p5/for" target="_blank">for loop</a>
+<a href="https://p5js.org/reference/p5/for" target="_blank">for loop</a>
 to repeat transformations. The loop initializes
 a variable called angle, which changes the rotation of a circle as
 well as its hue. Each time the loop repeats, a circle is drawn
 relative to the center of the canvas. The
-<a href="https://p5js.org/reference/#/p5/push" target="_blank">push()</a>
-and <a href="https://p5js.org/reference/#/p5/pop" target="_blank">pop()</a>
+<a href="https://p5js.org/reference/p5/push" target="_blank">push()</a>
+and <a href="https://p5js.org/reference/p5/pop" target="_blank">pop()</a>
 functions make these transformations affect only the individual circle.

--- a/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
+++ b/src/content/examples/en/07_Repetition/02_Bezier/description.mdx
@@ -5,10 +5,10 @@ title: Bezier
 oneLineDescription: Draw a set of curves.
 ---
 
-<a href="https://p5js.org/reference/#/p5/bezier" target="_blank">bezier()</a> 
+<a href="https://p5js.org/reference/p5/bezier" target="_blank">bezier()</a> 
 curves are created using control and anchor points.
 The first two parameters for the 
-<a href="https://p5js.org/reference/#/p5/bezier" target="_blank">bezier()</a>
+<a href="https://p5js.org/reference/p5/bezier" target="_blank">bezier()</a>
 function specify the first point in the curve and the last two parameters 
 specify the last point. The middle parameters set the control points that 
 define the shape of the curve.

--- a/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
+++ b/src/content/examples/en/07_Repetition/03_Kaleidoscope/description.mdx
@@ -7,7 +7,7 @@ oneLineDescription: Draw mirrored designs with the mouse.
 
 A kaleidoscope is an optical instrument with two or more
 reflecting surfaces tilted to each other at an angle. Using the
-<a href="https://p5js.org/reference/#/p5/translate" target="_blank">translate()</a>,
-<a href="https://p5js.org/reference/#/p5/rotate" target="_blank">rotate()</a>,
-and <a href="https://p5js.org/reference/#/p5/scale" target="_blank">scale()</a> functions, you can replicate the resulting visual
+<a href="https://p5js.org/reference/p5/translate" target="_blank">translate()</a>,
+<a href="https://p5js.org/reference/p5/rotate" target="_blank">rotate()</a>,
+and <a href="https://p5js.org/reference/p5/scale" target="_blank">scale()</a> functions, you can replicate the resulting visual
 of a kaleidoscope in a canvas.

--- a/src/content/examples/en/07_Repetition/04_Noise/description.mdx
+++ b/src/content/examples/en/07_Repetition/04_Noise/description.mdx
@@ -8,7 +8,7 @@ oneLineDescription: Generate naturalistic textures using Perlin noise.
 <a href="https://en.wikipedia.org/wiki/Perlin_noise" target="_blank">Perlin noise</a>
 is an algorithm written by Ken Perlin to produce sequences that appear both
 random and organic. The
-<a href="https://p5js.org/reference/#/p5/noise" target="_blank">noise()</a>
+<a href="https://p5js.org/reference/p5/noise" target="_blank">noise()</a>
 function in p5 produces Perlin noise.
 
 The dots in this example are sized based on noise values. The slider on the

--- a/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
+++ b/src/content/examples/en/08_Listing_Data_with_Arrays/00_Random_Poetry/description.mdx
@@ -6,8 +6,8 @@ oneLineDescription: Generate a poem with words randomly selected from a bank.
 ---
 
 Using the
-<a href="https://p5js.org/reference/#/p5/floor" target="_blank">floor()</a>
+<a href="https://p5js.org/reference/p5/floor" target="_blank">floor()</a>
 and
-<a href="https://p5js.org/reference/#/p5/random" target="_blank">random()</a>
+<a href="https://p5js.org/reference/p5/random" target="_blank">random()</a>
 functions, you can randomly select a series of items from an array
 and draw them at different sizes and positions on the canvas.

--- a/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/01_Aim/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Rotate toward a point.
 ---
 
 The
-<a href="https://p5js.org/reference/#/p5/atan2" target="_blank">atan2()</a>
+<a href="https://p5js.org/reference/p5/atan2" target="_blank">atan2()</a>
 function calculates the angle between two positions. The angle it
 calculates can be used to rotate a shape toward something. In this
 example, the eyes rotate to look at the cursor.

--- a/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/description.mdx
@@ -7,8 +7,8 @@ oneLineDescription: Split a ring into triangles.
 
 This example demonstrates how to create a shape
 by specifying its vertices in TRIANGLE_STRIP mode, using the
-<a href="https://p5js.org/reference/#/p5/beginShape">beginShape()</a>,
-<a href="https://p5js.org/reference/#/p5/endShape">endShape()</a>,
+<a href="https://p5js.org/reference/p5/beginShape">beginShape()</a>,
+<a href="https://p5js.org/reference/p5/endShape">endShape()</a>,
 and
-<a href="https://p5js.org/reference/#/p5/vertex">vertex()</a>
+<a href="https://p5js.org/reference/p5/vertex">vertex()</a>
 functions.

--- a/src/content/examples/en/10_Games/02_Snake/description.mdx
+++ b/src/content/examples/en/10_Games/02_Snake/description.mdx
@@ -17,6 +17,6 @@ as possible without colliding the snake into itself or into the edges
 of the play area.
 
 This example uses an array of
-<a href="https://p5js.org/reference/#/p5.Vector" target="_blank">vectors</a>
+<a href="https://p5js.org/reference/p5/p5.Vector" target="_blank">vectors</a>
 to store the positions of each of the segments of the snake. The arrow
 keys control the snake's movement.

--- a/src/content/examples/en/11_3D/00_Geometries/description.mdx
+++ b/src/content/examples/en/11_3D/00_Geometries/description.mdx
@@ -6,11 +6,11 @@ oneLineDescription: Draw 3D shapes, including a custom model.
 ---
 
 p5's
-<a href="https://p5js.org/reference/#/p5/WEBGL" target="_blank">WEBGL</a>
+<a href="https://p5js.org/reference/p5/WEBGL" target="_blank">WEBGL</a>
 mode includes 7 primitive shapes. Those shapes are plane, box,
 cylinder, cone, torus, sphere, and ellipsoid. Additionally,
-<a href="https://p5js.org/reference/#/p5/model" target="_blank">model()</a>
+<a href="https://p5js.org/reference/p5/model" target="_blank">model()</a>
 displays a custom geometry loaded via
-<a href="https://p5js.org/reference/#/p5/loadModel" target="_blank">loadModel()</a>.
+<a href="https://p5js.org/reference/p5/loadModel" target="_blank">loadModel()</a>.
 This example includes each of the primitive shapes. It also includes a model
 from <a href="https://nasa3d.arc.nasa.gov/models" target="_blank">NASA's collection</a>.

--- a/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
+++ b/src/content/examples/en/11_3D/01_Custom_Geometry/description.mdx
@@ -6,6 +6,6 @@ oneLineDescription: Generate a 3D shape programmatically.
 ---
 
 The
-<a href="https://p5js.org/reference/#/p5/buildGeometry" target="_blank">buildGeometry()</a>
+<a href="https://p5js.org/reference/p5/buildGeometry" target="_blank">buildGeometry()</a>
 function stores shapes into a 3D model that can be efficiently used and
 reused.

--- a/src/content/examples/en/11_3D/02_Materials/description.mdx
+++ b/src/content/examples/en/11_3D/02_Materials/description.mdx
@@ -7,12 +7,12 @@ oneLineDescription: Change 3D objects' color, texture, and how they respond to l
 
 In 3D rendering, a material determines how a surface
 responds to light. p5's
-<a href="https://p5js.org/reference/#/p5/WEBGL" target="_blank">WEBGL</a>
+<a href="https://p5js.org/reference/p5/WEBGL" target="_blank">WEBGL</a>
 mode supports
-<a href="https://p5js.org/reference/#/p5/ambientMaterial" target="_blank">ambient</a>,
-<a href="https://p5js.org/reference/#/p5/emissiveMaterial" target="_blank">emissive</a>,
-<a href="https://p5js.org/reference/#/p5/normalMaterial" target="_blank">normal</a>, and
-<a href="https://p5js.org/reference/#/p5/specularMaterial" target="_blank">specular</a>
+<a href="https://p5js.org/reference/p5/ambientMaterial" target="_blank">ambient</a>,
+<a href="https://p5js.org/reference/p5/emissiveMaterial" target="_blank">emissive</a>,
+<a href="https://p5js.org/reference/p5/normalMaterial" target="_blank">normal</a>, and
+<a href="https://p5js.org/reference/p5/specularMaterial" target="_blank">specular</a>
 materials.
 
 An ambient material responds to ambient light only. A specular
@@ -28,6 +28,6 @@ color for the surface, and stroke sets the color for the object's
 vertices.
 
 Additionally,
-<a href="https://p5js.org/reference/#/p5/texture" target="_blank">texture()</a>
+<a href="https://p5js.org/reference/p5/texture" target="_blank">texture()</a>
 wraps an object with an image. The model and image texture in this example are
 from <a href="https://nasa3d.arc.nasa.gov" target="_blank">NASA's collection</a>.

--- a/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
+++ b/src/content/examples/en/11_3D/03_Orbit_Control/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Control the camera with the mouse.
 featured: true
 ---
 
-<a href="https://p5js.org/reference/#/p5/orbitControl" target="_blank">Orbit control</a>
+<a href="https://p5js.org/reference/p5/orbitControl" target="_blank">Orbit control</a>
 uses mouse or touch input to adjust camera orientation in a 3D
 sketch. To rotate the camera, left click and drag a mouse or swipe
 on a touch screen. To pan the camera, right click and drag a mouse

--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/description.mdx
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/description.mdx
@@ -8,7 +8,7 @@ oneLineDescription: Simulate a camera's depth of field.
 The
 <a href="https://www.khronos.org/opengl/wiki/Shader" target="_blank">shader</a>
 in this example uses depth information from a
-<a href="https://p5js.org/reference/#/p5.Framebuffer" target="_blank">p5.Framebuffer</a>
+<a href="https://p5js.org/reference/p5/p5.Framebuffer" target="_blank">p5.Framebuffer</a>
 to apply a blur. On a real camera, objects appear blurred if they
 are closer or farther than the lens's focus. This simulates that
 effect. First, the sketch renders five spheres to the framebuffer.

--- a/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
+++ b/src/content/examples/en/12_Advanced_Canvas_Rendering/00_Create_Graphics/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Draw imagery off-screen.
 ---
 
 The
-<a href="https://p5js.org/reference/#/p5/createGraphics" target="_blank">createGraphics()</a>
+<a href="https://p5js.org/reference/p5/createGraphics" target="_blank">createGraphics()</a>
 function can be used to create a new p5.Graphics object, which can serve as
 an off-screen graphics buffer within the canvas. Off-screen buffers can have
 different dimensions and properties than their current display surface, even

--- a/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/00_Snowflakes/description.mdx
@@ -8,5 +8,5 @@ oneLineDescription: Animate snowfall.
 This example demonstrates the use of a particle system
 to simulate the motion of falling snowflakes. This program defines a
 snowflake
-<a href="https://p5js.org/reference/#/p5/class">class</a>
+<a href="https://p5js.org/reference/p5/class">class</a>
 and uses an array to hold the snowflake objects.

--- a/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/01_Shake_Ball_Bounce/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Animate ball movement based on mobile device motion.
 ---
 
 Using a 
-<a href="https://p5js.org/reference/#/p5/class" target="_blank">class</a>, 
+<a href="https://p5js.org/reference/p5/class" target="_blank">class</a>, 
 you can create a collection of circles that move within the canvas in 
 response to the tilt of a mobile device. You must open this page on a mobile 
 device to display the sketch.

--- a/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
+++ b/src/content/examples/en/13_Classes_And_Objects/02_Connected_Particles/description.mdx
@@ -6,7 +6,7 @@ oneLineDescription: Draw circles and connecting lines using the mouse.
 ---
 
 This example uses two custom
-<a href="https://p5js.org/reference/#/p5/class" target="_blank">classes</a>.
+<a href="https://p5js.org/reference/p5/class" target="_blank">classes</a>.
 The Particle class stores a position, velocity, and hue. It renders
 a circle using the current position and hue, and it updates the
 position using the current velocity. The Path class stores an array

--- a/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/00_Local_Storage/description.mdx
@@ -8,15 +8,15 @@ oneLineDescription: Save data from the browser on the device.
 Browsers allow websites to store data on the visitor's
 device. This is called
 <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage" target="_blank">local storage</a>.
-The <a href="https://p5js.org/reference/#/p5/getItem" target="_blank">getItem()</a>,
-<a href="https://p5js.org/reference/#/p5/storeItem" target="_blank">storeItem()</a>,
-<a href="https://p5js.org/reference/#/p5/clearStorage" target="_blank">clearStorage()</a>,
-and <a href="https://p5js.org/reference/#/p5/removeItem" target="_blank">removeItem()</a>
+The <a href="https://p5js.org/reference/p5/getItem" target="_blank">getItem()</a>,
+<a href="https://p5js.org/reference/p5/storeItem" target="_blank">storeItem()</a>,
+<a href="https://p5js.org/reference/p5/clearStorage" target="_blank">clearStorage()</a>,
+and <a href="https://p5js.org/reference/p5/removeItem" target="_blank">removeItem()</a>
 functions control it.
 
 This example is inspired by Daniel Shiffman's Loading JSON Data and Loading 
 Tabular Data examples for Processing written in Java. It uses a
-<a href="https://p5js.org/reference/#/p5/class" target="_blank">class</a>
+<a href="https://p5js.org/reference/p5/class" target="_blank">class</a>
 to organize data for a bubble. The visitor can add new bubbles, and their data 
 will be saved in local storage. If the visitor revisits the sketch, it will
 reload the same bubbles.

--- a/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/01_JSON/description.mdx
@@ -10,7 +10,7 @@ is a format for writing data in a file. While the syntax comes from
 JavaScript, JSON is used in many other contexts. This example  is
 based on Daniel Shiffman's Loading JSON Data Example for Processing
 written in Java. It uses a
-<a href="https://p5js.org/reference/#/p5/class" target="_blank">class</a>
+<a href="https://p5js.org/reference/p5/class" target="_blank">class</a>
 to organize data for a bubble. When the sketch starts, it
 loads the data for two bubbles from a JSON file. The visitor can add
 new bubbles, download an updated JSON file, and load in a JSON file.

--- a/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
+++ b/src/content/examples/en/14_Loading_And_Saving_Data/02_Table/description.mdx
@@ -7,7 +7,7 @@ oneLineDescription: Store data as comma-separated values.
 
 Comma-Separated Values, or CSV, is a format for writing
 data in a file. p5 can work with this format using a
-<a href="https://p5js.org/reference/#/p5.Table" target="_blank">p5.Table</a>.
+<a href="https://p5js.org/reference/p5/p5.Table" target="_blank">p5.Table</a>.
 This example is based on Daniel Shiffman's
 <a href="https://processing.org/examples/loadsavetable.html" target="_blank">Loading Tabular Data</a>
 example for Processing. It uses a class to organize data representing

--- a/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/00_Non_Orthogonal_Reflection/description.mdx
@@ -9,11 +9,11 @@ This example demonstrates a ball bouncing on a slanted
 surface, implemented using vector calculations for reflection.
 
 The code makes extensive use of the 
-<a href="https://p5js.org/reference/#/p5.Vector">p5.Vector</a>
+<a href="https://p5js.org/reference/p5/p5.Vector">p5.Vector</a>
 class, including the 
-<a href="https://p5js.org/reference/#/p5/createVector">createVector()</a> function to create new vectors,
+<a href="https://p5js.org/reference/p5/createVector">createVector()</a> function to create new vectors,
 and the vector methods
-<a href="https://p5js.org/reference/#/p5.Vector/add">add()</a>
+<a href="https://p5js.org/reference/p5.Vector/add">add()</a>
 and
-<a href="https://p5js.org/reference/#/p5.Vector/dot">dot()</a>
+<a href="https://p5js.org/reference/p5.Vector/dot">dot()</a>
 for the vector calculations.

--- a/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/01_Soft_Body/description.mdx
@@ -8,6 +8,6 @@ oneLineDescription: Simulate the physics of a soft body accelerating toward the 
 Physics simulation of a soft body experiencing
 acceleration toward the mouse position. The shape is created
 with curves using
-<a href="https://p5js.org/reference/#/p5/curveVertex">curveVertex()</a>
+<a href="https://p5js.org/reference/p5/curveVertex">curveVertex()</a>
 and
-<a href="https://p5js.org/reference/#/p5/curveTightness">curveTightness()</a>.
+<a href="https://p5js.org/reference/p5/curveTightness">curveTightness()</a>.

--- a/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/02_Forces/description.mdx
@@ -11,7 +11,7 @@ resistance when in "water".
 (<a href="http://natureofcode.com">natureofcode.com</a>)
 
 The force calculations are performed using the
-<a href="https://p5js.org/reference/#/p5.Vector">p5.Vector</a>
+<a href="https://p5js.org/reference/p5/p5.Vector">p5.Vector</a>
 class, including the
-<a href="https://p5js.org/reference/#/p5/createVector">createVector()</a>
+<a href="https://p5js.org/reference/p5/createVector">createVector()</a>
 function to create vectors.

--- a/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
+++ b/src/content/examples/en/15_Math_And_Physics/03_Smoke_Particle_System/description.mdx
@@ -13,12 +13,12 @@ Dan Shiffman's original
 for Processing.
 
 The code makes use of the
-<a href="https://p5js.org/reference/#/p5.Vector">p5.Vector</a>
+<a href="https://p5js.org/reference/p5/p5.Vector">p5.Vector</a>
 class, including the
-<a href="https://p5js.org/reference/#/p5/createVector">createVector()</a>
+<a href="https://p5js.org/reference/p5/createVector">createVector()</a>
 function. The various calculations for updating particles'
 positions and velocities are performed with p5.Vector methods.
 
 The particle system is implemented as a
-<a href="https://p5js.org/reference/#/p5/class">class</a>, which contains an array of
+<a href="https://p5js.org/reference/p5/class">class</a>, which contains an array of
 objects (of class Particle).


### PR DESCRIPTION
Resolves:  some part of broken links ( https://github.com/processing/p5.js-website/issues?q=is:issue+is:open+link+label:%22Bug:+Broken+Link%22 )

changes: 
In example pages.
- fix link functions and methods. (remove prefix "#")
- fix link p5.* Objects. e.g. p5.Vector  (change prefix "#" to "p5")
- fix link p5.Element/create* function (change prefix "#/p5.Element" to "p5")
- fix link to "if-else" to "if"