### PR TITLE
fix: add trailing slashes to broken links for proper navigation

### DIFF
--- a/src/components/Footer/index.astro
+++ b/src/components/Footer/index.astro
@@ -26,25 +26,25 @@ const bannerEntry = await getEntry("banner", currentLocale);
   <div>
     <div class="mb-5" id="resources-footer-category">{t("Resources")}</div>
     <ul aria-labelledby="resources-footer-category">
-      <li><a href="/reference">{t("Reference")}</a></li>
-      <li><a href="/tutorials">{t("Tutorials")}</a></li>
-      <li><a href="/examples">{t("Examples")}</a></li>
-      <li><a href="/contribute">{t("Contribute")}</a></li>
-      <li><a href="/community">{t("Community")}</a></li>
-      <li><a href="/about">{t("About")}</a></li>
+      <li><a href="/reference/">{t("Reference")}</a></li>
+      <li><a href="/tutorials/">{t("Tutorials")}</a></li>
+      <li><a href="/examples/">{t("Examples")}</a></li>
+      <li><a href="/contribute/">{t("Contribute")}</a></li>
+      <li><a href="/community/">{t("Community")}</a></li>
+      <li><a href="/about/">{t("About")}</a></li>
       <li><a href="https://editor.p5js.org">{t("Start Coding")}</a></li>
-      <li><a href="/donate">{t("Donate")}</a></li>
+      <li><a href="/donate/">{t("Donate")}</a></li>
     </ul>
   </div>
   <div class="lg:col-span-2 grid grid-cols-subgrid">
     <div>
       <div class="mb-5" id="info-footer-category">{t("Information")}</div>
       <ul aria-labelledby="info-footer-category">
-        <li><a href="/download">{t("Download")}</a></li>
-        <li><a href="/contact">{t("Contact")}</a></li>
-        <li><a href="/copyright">{t("Copyright")}</a></li>
-        <li><a href="/privacy-policy">{t("Privacy Policy")}</a></li>
-        <li><a href="/terms-of-use">{t("Terms of Use")}</a></li>
+        <li><a href="/download/">{t("Download")}</a></li>
+        <li><a href="/contact/">{t("Contact")}</a></li>
+        <li><a href="/copyright/">{t("Copyright")}</a></li>
+        <li><a href="/privacy-policy/">{t("Privacy Policy")}</a></li>
+        <li><a href="/terms-of-use/">{t("Terms of Use")}</a></li>
       </ul>
     </div>
     <div class="lg:col-start-2 mt-xl lg:mt-0">

--- a/src/content/text-detail/en/about.mdx
+++ b/src/content/text-detail/en/about.mdx
@@ -36,6 +36,6 @@ Community values:
 </div>
 
 <div class='mt-xl'>
-<LinkButton variant='link' url='/contribute/access'>Access Statement</LinkButton>
-<LinkButton variant='link' url='/code-of-conduct'>Code of Conduct</LinkButton>
+<LinkButton variant='link' url='/contribute/access/'>Access Statement</LinkButton>
+<LinkButton variant='link' url='/code-of-conduct/'>Code of Conduct</LinkButton>
 </div>

--- a/src/content/text-detail/es/about.mdx
+++ b/src/content/text-detail/es/about.mdx
@@ -29,6 +29,6 @@ Valores de la comunidad:
 </div>
 
 <div class='mt-xl'>
-<LinkButton variant='link' url='/contribute/access'>Access Statement</LinkButton>
-<LinkButton variant='link' url='/code-of-conduct'>Code of Conduct</LinkButton>
+<LinkButton variant='link' url='/contribute/access/'>Access Statement</LinkButton>
+<LinkButton variant='link' url='/code-of-conduct/'>Code of Conduct</LinkButton>
 </div>

--- a/src/content/text-detail/hi/about.mdx
+++ b/src/content/text-detail/hi/about.mdx
@@ -29,6 +29,6 @@ P5.js समुदाय प्रौद्योगिकी के साथ �
 </div>
 
 <div class='mt-xl'>
-<LinkButton variant='link' url='/contribute/access'>प्रवेश विवरण</LinkButton>
-<LinkButton variant='link' url='/code-of-conduct'>आचार संहिता</LinkButton>
+<LinkButton variant='link' url='/contribute/access/'>प्रवेश विवरण</LinkButton>
+<LinkButton variant='link' url='/code-of-conduct/'>आचार संहिता</LinkButton>
 </div>

