### PR TITLE
fix: "process" not found on local dev environment

### DIFF
--- a/src/globals/globals.ts
+++ b/src/globals/globals.ts
@@ -14,7 +14,7 @@ export const sketchesPerPage = 12 as const;
 export const eventsPerPage = 12 as const;
 
 export const cdnLibraryUrl =
-  process.env.P5_LIBRARY_PATH ||
+  (typeof process !== "undefined" && process.env.P5_LIBRARY_PATH) ||
   `https://cdn.jsdelivr.net/npm/p5@${p5Version}/lib/p5.min.js` as const;
 export const fullDownloadUrl =
   `https://github.com/processing/p5.js/releases/download/v${p5Version}/p5.zip` as const;


### PR DESCRIPTION
Solves #627

changes:
It also determines if the process object is undefined.