### PR TITLE
Clarify that `calculateBoundingBox` is aligned to the axes.

### DIFF
--- a/src/content/reference/en/p5.Geometry/calculateBoundingBox.mdx
+++ b/src/content/reference/en/p5.Geometry/calculateBoundingBox.mdx
@@ -4,10 +4,10 @@ module: Shape
 submodule: 3D Primitives
 file: src/webgl/p5.Geometry.js
 description: >
-  <p>Calculates the position and size of the smallest box that contains the
+  <p>Calculates the position and size of the smallest axes-aligned box that contains the
   geometry.</p>
 
-  <p>A bounding box is the smallest rectangular prism that contains the entire
+  <p>A bounding box is the smallest rectangular prism aligned with the axes that contains the entire
 
   geometry. It's defined by the box's minimum and maximum coordinates along
 

--- a/src/content/reference/en/p5/p5.Geometry.mdx
+++ b/src/content/reference/en/p5/p5.Geometry.mdx
@@ -275,10 +275,10 @@ example:
 methods:
   calculateBoundingBox:
     description: >
-      <p>Calculates the position and size of the smallest box that contains the
+      <p>Calculates the position and size of the smallest axes-aligned box that contains the
       geometry.</p>
 
-      <p>A bounding box is the smallest rectangular prism that contains the
+      <p>A bounding box is the smallest rectangular prism aligned with the axes that contains the
       entire
 
       geometry. It's defined by the box's minimum and maximum coordinates along


### PR DESCRIPTION
The current docs for `calculateBoundingBox` are not quite correct, since the "smallest rectangular prism" containing the geometry need not be aligned to the axes.