### PR TITLE
Make library URL fall back to CDN

### DIFF
--- a/src/globals/globals.ts
+++ b/src/globals/globals.ts
@@ -14,8 +14,8 @@ export const sketchesPerPage = 12 as const;
 export const eventsPerPage = 12 as const;
 
 export const cdnLibraryUrl =
-  `/p5.min.js` as const;
-  // `https://cdn.jsdelivr.net/npm/p5@${p5Version}/lib/p5.min.js` as const;
+  process.env.P5_LIBRARY_PATH ||
+  `https://cdn.jsdelivr.net/npm/p5@${p5Version}/lib/p5.min.js` as const;
 export const fullDownloadUrl =
   `https://github.com/processing/p5.js/releases/download/v${p5Version}/p5.zip` as const;
 export const libraryDownloadUrl =


### PR DESCRIPTION
Forgot to commit one change in https://github.com/processing/p5.js-website/pull/605, replacing this hardcoded path with the CDN url.