### PR TITLE
fix links in speak-with-your-hands.mdx

### DIFF
--- a/src/content/tutorials/en/speak-with-your-hands.mdx
+++ b/src/content/tutorials/en/speak-with-your-hands.mdx
@@ -39,16 +39,16 @@ You Will Need:
 
 In past tutorials with interactivity, we learned how to use tools like the mouse and keyboard (physical objects) to interact with the computer. These tools have helped us talk with computers for many years. But now, we don't always need them. In this tutorial, we're going to learn how to control our p5.js drawings directly with our hands, like a magician waving her wand!
 
-To do this, we will use the [ml5.js library](https://ml5js.org/) and a *machine learning model* called [HandPose](https://learn.ml5js.org/#/reference/handpose?id=handpose). The ml5.js HandPose model figures out the positions of your hand on the computer screen. 
+To do this, we will use the [ml5.js library](https://ml5js.org/) and a *machine learning model* called [HandPose](https://docs.ml5js.org/#/reference/handpose). The ml5.js HandPose model figures out the positions of your hand on the computer screen. 
 
 *Machine learning* is like teaching a computer to learn and make choices by showing it lots of examples. The code looks at the examples and creates connections, kind of like how we learn. If we want to teach it to know the difference between cats and dogs, we show it lots of pictures and tell it which ones are cats and which ones are dogs. The more examples you show the machine learning model, the better it gets. You could then show it a new picture, and it would be able to tell if it's a cat or a dog. That's machine learning in action. For more examples of machine learning, watch [this video](https://www.youtube.com/watch?v=5q87K1WaoFI\&t=665s) on Youtube.
 
-The [ml5.js](https://ml5js.org/) [HandPose](https://learn.ml5js.org/#/reference/handpose?id=handpose) machine learning model can recognize a hand in a picture and identify points on each finger. When we create interactive sketches with the mouse, we extract a mouse cursor position and use built-in variables like `mouseX` and `mouseY` to control things on the screen. The ml5.js lets us do something similar, but with your hand movements via a webcam.
+The [ml5.js](https://ml5js.org/) [HandPose](https://docs.ml5js.org/#/reference/handpose) machine learning model can recognize a hand in a picture and identify points on each finger. When we create interactive sketches with the mouse, we extract a mouse cursor position and use built-in variables like `mouseX` and `mouseY` to control things on the screen. The ml5.js lets us do something similar, but with your hand movements via a webcam.
 
 
 ### Step 1 - Set up ml5.js
 
-- Open the [ml5.js HandPose Image](https://editor.p5js.org/ml5/sketches/Handpose_Image) example in the p5.js Web Editor. Make a copy and name it something like "Handpose Sketch".
+- Open the [ml5.js HandPose Image](https://editor.p5js.org/AsukaMinato/sketches/KI4OqvacU) example in the p5.js Web Editor. Make a copy and name it something like "Handpose Sketch".
 
   ![The ml5.js Handpose\_Image code running in the p5.js Web Editor. An image of a hand is shown on the canvas with green dots on various points along each finger and palm. The text Handpose with single image is displayed above the canvas.](../images/advanced/handpose-web-editor.png)
 
@@ -113,7 +113,7 @@ function drawKeypoints() {
 
 ![The palm of a hand with 4 fingers in green color that identify each finger, and 5 green points identifying the thumb and the bottom of the palm.](../images/advanced/handpose_image.jpg)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/I0TNZ9w_1)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/lmpV7LuOu)
 
 </Column>
 </Columns>
@@ -122,7 +122,7 @@ function drawKeypoints() {
 
 #### Deep Dive into ml5.js Sample Code
 
-Let's dive into how [ml5.js](https://ml5js.org/) works, especially with the [HandPose](https://learn.ml5js.org/#/reference/handpose?id=handpose) model. [ml5.js](https://ml5js.org/) is a tool made to help us all use machine learning easily. It works great with p5.js, which means our computer can "see, hear, and understand" stuff using a camera, just like we do!
+Let's dive into how [ml5.js](https://ml5js.org/) works, especially with the [HandPose](https://docs.ml5js.org/#/reference/handpose) model. [ml5.js](https://ml5js.org/) is a tool made to help us all use machine learning easily. It works great with p5.js, which means our computer can "see, hear, and understand" stuff using a camera, just like we do!
 
 The [HandPose](https://learn.ml5js.org/#/reference/handpose) model uses image recognition algorithms to recognize your hand. It can spot your palm and fingers and keep track of them as you move your hand around in front of the camera. It can only detect one one hand at a time, but it can identify 21 different key-points on the hand in 3D space. This means that it gives us the x-y-z coordinates of each point. These key-points show us key parts of your palm and fingers. 
 
@@ -224,7 +224,7 @@ function drawKeypoints() {
 
 ![The palm of a hand with 4 fingers in green color that identify each finger, and 5 green points identifying the thumb and the bottom of the palm.](../images/advanced/handpose_image.jpg)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/jsco7Hu4T)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/PrTg6fOe3)
 
 </Column>
 </Columns>
@@ -323,7 +323,7 @@ function drawKeypoints() {
 
 ![A hand with the tip of each finger and thumb identified with a different coloured dot.](../images/advanced/ml5-hand-multicolor.png)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/JmQqw7sZV)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/3EyR46WiN)
 
 </Column>
 </Columns>
@@ -443,22 +443,22 @@ function drawKeypoints() {
 
 ![A hand where the tip of each finger and thumb has a joker's hat on it](../images/advanced/ml5-hand-hats.png)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/UCskWrEkW)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/W6V8cSNIo)
 
 </Column>
 </Columns>
 
-Lets understand the code in this example:
+Let's understand the code in this example:
 
 - First, upload a small .png file (100x100 pixels max) that has a transparent background. We create a new variable to store this image and then load it in the preload function. 
 - Next, we place the image at the same location as each ellipse in the previous code example. 
-- Next, we adjust the points to center the image at each fingertip point. The image will render so that  the fingertip point is the left bottom corner of the hat image, representing the (0,0) point. To center the hat image on that point, we subtract half the width of the image from the x-coordinate of the fingertip point and subtract half the height of the image from the y-coordinate of the fingertip point. 
+- Next, we adjust the points to center the image at each fingertip point. The image will render so that the fingertip point is the left bottom corner of the hat image, representing the (0,0) point. To center the hat image on that point, we subtract half the width of the image from the x-coordinate of the fingertip point and subtract half the height of the image from the y-coordinate of the fingertip point. 
 - Finally, we render the hatImage instead of drawing the ellipses at the end of the `drawKeypoints()` function.
 
 
 #### Example: Using a live Webcam feed
 
-In this example we replace the static image with a live webcam feed. 
+In this example, we replace the static image with a live webcam feed. 
 
 Let’s go back to the ml5.js Handpose, and open up the [Webcam reference for p5.js web editor](https://editor.p5js.org/ml5/sketches/Handpose_Webcam). Make a copy and name it something like “Handpose Webcam Sketch”. 
 
@@ -510,7 +510,7 @@ function drawKeypoints() {
 
 ![A video feed of a hand up in the air with green dots on each finger](../images/advanced/ml5-pose-webcam.gif)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/_h4n2eFvE)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/sccc0y2hx)
 
 </Column>
 </Columns>
@@ -617,7 +617,7 @@ function drawKeypoints() {
 
 ![A hand moving around the screen where the tip of each finger and thumb has a joker's hat on it and the hats move with the hand.](../images/advanced/ml5-webcam-hats.gif)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/4-E2ThsHY)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/10yJDZmH0)
 
 </Column>
 
@@ -630,14 +630,14 @@ Give each finger a different hat!
 
 ### Step 3 -  Adding interactivity 
 
-Now that we understand the data that the ml5.js HandPose model provides to us, we can use it to interact with our sketches. There are some fun examples of interacting with sketches in the [Conditionals and Interactivity](/tutorials/conditionals-and-interactivity) tutorial. Let’s start with some of these examples - but use our hands instead of the mouse.
+Now that we understand the data that the ml5.js HandPose model provides to us, we can use it to interact with our sketches. There are some fun examples of interacting with sketches in the [Conditionals and Interactivity](https://p5js.org/tutorials/conditionals-and-interactivity/) tutorial. Let’s start with some of these examples - but use our hands instead of the mouse.
 
 When we interacted with our sketches using the mouse, we used the `mouseX` and `mouseY` variables to track the x-y coordinates of the cursor. Now, we will use the x-y coordinates of the tip of a finger. 
 
 
 #### Example: Move a ball with your index finger
 
-In this example we control a circle on the screen with our index finger. 
+In this example, we control a circle on the screen with our index finger. 
 
 Let’s start with the “Using a live Webcam feed” example. 
 
@@ -709,7 +709,7 @@ function drawObject() {
 
 ![Video of fingers (one or many) moving around the screen, with a white dot on the tip of the index finger only](../images/advanced/ml5js-webcam-ballcontrol.gif)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/xJkXVoQQs)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/OQyXTAPhG)
 
 </Column>
 </Columns>
@@ -762,7 +762,7 @@ function drawObject() {
 
 ![A webcam feed of a hand in the air with three white circles on the three central fingers of the hand](../images/advanced/ml5-webcam-multiple.gif)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/tbB8BR-7c)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/ZBAlPcqsT)
 
 </Column>
 </Columns>
@@ -822,7 +822,7 @@ function drawObject() {
 
 ![A finger pointing to the right or left with a gray rectangle covering half the screen where the finger is pointing ](../images/advanced/mljs-move-object.gif)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/kfseWyYR4)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/fi1MJKxK1)
 
 </Column>
 
@@ -907,7 +907,7 @@ function drawObject() {
 
 ![A gray box in the middle of the screen and a small gray dot moving near the box. The box turns yellow when the dot is within the box.](../images/advanced/mljs-handpose-colour.gif)
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/7BBJPBCyI)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/fbPQpLvfb)
 
 </Column>
 
@@ -1039,7 +1039,7 @@ function drawObject() {
 
 Sketch by [Akif Kazi](https://www.instagram.com/designer_akifkazi), Student at KJ Somaiya University, Mumbai.
 
-[Live](https://editor.p5js.org/vyasakanksha/sketches/tqvxO53fn)
+[Live](https://editor.p5js.org/AsukaMinato/sketches/a8dEKOBPK)
 
 </Column>
 </Columns>
@@ -1054,7 +1054,7 @@ Sketch by [Akif Kazi](https://www.instagram.com/designer_akifkazi), Student at K
 
 ### Next Steps
 
-Explore the [PoseNet](https://learn.ml5js.org/#/reference/posenet) and [Facemesh](https://learn.ml5js.org/#/reference/facemesh) models in the ml5.js library. The PoseNet model detects points on the whole body, in the exact same way that HandPose detects it for the hand. The Facemesh model returns points on the face. You should understand the data that these models return and use them in your sketches. 
+Explore the [PoseNet](https://archive-docs.ml5js.org/#/reference/posenet) and [Facemesh](https://docs.ml5js.org/#/reference/facemesh) models in the ml5.js library. The PoseNet model detects points on the whole body, in the exact same way that HandPose detects it for the hand. The Facemesh model returns points on the face. You should understand the data that these models return and use them in your sketches. 
 
 <Callout>
 
@@ -1068,6 +1068,6 @@ Using the Facemesh model, create the following:
 ### Resources
 
 - [ml5.js library](https://ml5js.org/)
-- [ml5.js Handpose Examples](https://learn.ml5js.org/#/reference/handpose?id=examples)
+- [ml5.js Handpose Examples](https://docs.ml5js.org/#/reference/handpose?id=examples)
 - [Computer Scientist Explains ML in 5 Levels](https://www.youtube.com/watch?v=5q87K1WaoFI\&t=665s)
-- [Conditionals and Interactivity in p5.js](/tutorials/conditionals-and-interactivity/)
+- [Conditionals and Interactivity in p5.js](https://p5js.org/tutorials/conditionals-and-interactivity/)

--- a/src/content/tutorials/en/speak-with-your-hands.mdx
+++ b/src/content/tutorials/en/speak-with-your-hands.mdx
@@ -124,7 +124,7 @@ function drawKeypoints() {
 
 Let's dive into how [ml5.js](https://ml5js.org/) works, especially with the [HandPose](https://docs.ml5js.org/#/reference/handpose) model. [ml5.js](https://ml5js.org/) is a tool made to help us all use machine learning easily. It works great with p5.js, which means our computer can "see, hear, and understand" stuff using a camera, just like we do!
 
-The [HandPose](https://learn.ml5js.org/#/reference/handpose) model uses image recognition algorithms to recognize your hand. It can spot your palm and fingers and keep track of them as you move your hand around in front of the camera. It can only detect one one hand at a time, but it can identify 21 different key-points on the hand in 3D space. This means that it gives us the x-y-z coordinates of each point. These key-points show us key parts of your palm and fingers. 
+The [HandPose](https://docs.ml5js.org/#/reference/handpose) model uses image recognition algorithms to recognize your hand. It can spot your palm and fingers and keep track of them as you move your hand around in front of the camera. It can only detect one one hand at a time, but it can identify 21 different key-points on the hand in 3D space. This means that it gives us the x-y-z coordinates of each point. These key-points show us key parts of your palm and fingers. 
 
 Now let’s start with the static image to see this in action.
 


### PR DESCRIPTION
fix #507 

1. all the docs point to the new site
2. the p5js example, I change to my link, but all what I did is to point to `0.12.2` version so the code can run.
