### PR TITLE
Fixed incorrect example in mouseWheel reference.

### DIFF
--- a/src/content/reference/en/p5/mouseWheel.mdx
+++ b/src/content/reference/en/p5/mouseWheel.mdx
@@ -97,7 +97,7 @@ example:
       background(200);
 
       // Draw the circle
-      circle(circleSize, 50, 50);
+      circle(width / 2, height / 2, circleSize);
     }
 
     // Increment circleSize when the user scrolls the mouse wheel.


### PR DESCRIPTION
The example incorrectly modified the X coordinate instead of the circle size. 
This fix correctly centers the circle while allowing size changes.

Closes #7613

