### PR TITLE
Fix custom branch builds not generating p5.min.js

### DIFF
--- a/src/scripts/parsers/reference.ts
+++ b/src/scripts/parsers/reference.ts
@@ -36,8 +36,8 @@ export const parseLibraryReference =
 
     // If we're using a custom build of p5 instead of a public release, create
     // a build and copy it to the specified path
-    if (process.env.P5_LIBRARY_PATH) {
-      await createP5Build('p5.js', '../../../public' + process.env.P5_LIBRARY_PATH)
+    if (process.env.PUBLIC_P5_LIBRARY_PATH) {
+      await createP5Build('p5.js', '../../../public' + process.env.PUBLIC_P5_LIBRARY_PATH)
     }
 
     // Copy the reference output so we can process it


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/661

The env var used to determine if we're in a custom branch build had changed, but this check didn't! Updated now.