### PR TITLE
Fix reference syntax box not having correct color in dark mode

### DIFF
--- a/src/components/MethodSignature/index.astro
+++ b/src/components/MethodSignature/index.astro
@@ -32,7 +32,7 @@ const signature = `${name}(${formattedParams})`;
 {
   formattedParams.map((params) => (
     <CodeContainer>
-      <span>{`${name}(${params})`}</span>
+      <span class="text-black">{`${name}(${params})`}</span>
       <div class="absolute top-xs right-xs">
         <CopyCodeButton client:load textToCopy={signature} />
       </div>


### PR DESCRIPTION
Fixes #680

Color propogated down from body in dark mode (accent color) is being inverted by a filter in the code box when it shouldn't have. To avoid affecting other inline code box, direct Tailwind class is added to target only the syntax box.