### PR TITLE
Fix: Exclude @swc/html from Vite dependencies to fix Windows dev issue

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -63,6 +63,9 @@ export default defineConfig({
     },
   },
   vite: {
+    optimizeDeps: {
+      exclude: ["@swc/html"]
+    },
     rollupOptions: {
       external: ["/src/scripts/*"],
     },


### PR DESCRIPTION
resolves #723 

This PR addresses the issue where running `npm run dev` on Windows fails due to `@swc/html` being incorrectly imported during development. The error occurs because `.node` files are not properly handled by Astro’s dev mode.

`npm run dev` now runs successfully on Windows.
`npm run build` works as expected.