### PR TITLE
fixed reference classes don't show up in filter search

### DIFF
--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -72,7 +72,7 @@ export const ReferenceDirectoryWithFilter = ({
 
     return categoryData.reduce((acc: FilteredCategoryData[], category) => {
       const filteredSubcats = category.subcats.reduce(
-        (subAcc :typeof category.subcats, subcat) => {
+        (subAcc: typeof category.subcats, subcat) => {
           const filteredEntries = subcat.entries.filter((entry) =>
             entry.data.title
               .toLowerCase()

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -78,12 +78,11 @@ export const ReferenceDirectoryWithFilter = ({
               .toLowerCase()
               .includes(searchKeyword.toLowerCase()),
           );
-          if (subcat.entry &&
-            subcat.entry.data.title
-            .toLowerCase()
-            .includes(searchKeyword.toLowerCase())
-            ) {
-           filteredEntries.push(subcat.entry);
+          if (
+            subcat.entry &&
+            subcat.entry.data.title.toLowerCase().includes(searchKeyword.toLowerCase())
+          ) {
+            filteredEntries.push(subcat.entry);
           }
           
           if (filteredEntries.length > 0) {

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -72,18 +72,26 @@ export const ReferenceDirectoryWithFilter = ({
 
     return categoryData.reduce((acc: FilteredCategoryData[], category) => {
       const filteredSubcats = category.subcats.reduce(
-        (subAcc, subcat) => {
+        (subAcc :typeof category.subcats, subcat) => {
           const filteredEntries = subcat.entries.filter((entry) =>
             entry.data.title
               .toLowerCase()
               .includes(searchKeyword.toLowerCase()),
           );
+          if (subcat.entry &&
+            subcat.entry.data.title
+            .toLowerCase()
+            .includes(searchKeyword.toLowerCase())
+            ) {
+           filteredEntries.push(subcat.entry);
+          }
+          
           if (filteredEntries.length > 0) {
             subAcc.push({ ...subcat, entries: filteredEntries });
           }
           return subAcc;
         },
-        [] as typeof category.subcats,
+        [],
       );
 
       if (filteredSubcats.length > 0) {


### PR DESCRIPTION
Fixes #717
 
earlier classes was not showing in filer search, after i modified the code and added a check , classes comes up in filter search 
| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/2dadf2fd-b321-4c5f-a6a8-61c08e979e71) | ![image](https://github.com/user-attachments/assets/ff4dd6cf-1813-45b9-b8b2-2cece4f242c3)|

more example 
| Before | After |
|--------|--------|
| ![Screenshot 2025-04-11 225919](https://github.com/user-attachments/assets/5ac0a6bb-5db6-4184-9060-bffec38f2cbf) | ![Screenshot 2025-04-11 225928](https://github.com/user-attachments/assets/098df5b4-fc19-424d-b279-43e738745157)|


@ksen0  , @davepagurek - please verify if this is correct. Tell me if something needs to be changed 
