### PR TITLE
added padding in examples header

### DIFF
--- a/src/layouts/CommunityLayout.astro
+++ b/src/layouts/CommunityLayout.astro
@@ -45,7 +45,7 @@ setJumpToState({
 
 <BaseLayout title="Community">
   <section>
-    <h2>{t("Sketches")}<a id="sketches"></a></h2>
+    <h2 class="mb-gutter-md mt-0">{t("Sketches")}<a id="sketches"></a></h2>
     <ul class="content-grid-simple">
       {
         sketches.map((sk, i) => (
@@ -74,7 +74,7 @@ setJumpToState({
   </section>
 
   <section>
-    <h2>{t("Libraries")}<a id="libraries"></a></h2>
+    <h2 class="mb-gutter-md mt-0">{t("Libraries")}<a id="libraries"></a></h2>
     <ul class="content-grid-simple">
       {
         libraries.map((lib) => (
@@ -94,7 +94,7 @@ setJumpToState({
   </section>
 
   <section>
-    <h2>{t("Events")}<a id="events"></a></h2>
+    <h2 class="mb-gutter-md mt-0">{t("Events")}<a id="events"></a></h2>
     <ul class="content-grid-simple">
       {
         events.map((event, i) => (

--- a/src/layouts/ContributeLayout.astro
+++ b/src/layouts/ContributeLayout.astro
@@ -53,7 +53,7 @@ setJumpToState({
 
 <BaseLayout title="Contribute">
   <section>
-    <h2 id="docs">{t("Contributor Docs")}</h2>
+    <h2 id="docs" class="mb-gutter-md mt-0">{t("Contributor Docs")}</h2>
     <div
       class="mb-md grid grid-cols-1 gap-x-gutter-sm md:gap-x-gutter-md lg:grid-cols-2"
     >
@@ -81,7 +81,7 @@ setJumpToState({
     </ul>
   </section>
   <section>
-    <h2 id="donate">{t("Donate")}</h2>
+    <h2 id="donate" class="mb-gutter-md mt-0">{t("Donate")}</h2>
     <ul class="content-grid-simple">
       {
         // This is the same markup as in ContributorDocItem

--- a/src/layouts/ExamplesLayout.astro
+++ b/src/layouts/ExamplesLayout.astro
@@ -58,7 +58,7 @@ setJumpToState(jumpToState);
   {
     examplesByCategory.map((category, i) => (
       <section class="grid">
-        <h2 class="col-span-full mb-gutter-md mt-0"">
+        <h2 class="col-span-full mb-gutter-md mt-0">
           {category.name} <a id={category.name.toLowerCase()} />
         </h2>
         <ul class="col-span-full content-grid-simple">

--- a/src/layouts/ExamplesLayout.astro
+++ b/src/layouts/ExamplesLayout.astro
@@ -58,7 +58,7 @@ setJumpToState(jumpToState);
   {
     examplesByCategory.map((category, i) => (
       <section class="grid">
-        <h2 class="col-span-full">
+        <h2 class="col-span-full mb-gutter-md mt-0"">
           {category.name} <a id={category.name.toLowerCase()} />
         </h2>
         <ul class="col-span-full content-grid-simple">

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -230,7 +230,7 @@ section,
   h2,
   .text-h2 {
     margin-top: var(--gutter-md);
-    margin-bottom: 0;
+    margin-bottom: 0px;
   }
 
   h2,

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -230,7 +230,7 @@ section,
   h2,
   .text-h2 {
     margin-top: var(--gutter-md);
-    margin-bottom: var(--gutter-md);
+    margin-bottom: 0;
   }
 
   h2,

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -230,7 +230,7 @@ section,
   h2,
   .text-h2 {
     margin-top: var(--gutter-md);
-    margin-bottom: 0px;
+    margin-bottom: var(--gutter-md);
   }
 
   h2,


### PR DESCRIPTION
Fixes #573 
A padding is added for the headings of the Example section to give gap between heading and images
![Screenshot (23)](https://github.com/user-attachments/assets/dff9e1ab-abeb-4d38-bdb7-76b12215753a)
