### PR TITLE
Fix typo (dpeth -> depth)

### DIFF
--- a/src/content/reference/en/p5.Framebuffer/depth.mdx
+++ b/src/content/reference/en/p5.Framebuffer/depth.mdx
@@ -4,7 +4,7 @@ module: Rendering
 submodule: ''
 file: src/webgl/p5.Framebuffer.js
 description: >
-  <p>An object that stores the framebuffer's dpeth data.</p>
+  <p>An object that stores the framebuffer's depth data.</p>
 
   <p>Each framebuffer uses a
 

--- a/src/content/reference/en/p5/p5.Framebuffer.mdx
+++ b/src/content/reference/en/p5/p5.Framebuffer.mdx
@@ -405,7 +405,7 @@ properties:
     path: p5.Framebuffer/color
   depth:
     description: >
-      <p>An object that stores the framebuffer's dpeth data.</p>
+      <p>An object that stores the framebuffer's depth data.</p>
 
       <p>Each framebuffer uses a
 


### PR DESCRIPTION
Hi! Apologies if I'm doing something incorrectly, but I spotted a simple typo on the online reference ([p5.Framebuffer](https://p5js.org/reference/p5/p5.Framebuffer/) & [depth](https://p5js.org/reference/p5.Framebuffer/depth/)), and so made this PR (as well as one on the [main repo](https://github.com/processing/p5.js/pull/7348)).