### PR TITLE
fixed yuidoc path for build reference.ts

### DIFF
--- a/src/scripts/parsers/reference.ts
+++ b/src/scripts/parsers/reference.ts
@@ -128,8 +128,7 @@ export const saveYuidocOutput = async (
     const inPath = path.join(__dirname, "in", inDirName);
     console.log(inPath)
     await new Promise((resolve, reject) => {
-      exec(`yuidoc -p --outdir ${outputFilePath} ${flags} ${inputPath}`, { cwd: inPath }, (error, stdout) => {
-        if (error) {
+exec(`yuidoc -p --outdir "${outputFilePath.replace(/"/g, '\\"')}" ${flags} ${inputPath}`, { cwd: inPath }, (error, stdout) => {        if (error) {
           console.error(`Error running YUIDoc command: ${error}`);
           reject(error);
         } else {


### PR DESCRIPTION
Previously if the user has space in their path then `npm run build:reference` gives error and tries to delete the user folder 
fixed it