### PR TITLE
fix : #709 Scroll removed and code cell now expands to fit code

### DIFF
--- a/src/components/AnnotatedCode/index.astro
+++ b/src/components/AnnotatedCode/index.astro
@@ -95,7 +95,7 @@ for (const attr of codeTag.attributes) {
         return (
           <tr class="[&>*]:align-top [&>*]:m-0 [&>*:not(:first-child)]:py-2 [&>*:not(:first-child)]:pl-6 [&>*:not(:first-child)]:max-w-xl">
             <td class="align-top p-0" style="height:100%; margin:0">
-            <pre {...preAttrs} style={`${getPreStyle(i)};overflow:visible;white-space:pre-wrap;word-wrap:break-word;`}><code {...codeAttrs} set:html={lineNodes.map((n) => n.outerHTML).join('\n')} /></pre>
+            <pre {...preAttrs} style={`${getPreStyle(i)};overflow:visible;white-space:pre-wrap;word-wrap:break-word;height:100%;`}><code {...codeAttrs} set:html={lineNodes.map((n) => n.outerHTML).join('\n')} /></pre>
             </td>
             {props.columns ? (
               <Fragment set:html={row.slot ? Astro.slots.render(row.slot) : undefined} />

--- a/src/components/AnnotatedCode/index.astro
+++ b/src/components/AnnotatedCode/index.astro
@@ -95,7 +95,7 @@ for (const attr of codeTag.attributes) {
         return (
           <tr class="[&>*]:align-top [&>*]:m-0 [&>*:not(:first-child)]:py-2 [&>*:not(:first-child)]:pl-6 [&>*:not(:first-child)]:max-w-xl">
             <td class="align-top p-0" style="height:100%; margin:0">
-            <pre {...preAttrs} style={`${getPreStyle(i)};height:100%`}><code {...codeAttrs} set:html={lineNodes.map((n) => n.outerHTML).join('\n')} /></pre>
+            <pre {...preAttrs} style={`${getPreStyle(i)};overflow:visible;white-space:pre-wrap;word-wrap:break-word;`}><code {...codeAttrs} set:html={lineNodes.map((n) => n.outerHTML).join('\n')} /></pre>
             </td>
             {props.columns ? (
               <Fragment set:html={row.slot ? Astro.slots.render(row.slot) : undefined} />


### PR DESCRIPTION
Fixes issue #709
Here are the screenshots of before and after the fix
#### Before :
![Screenshot 2025-03-02 131321](https://github.com/user-attachments/assets/7a488c6f-ec5c-41d5-971d-7c63e1474ffc)

#### After :
![Screenshot 2025-03-02 131109](https://github.com/user-attachments/assets/eb354146-6e8a-4234-8968-2a60beb91b32)

@davepagurek
Let me know if there are any other changes require, i would love to address them.