--- a/src/content/text-detail/ko/about.mdx
+++ b/src/content/text-detail/ko/about.mdx
@@ -29,6 +29,6 @@ p5.js 커뮤니티는 기술을 통해 예술과 디자인에 관련된 탐구�
 </div>
 
 <div class='mt-xl'>
-<LinkButton variant='link' url='/contribute/access'>접근성 성명서</LinkButton>
-<LinkButton variant='link' url='/code-of-conduct'>행동 강령</LinkButton>
+<LinkButton variant='link' url='/contribute/access/'>접근성 성명서</LinkButton>
+<LinkButton variant='link' url='/code-of-conduct/'>행동 강령</LinkButton>
 </div>

--- a/src/content/text-detail/zh-Hans/about.mdx
+++ b/src/content/text-detail/zh-Hans/about.mdx
@@ -29,6 +29,6 @@ p5.js 鼓励通过迭代编码来实现创意表达。我们重视代码开源�
 </div>
 
 <div class='mt-xl'>
-<LinkButton variant='link' url='/contribute/access'>可及性声明</LinkButton>
-<LinkButton variant='link' url='/code-of-conduct'>行为规范</LinkButton>
+<LinkButton variant='link' url='/contribute/access/'>可及性声明</LinkButton>
+<LinkButton variant='link' url='/code-of-conduct/'>行为规范</LinkButton>
 </div>

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -78,7 +78,7 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
         ))
       }
     </ul>
-    <LinkButton variant="link" url="/people" class="mt-md min-w-[220px]"
+    <LinkButton variant="link" url="/people/" class="mt-md min-w-[220px]"
       >{t("All People")}</LinkButton
     >
   </section>

--- a/src/layouts/HomepageLayout.astro
+++ b/src/layouts/HomepageLayout.astro
@@ -41,7 +41,7 @@ setJumpToState(null);
       class="col-span-2 lg:col-span-3 order-1 grid grid-cols-subgrid content-start"
     >
       <h2 class="col-span-3">{data.referenceHeaderText}</h2>
-      <LinkButton class="col-span-1 w-full" variant="link" url="/reference"
+      <LinkButton class="col-span-1 w-full" variant="link" url="/reference/"
         >{t("Reference")}</LinkButton
       >
     </div>
@@ -49,7 +49,7 @@ setJumpToState(null);
       class="col-span-2 lg:col-span-3 order-2 lg:order-4 grid grid-cols-subgrid content-start"
     >
       <h2 class="col-span-full">{data.examplesHeaderText}</h2>
-      <LinkButton class="col-span-1 w-full" variant="link" url="/examples"
+      <LinkButton class="col-span-1 w-full" variant="link" url="/examples/"
         >{t("Examples")}</LinkButton
       >
     </div>
@@ -64,7 +64,7 @@ setJumpToState(null);
   <div class="content-grid-simple mb-xl">
     <div class="col-span-2 lg:col-span-3 grid grid-cols-subgrid content-start">
       <h2 class="col-span-3">{data.communityHeaderText}</h2>
-      <LinkButton class="col-span-1 w-full" variant="link" url="/community"
+      <LinkButton class="col-span-1 w-full" variant="link" url="/community/"
         >{t("Community")}</LinkButton
       >
     </div>
@@ -84,7 +84,7 @@ setJumpToState(null);
     <div class="grid grid-cols-subgrid col-span-1 lg:col-span-2">
       <h2 class="col-span-2">{t("Donate to p5.js")}</h2>
       <div class="col-span-1">
-        <LinkButton class="w-full" variant="link" url="/donate"
+        <LinkButton class="w-full" variant="link" url="/donate/"
           >{t("Donate")}</LinkButton
         >
       </div>
@@ -92,7 +92,7 @@ setJumpToState(null);
     <div class="grid grid-cols-subgrid col-span-1 lg:col-span-2">
       <h2 class="col-span-2">{t("Download p5.js")}</h2>
       <div class="col-span-1">
-        <LinkButton class="w-full" variant="link" url="/download"
+        <LinkButton class="w-full" variant="link" url="/download/"
           >{t("Download Library")}</LinkButton
         >
       </div>


### PR DESCRIPTION
resolves #727 

This PR fixes broken links that were missing trailing slashes, which caused incorrect navigation. Initially, the focus was on fixing the **Code of Conduct** and **Access Statement** links, but I found and fixed several other links with the same issue.

- Ensured all links have a trailing slash where necessary.
- Verified changes locally to confirm proper navigation.
