### PR TITLE
Fix typos in examples

### DIFF
--- a/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/code.js
+++ b/src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/code.js
@@ -34,7 +34,7 @@ function setup() {
   circle(560, 100, 100);
 
   // Draw arc (compare to ellipse()) as eyelid
-  // x, y, width, heght, start angle, stop angle, mode
+  // x, y, width, height, start angle, stop angle, mode
   arc(540, 100, 300, 100, 180, 360, CHORD);
 
   // Draw line

--- a/src/content/examples/en/07_Repetition/More/Radial_Gradient.js
+++ b/src/content/examples/en/07_Repetition/More/Radial_Gradient.js
@@ -1,6 +1,6 @@
 /*
  * @name Radial Gradient
- * @arialabel Three circles on a black background. The middle circle is completely visible but the user can only see half of the other two. There is a gradiant from the center of the circle to the outer edge that changes every second
+ * @arialabel Three circles on a black background. The middle circle is completely visible but the user can only see half of the other two. There is a gradient from the center of the circle to the outer edge that changes every second
  * @description Draws a series of concentric circles to create a gradient
  * from one color to another.
  */

--- a/src/content/examples/en/09_Angles_And_Motion/More/polartocartesian.js
+++ b/src/content/examples/en/09_Angles_And_Motion/More/polartocartesian.js
@@ -7,7 +7,7 @@
  */
 let r;
 
-// Angle and angular velocity, accleration
+// Angle and angular velocity, acceleration
 let theta;
 let theta_vel;
 let theta_acc;

--- a/src/content/examples/en/15_Math_And_Physics/More/WolframCA.js
+++ b/src/content/examples/en/15_Math_And_Physics/More/WolframCA.js
@@ -44,8 +44,8 @@ function draw() {
 function generate() {
   // First we create an empty array for the new values
   let nextgen = Array(cells.length);
-  // For every spot, determine new state by examing current state, and neighbor states
-  // Ignore edges that only have one neighor
+  // For every spot, determine new state by examining current state, and neighbor states
+  // Ignore edges that only have one neighbor
   for (let i = 1; i < cells.length-1; i++) {
     let left   = cells[i-1];   // Left neighbor state
     let me     = cells[i];     // Current state


### PR DESCRIPTION
I found a few typos in some of the examples.