### PR TITLE
Added ts-ignore check

### DIFF
--- a/.github/scripts/detect_ts_ignore.py
+++ b/.github/scripts/detect_ts_ignore.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Script to detect and report usage of @ts-ignore comments in TypeScript."""
+
+import argparse
+import re
+import sys
+import logging
+import os
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s: %(message)s",
+)
+
+
+
+IGNORED_EXTENSIONS = {
+    ".avif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".webp",
+    ".gif",
+    ".bmp",
+    ".ico",
+    ".svg",
+    ".mp4",
+    ".webm",
+    ".mov",
+    ".avi",
+    ".mkv",
+    ".mp3",
+    ".wav",
+    ".ogg",
+    ".pdf",
+    ".doc",
+    ".docx",
+}
+
+
+def is_binary_file(filepath: str) -> bool:
+    """Check if a file is binary based on its extension.
+
+    Args:
+        filepath (str): The file path.
+
+    Returns:
+        bool: True if the file should be ignored, False otherwise.
+    """
+    return os.path.splitext(filepath)[1].lower() in IGNORED_EXTENSIONS
+
+def check_ts_ignore(files: list[str]) -> int:
+    """Check for occurrences of '@ts-ignore' in the given files, allowing justified ones."""
+    ts_ignore_found = False
+
+    for file in files:
+        if not is_binary_file(file):
+            try:
+                logging.info("Checking file: %s", file)
+                with open(file, encoding="utf-8") as f:
+                    previous_line = ""  
+
+                    for line_num, line in enumerate(f, start=1):
+                        if "@ts-ignore" in line.strip():
+                            if not re.search(r"//\s*Reason:.*", previous_line.strip()):
+                                print(f"❌ Error: '@ts-ignore' found in {file} at line {line_num}")
+                                logging.debug("Found @ts-ignore without Reason: in line: %s", line.strip())
+                                ts_ignore_found = True
+                        previous_line = line
+
+            except FileNotFoundError:
+                logging.warning("File not found: %s", file)
+            except OSError:
+                logging.exception("Could not read %s", file)
+
+    if not ts_ignore_found:
+        print("✅ No '@ts-ignore' comments found in the files.")
+
+    return 1 if ts_ignore_found else 0
+
+
+def main() -> None:
+    """Main function to parse arguments and run the check.
+
+    This function sets up argument parsing for file paths and runs the ts-ignore
+    check on the specified files.
+
+    Args:
+        None
+
+    Returns:
+        None: The function exits the program with status code 0 if no ts-ignore
+        comments are found, or 1 if any are detected.
+    """
+    parser = argparse.ArgumentParser(
+        description="Check for @ts-ignore in changed files.",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="+",
+        help="List of changed files",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    ts_files = [f for f in args.files if f.endswith((".ts", ".tsx"))]
+    if not ts_files:
+        logging.info("No TypeScript files to check.")
+        sys.exit(0)
+
+    exit_code = check_ts_ignore(args.files)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,25 @@ jobs:
         run: npm ci
       - name: Typecheck
         run: npm run check
+
+  check-ts-ignore-check:
+    name: Check ts-ignore
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get Changed Files
+        id: get_changed_files
+        uses: tj-actions/changed-files@v45
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Run TS Ignore Check
+        run: python3 .github/scripts/detect_ts_ignore.py --files ${{ steps.get_changed_files.outputs.all_changed_files }}
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds an automated check to detect @ts-ignore comments in TypeScript files during PRs.


- A Python script (detect_ts_ignore.py) that scans changed .ts/.tsx files for @ts-ignore comments.

- If any @ts-ignore is found without a preceding comment like // Reason: ..., the check fails.

Closes #738 