### PR TITLE
Fix/p5sound

### DIFF
--- a/src/components/CodeEmbed/frame.tsx
+++ b/src/components/CodeEmbed/frame.tsx
@@ -42,7 +42,7 @@ canvas {
 }
 ${code.css || ""}
 </style>
-${(code.scripts ?? []).map((src) => `<script type="text/javascript" src="${src}"></script>`).join('\n')}
+${(code.scripts ? [cdnLibraryUrl, ...code.scripts] : []).map((src) => `<script type="text/javascript" src="${src}"></script>`).join('\n')}
 <body>${code.htmlBody || ""}</body>
 <script id="code" type="text/javascript">${wrapSketch(code.js) || ""}</script>
 ${(code.scripts?.length ?? 0) > 0 ? '' : `

--- a/src/components/CodeEmbed/frame.tsx
+++ b/src/components/CodeEmbed/frame.tsx
@@ -42,7 +42,7 @@ canvas {
 }
 ${code.css || ""}
 </style>
-${(code.scripts ? [cdnLibraryUrl, ...code.scripts] : []).map((src) => `<script type="text/javascript" src="${src}"></script>`).join('\n')}
+${((code.scripts?.length ?? 0) > 0 ? [cdnLibraryUrl, ...(code.scripts ?? [])] : []).map((src) => `<script type="text/javascript" src="${src}"></script>`).join('\n')}
 <body>${code.htmlBody || ""}</body>
 <script id="code" type="text/javascript">${wrapSketch(code.js) || ""}</script>
 ${(code.scripts?.length ?? 0) > 0 ? '' : `

--- a/src/components/CodeEmbed/frame.tsx
+++ b/src/components/CodeEmbed/frame.tsx
@@ -42,6 +42,8 @@ canvas {
 }
 ${code.css || ""}
 </style>
+<!-- If we need an addon script, load p5 the usual way with no caching to make sure
+the import order doesn't get messed up. -->
 ${((code.scripts?.length ?? 0) > 0 ? [cdnLibraryUrl, ...(code.scripts ?? [])] : []).map((src) => `<script type="text/javascript" src="${src}"></script>`).join('\n')}
 <body>${code.htmlBody || ""}</body>
 <script id="code" type="text/javascript">${wrapSketch(code.js) || ""}</script>


### PR DESCRIPTION
Resolves #790

Also reverts #781 which tried to fix another issue but created this one. 

- We usually load p5 through script injection for caching purposes
- This messes up the load order with p5.sound, so we load p5 the usual way with slightly less efficient caching policies in that case.
- Previously to #781, there was a bug where it was also loading p5 the usual way ALL THE TIME.
- After #781, p5.sound examples broke because it NEVER loads p5 the usual way.
- This fixes the actual issue, where not passing `scripts` (as opposed to passing `[]`) would cause the cdn link to get added mistakenly.