### PR TITLE
Give class names a prefix on reference pages

### DIFF
--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -82,6 +82,7 @@ const seenParams: Record<string, true> = {};
 
 <BaseLayout
   title={title}
+  titleClass={`reference_${title.toLowerCase()}`}
   subtitle={null}
   variant="item"
   topic="reference"


### PR DESCRIPTION
fixes #650

Before: blur reference page would have .blur CSS style applied 
After: blur reference page has .reference_blur class name, so there are no more collisions with CSS styles