### PR TITLE
Added scripts to clear parsers/in and parsers/out after build:reference

### DIFF
--- a/src/scripts/parsers/reference.ts
+++ b/src/scripts/parsers/reference.ts
@@ -1,4 +1,4 @@
-import { cloneLibraryRepo, p5RepoUrl, readFile } from "../utils";
+import { cloneLibraryRepo,cleanUpDirectory, p5RepoUrl, readFile } from "../utils";
 import fs from "fs/promises";
 import { exec, execSync } from "child_process";
 import path from "path";
@@ -12,6 +12,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const localPath = path.join(__dirname, "in", "p5.js");
 const localSoundPath = path.join(__dirname, "in", "p5.sound.js");
 const yuidocOutputPath = path.join(__dirname, "out")
+
+//Directory to clean after cloning the libraries
+const parsersInPath = path.join(__dirname, "in");
+const parsersOutPath = path.join(__dirname, "out");
 
 /**
  * Main function to clone the p5.js library and save the YUIDoc output to a file
@@ -77,6 +81,10 @@ export const parseLibraryReference =
     );
 
     await serveYuidocOutput('data');
+
+    //delete the cloned directories
+    await cleanUpDirectory(parsersInPath );
+    await cleanUpDirectory(parsersOutPath );
     return combined;
   };
 

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -304,3 +304,15 @@ export const rewriteRelativeMdLinks = (markdownText: string): string => {
     return `[${linkText}](${updatedUrl})`;
   });
 };
+/**
+ * Deletes the contents of the given directory.
+ * @param dirPath Path to the directory to clean up.
+ */
+export const cleanUpDirectory = async (dirPath: string) => {
+  try {
+    await fs.rm(dirPath, { recursive: true, force: true });
+    console.log(`Cleaned up directory: ${dirPath}`);
+  } catch (err) {
+    console.error(`Error cleaning up directory ${dirPath}: ${err}`);
+  }
+};


### PR DESCRIPTION
Fixes the issue #722 

The following changes had been done in this PR
1. Added a function `cleanUpDirectory` in `scripts/utils.ts` 
2.  Call that function in `reference.ts` which will be executed at the end of all the processes to clean the cloned `p5.js` and `p5.sound.js` repo in `scripts/parsers/in` and `out` too

after that dev server is starting faster without any errors

@davepagurek tell me if anything need changes, i would love to do so 