### PR TITLE
Update en.mdx to unhide old-site banner

### DIFF
--- a/src/content/banner/en.mdx
+++ b/src/content/banner/en.mdx
@@ -2,7 +2,7 @@
 # Give each new message a unique title so we know which one a user closed
 title: "old-site"
 link: "https://archive.p5js.org"
-hidden: true
+hidden: false
 ---
 
 Looking for the old p5.js site? Find it here!


### PR DESCRIPTION
The old-site banner was hidden to avoid having two banners on at the same time but we still want the old-site banner to be shown when the donation banner is closed so this is not the right approach.