### PR TITLE
Handle deprecation notes in reference items

### DIFF
--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -3,6 +3,7 @@ import { useMemo, useRef, useState } from "preact/hooks";
 import { type JSX } from "preact";
 import { Icon } from "../Icon";
 import flask from "@src/content/ui/images/icons/flask.svg?raw"; 
+import warning from "@src/content/ui/images/icons/warning.svg?raw"; 
 
 type ReferenceDirectoryEntry = ReferenceDocContentItem & {
   data: {
@@ -42,6 +43,10 @@ const getOneLineDescription = (description: string): string => {
   const firstParagraphRegex = /^<p>(.*?)<\/p>/;
   let [oneLineDescription] = description.replace(/\n/g, " ").trim()
     .match(firstParagraphRegex) ?? [];
+
+  if (!oneLineDescription && description) {
+    oneLineDescription = description;
+  }
 
   if(oneLineDescription){
     oneLineDescription = oneLineDescription
@@ -106,6 +111,12 @@ export const ReferenceDirectoryWithFilter = ({
                   <div
                     className="inline-block mr-2 w-[16px] h-[16px] mb-[-2px]"
                     dangerouslySetInnerHTML={{ __html: flask }}
+                  />
+                )}
+                {entry.data.deprecated && (
+                  <div
+                    className="inline-block mr-2 w-[16px] h-[16px] mb-[-2px]"
+                    dangerouslySetInnerHTML={{ __html: warning }}
                   />
                 )}
                 <span dangerouslySetInnerHTML={{ __html: entry.data.title }} />

--- a/src/content/reference/config.ts
+++ b/src/content/reference/config.ts
@@ -64,6 +64,7 @@ export const referenceSchema = z.object({
   submodule: z.string().optional(),
   file: z.string(),
   description: z.string().optional(),
+  deprecated: z.string().optional(),
   line: z.number().or(z.string().transform((v) => parseInt(v, 10))),
   params: z.array(paramSchema).optional(),
   overloads: z.array(z.object({ params: z.array(paramSchema) })).optional(),

--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -186,6 +186,7 @@ calloutTitles:
   "Try this!": "Try this!"
   Tip: Tip
   Note: Note
+  Warning: Warning
 LibrariesLayout:
   View All: View All
   Featured: Featured

--- a/src/content/ui/images/icons/warning.svg
+++ b/src/content/ui/images/icons/warning.svg
@@ -1,0 +1,5 @@
+<svg width="100%" height="100%" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 3L2 27H28L15 3Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+<path d="M15 10V19" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="15" cy="22.3361" r="1" stroke-width="2" stroke="currentColor"/>
+</svg>

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -20,6 +20,7 @@ import type {
 import { setJumpToState } from "../globals/state";
 import { p5Version } from "../globals/p5-version";
 import flask from "@src/content/ui/images/icons/flask.svg?raw"; 
+import warning from "@src/content/ui/images/icons/warning.svg?raw"; 
 
 const { entry, relatedEntries } = Astro.props;
 const currentLocale = getCurrentLocale(Astro.url.pathname);
@@ -104,6 +105,18 @@ const descriptionParts = description.split(
             {t('experimentalApi', 'title')}
           </h5>
           <p>{t('experimentalApi', 'description')}</p>
+        </div>
+      )}
+      {entry.data.deprecated && (
+        <div class="deprecated">
+          <h5>
+            <div
+              class="inline-block mr-2 w-[20px] h-[20px] mb-[-2px]"
+              set:html={warning}
+            />
+            {t('calloutTitles', 'Warning')}
+          </h5>
+          <p set:html={entry.data.deprecated} />
         </div>
       )}
       {descriptionParts.map((part) => {

--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -255,6 +255,7 @@ const convertToMDX = async (
     file: doc.file.replace(/.*p5\.js\/(.*)/, "$1"),
     description: doc.description ?? "",
     line: doc.line,
+    deprecated: doc.deprecated,
   } as Record<string, unknown>;
 
   // Add specific frontmatter based on the type of doc

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -291,7 +291,7 @@ pre.code-box,
   white-space: break-spaces;
 }
 
-.callout, .experimental {
+.callout, .experimental, .deprecated {
   padding: var(--spacing-sm);
   border-radius: 20px;
   background-color: var(--bg-magenta-20);
@@ -308,7 +308,7 @@ pre.code-box,
   }
 }
 
-.experimental {
+.experimental, .deprecated {
   background-color: var(--bg-yellow);
 }
 

--- a/types/parsers.interface.ts
+++ b/types/parsers.interface.ts
@@ -49,7 +49,7 @@ export type ReferenceOverload = {
 export type ReferenceOverloads = ReferenceOverload[];
 
 /* Represents the definition of a class within the project, including its properties, methods, and inheritance information. */
-export interface ReferenceClassDefinition extends Chainable {
+export interface ReferenceClassDefinition extends Chainable, Deprecatable, MaybeBeta {
   name: string; // The name of the class.
   shortname: string; // A shorter or abbreviated name for the class.
   classitems: ReferenceParam[]; // Parameters or properties of the class.
@@ -92,6 +92,10 @@ interface Chainable {
   chainable: number;
 }
 
+interface Deprecatable {
+  deprecated?: string; // If this item is deprecated, a description of why.
+}
+
 /* Represents the return value of a method or constructor */
 interface Return {
   description: string;
@@ -103,7 +107,7 @@ interface MaybeBeta {
 }
 
 /* Represents a method within a class */
-export interface ReferenceClassItemMethod extends BaseClassItem, Chainable, MaybeBeta {
+export interface ReferenceClassItemMethod extends BaseClassItem, Chainable, MaybeBeta, Deprecatable {
   params?: ReferenceParam[];
   return?: Return;
   example?: string[];
@@ -119,7 +123,7 @@ interface MethodOverload {
 }
 
 /* Represents a property within a class */
-export interface ReferenceClassItemProperty extends BaseClassItem {
+export interface ReferenceClassItemProperty extends BaseClassItem, Deprecatable {
   type: string;
 }
 


### PR DESCRIPTION
This adds a warning icon to items listed as deprecated, and shows whatever description is given in the data (e.g. the content in https://github.com/processing/p5.js/pull/7624.)

### Directory:
<img width="1696" alt="image" src="https://github.com/user-attachments/assets/d54ff8f7-827d-44ed-8113-0a81a0228ea7" />

### Reference item:
<img width="1705" alt="Screenshot 2025-03-12 at 5 11 32 PM" src="https://github.com/user-attachments/assets/ea62ee6c-cc68-4d0e-806e-d262a17f5c69" />
