### PR TITLE
added vertical margin to nav items

### DIFF
--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -47,6 +47,10 @@
     line-height: 1.167;
     -webkit-text-stroke-width: 0.15px;
     margin-bottom: var(--spacing-xs);
+    
+    li:not(:first-child) {
+      margin-top: 10px;
+    }
   }
 
   @media (min-width: $breakpoint-tablet) {


### PR DESCRIPTION
Resolves #612 by adding vertical margin to navigation items.

Margin value was picked to match `jump to` section margin value, mentioned in the issue. 

Branch cotaines one failing test although, it also occurs in the main branch. So I decided to leave it as-is. 

Below I attached screenshots showing before and after.


**Desktop before**             |  **Desktop after**
:-------------------------:|:-------------------------:
![p5 - original](https://github.com/user-attachments/assets/635bd614-c347-4f9c-bf25-0d874a7a6a68)  |  ![p5 - padding](https://github.com/user-attachments/assets/8c6b8f08-a22f-457a-9776-df353b1f440e)


**Mobile before**         |  **Mobile after** 
:-------------------------:|:-------------------------:
![p5mobile - original](https://github.com/user-attachments/assets/0c0d8b8b-94cc-4985-a643-08d424a090dd) |  ![p5mobile - padding](https://github.com/user-attachments/assets/2c19fc2e-3774-411d-98ed-0bf9c1fe72c1)

