### PR TITLE
Fix color pickers getting cut off

### DIFF
--- a/src/components/CodeEmbed/index.jsx
+++ b/src/components/CodeEmbed/index.jsx
@@ -45,7 +45,7 @@ export const CodeEmbed = (props) => {
   const largeSketch = previewWidth && previewWidth > 770 - 60;
 
   // Quick hack to make room for DOM that gets added below the canvas by default
-  const domMatch = /create(Button|Select|P|Div|Input)/.exec(initialCode);
+  const domMatch = /create(Button|Select|P|Div|Input|ColorPicker)/.exec(initialCode);
   if (domMatch && previewHeight) {
     previewHeight += 100;
   }


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/435

Before:

![image](https://github.com/user-attachments/assets/1017b9d8-0492-4ba0-a41f-e49aed32418f)

After:

![image](https://github.com/user-attachments/assets/71ab748e-bb96-4c44-b01c-dbf536b5502b)
