### PR TITLE
Remove CDN script tag from embedded sketches

### DIFF
--- a/src/components/CodeEmbed/frame.tsx
+++ b/src/components/CodeEmbed/frame.tsx
@@ -42,7 +42,7 @@ canvas {
 }
 ${code.css || ""}
 </style>
-${(code.scripts ? [cdnLibraryUrl, ...code.scripts] : []).map((src) => `<script type="text/javascript" src="${src}"></script>`).join('\n')}
+${(code.scripts ?? []).map((src) => `<script type="text/javascript" src="${src}"></script>`).join('\n')}
 <body>${code.htmlBody || ""}</body>
 <script id="code" type="text/javascript">${wrapSketch(code.js) || ""}</script>
 ${(code.scripts?.length ?? 0) > 0 ? '' : `


### PR DESCRIPTION
`CodeFrame` already injects p5 into the iframe (this helps with browser caching), so by having a CDN script tag too, p5 gets loaded twice.