### PR TITLE
Added missing Vimeo videos for Contributors Conference 2015 solves issue #656

### DIFF
--- a/src/content/events/en/contributors-conference-2015.mdx
+++ b/src/content/events/en/contributors-conference-2015.mdx
@@ -11,10 +11,9 @@ relatedPastEvents:
 
 import YouTubeEmbed from '../../../components/YouTubeEmbed/index.astro'
 import Logos from '../../../components/Logos/index.astro'
+import VimeoEmbed from '../../../components/VimeoEmbed/index.astro'
 
 A group of approximately 30 participants gathered spent a week at the [Frank-Ratchye STUDIO for Creative Inquiry](http://studioforcreativeinquiry.org/), advancing the code, documentation, and community outreach tools of the p5.js programming environment. Participants came from as far away as Hong Kong, Seattle, Los Angeles, Boston and New York. Most were working professionals in the fields of creative technology, interaction design, and new-media arts, but the group also included a half-dozen undergraduate and graduate students from Carnegie Mellon’s Schools of Art and Architecture.
-
-
 
 ![A group of participants smile and make a p5 sign with their hands](../images/cc2015/2015_1.jpg)
 ![Woman presenting the p5.js community statement from her laptop](../images/cc2015/2015_3.jpg)
@@ -32,6 +31,27 @@ A group of approximately 30 participants gathered spent a week at the [Frank-Rat
 ![Man in a classroom with a microphone speaking out to a group of participants](../images/cc2015/2015_15.jpg)
 ![Participants jump, smile and throw their hands in the air on a green lawn](../images/cc2015/2015_2.jpg)
 
+Introduction
+<VimeoEmbed id="129140298" />
+Casey Reas
+<VimeoEmbed id="129151416" />
+Johanna Hedva
+<VimeoEmbed id="129151418" />
+Stephanie Pi
+<VimeoEmbed id="129160951" />
+Phoenix Perry
+<VimeoEmbed id="129163155" />
+Taeyoon Choi
+<VimeoEmbed id="129173628" />
+Sara Hendren
+<VimeoEmbed id="129177689" />
+Epic Jefferson
+<VimeoEmbed id="129183825" />
+Chandler McWilliams
+<VimeoEmbed id="129187909" />
+Q&A
+<VimeoEmbed id="129192014" />
+
 ## Participants
 
 [Jason Alderman](http://huah.net/jason/), [Sepand Ansari](http://sepans.com/), [Tega Brain](http://tegabrain.com/), [Emily Chen](https://medium.com/@emchenNYC/), [Andres Colubri](http://andrescolubri.net/), [Luca Damasco](https://twitter.com/lucapodular), [Guy de Bree](http://guydebree.com/), [Christine de Carteret](http://www.cjdecarteret.com/), [Xy Feng](http://xystudio.cc/), [Sarah Groff-Palermo](http://www.sarahgp.com/), [Chris Hallberg](http://www.crhallberg.com/), [Val Head](http://valhead.com/), [Johanna Hedva](http://johannahedva.com/), [Kate Hollenbach](http://www.katehollenbach.com/), [Jennifer Jacobs](http://web.media.mit.edu/~jacobsj/), [Epic Jefferson](http://www.epicjefferson.com/), [Michelle Partogi](http://michellepartogi.com/), [Sam Lavigne](http://lav.io/), [Golan Levin](http://flong.com/), [Cici Liu](http://www.liuchangitp.com/), [Maya Man](http://www.mayaman.cc/), [Lauren McCarthy](http://lauren-mccarthy.com/), [David Newbury](http://www.workergnome.com/), [Paolo Pedercini](http://molleindustria.org/), [Luisa Pereira](http://luisaph.com/), [Miles Peyton](http://mileshiroo.info/), [Caroline Record](http://carolinerecord.com/), [Berenger Recoules](http://b2renger.github.io/), [Stephanie Pi](https://pibloginthesky.wordpress.com/), [Jason Sigal](http://jasonsigal.cc/), [Kevin Siwoff](http://studioindefinit.com/), [Charlotte Stiles](http://charlottestiles.com/)
@@ -39,6 +59,7 @@ A group of approximately 30 participants gathered spent a week at the [Frank-Rat
 ## Diversity
 
 Alongside technical development, one of the main focuses of this conference was outreach, community, and diversity. The conference began with a panel—[Diversity: Seven Voices on Race, Gender, Ability & Class for FLOSS and the Internet](http://studioforcreativeinquiry.org/events/diversity-seven-voices-on-race-gender-ability-class-for-floss-and-the-internet). Organized by [Johanna Hedva](http://johannahedva.com/) and [Lauren McCarthy](http://lauren-mccarthy.com/), the panel took place Tuesday, 25 May 2015 in Kresge Auditorium at Carnegie Mellon University. Speakers included [Maya Man](http://www.mayaman.cc/), [Casey Reas](http://reas.com/), [Johanna Hedva](http://johannahedva.com/), [Stephanie Pi](https://pibloginthesky.wordpress.com/), [Phoenix Perry](http://phoenixperry.com/), [Taeyoon Choi](http://taeyoonchoi.com/), [Sara Hendren](http://ablersite.org/), [Epic Jefferson](http://www.epicjefferson.com/), and [Chandler McWilliams](http://chandlermcwilliams.com/).
+
 ![A poster about diversity for FLOSS and the Internet](../images/cc2015/diversity_640.jpg)
 
 ## Support


### PR DESCRIPTION
This pull request updates the Contributors Conference 2015 event page by adding missing Vimeo videos from the archived content. The following videos have been embedded using the VimeoEmbed component:  
As advised by @davepagurek 

- Casey Reas
- Johanna Hedva
- Stephanie Pi
- Phoenix Perry
- Taeyoon Choi
- Sara Hendren
- Epic Jefferson
- Chandler McWilliams
- Q&A

Additionally, I’ve ensured that the video layout aligns with the existing structure of the page. All changes have been verified, and the content should now match the original archived event page.

Changes Made:
Embedded Vimeo videos for key speakers and Q&A sessions.
Used the existing VimeoEmbed component to maintain consistency with the website’s design.
Corrected the visual hierarchy of the content by stacking the videos below the images.