### PR TITLE
Handle change to deprecation message format

### DIFF
--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -415,6 +415,8 @@ const convertDocsToMDX = async (
           doc.example = correctRelativeLinksToExampleAssets(
             doc.example,
           ) as string[];
+          // @ts-ignore
+          doc.deprecated = doc.deprecated ? (doc.deprecationMessage ?? true) : undefined;
           const mdx = await convertToMDX(doc);
 
           return mdx ? { mdx, savePath, name: doc.name } : null;

--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -415,8 +415,7 @@ const convertDocsToMDX = async (
           doc.example = correctRelativeLinksToExampleAssets(
             doc.example,
           ) as string[];
-          // @ts-ignore
-          doc.deprecated = doc.deprecated ? (doc.deprecationMessage ?? true) : undefined;
+          doc.deprecated = (doc.deprecated ? (doc.deprecationMessage ?? true) : undefined) as any;
           const mdx = await convertToMDX(doc);
 
           return mdx ? { mdx, savePath, name: doc.name } : null;

--- a/types/parsers.interface.ts
+++ b/types/parsers.interface.ts
@@ -94,7 +94,7 @@ interface Chainable {
 
 interface Deprecatable {
   deprecated?: boolean; // If this item is deprecated, a description of why.
-  deprecatedMessage?: string; // If this item is deprecated, a description of why.
+  deprecationMessage?: string; // If this item is deprecated, a description of why.
 }
 
 /* Represents the return value of a method or constructor */

--- a/types/parsers.interface.ts
+++ b/types/parsers.interface.ts
@@ -93,7 +93,8 @@ interface Chainable {
 }
 
 interface Deprecatable {
-  deprecated?: string; // If this item is deprecated, a description of why.
+  deprecated?: boolean; // If this item is deprecated, a description of why.
+  deprecatedMessage?: string; // If this item is deprecated, a description of why.
 }
 
 /* Represents the return value of a method or constructor */


### PR DESCRIPTION
Makes changes to handle the updated format for deprecation in https://github.com/processing/p5.js/pull/7719.

I've only updated how the inputs are processed, it still converts them into `deprecated: string | boolean` inside the website repo since this is what the layouts are expecting right now. We can update the layouts and such to match the same format using two properties if we want, but I figured for now it would be less brittle to just transform the inputs to match the existing website expectations.