### PR TITLE
Display examples interleaved within reference docs

### DIFF
--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -76,6 +76,10 @@ const relatedReferences = [
 
 const seenParams: Record<string, true> = {};
 
+const descriptionParts = description.split(
+  /(<pre><code class="language-js example">[\s\S]+?<\/code><\/pre>)/gm
+);
+
 ---
 
 <Head title={entry.data.title} locale={currentLocale} />
@@ -101,10 +105,32 @@ const seenParams: Record<string, true> = {};
           <p>{t('experimentalApi', 'description')}</p>
         </div>
       )}
-      <div
-        set:html={description}
-        class="[&_a]:text-type-magenta-dark [&_a]:!decoration-type-magenta-dark mb-xl reference-item rendered-markdown"
-      />
+      {descriptionParts.map((part) => {
+        if (part.startsWith('<pre')) {
+          const exampleCode = part
+            .replace(/<pre><code class="language-js example">/, '')
+            .replace(/<\/code><\/pre>/, '');
+
+          return (
+            <CodeEmbed
+              client:load
+              initialValue={exampleCode}
+              previewable
+              editable
+              lazyLoad={false}
+              allowSideBySide={true}
+              includeSound={entry.data.module === 'p5.sound'}
+            />
+          )
+        } else {
+          return (
+            <div
+              set:html={part}
+              class="[&_a]:text-type-magenta-dark [&_a]:!decoration-type-magenta-dark mb-xl reference-item rendered-markdown"
+            />
+          );
+        }
+      })}
       {
         examples && (
           <div class="mb-xl">

--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -80,7 +80,7 @@ const getModulePath = (doc: ReferenceClassDefinition | ReferenceClassItem) => {
     docClass = doc.class;
   } else {
     if (!doc.module) console.log(doc)
-    docClass = doc.module.startsWith("p5.") ? doc.module : "p5";
+    docClass = doc.module?.startsWith("p5.") ? doc.module : "p5";
   }
 
   return path.join(prefix, docClass, sortedModule);


### PR DESCRIPTION
I made some updates to p5 here https://github.com/processing/p5.js/pull/7466 and tested this with `npm run custom:dev https://github.com/processing/p5.js.git#interleaved-examples` on this branch.

So the idea is to allow examples to be put in between other sections of the docs so they can stay more contextual.

In the reference, you can add the `example` tag to a code block like this:


    Here are some docs

    Here's an interleaved example:

    ```js example
    console.log('test')
    ```

    and here's more docs!

In https://github.com/processing/p5.js/pull/7466, I tried pulling an example for `image()` up in between other stuff, and it looks like this:

<img width="1394" alt="image" src="https://github.com/user-attachments/assets/5d78a9f3-4ec9-4117-a640-1ba6e6338c4f" />

### Notes

- It's parsing `<pre><code class="example">` blocks out of the description rather than using a different JSON structure because that would invalidate the existing structure in the reference section of the site
- It doesn't use *quite* the same syntax as before with `@example` at the end in the reference in the p5 codebase. Both can be used in one reference without issue at least
- I'm not sure if the existing reference linting will work since this is part of the description body and not the examples section
- I'm currently using a nasty regex to split the examples out of the description, that could definitely be cleaned up
