### PR TITLE
Temporary fix on 2.0 reference assets URLs

### DIFF
--- a/src/content/reference/en/p5.Font/textToContours.mdx
+++ b/src/content/reference/en/p5.Font/textToContours.mdx
@@ -59,7 +59,7 @@ example:
 
     async function setup() {
       createCanvas(100, 100);
-      font = await loadFont('//assets/inconsolata.otf');
+      font = await loadFont('/assets/inconsolata.otf');
     }
 
     function draw() {

--- a/src/content/reference/en/p5/vertex.mdx
+++ b/src/content/reference/en/p5/vertex.mdx
@@ -185,7 +185,7 @@ example:
     let vid;
     function setup() {
       // Load a video and create a p5.MediaElement object.
-      vid = createVideo('//assets/fingers.mov');
+      vid = createVideo('/assets/fingers.mov');
       createCanvas(100, 100, WEBGL);
 
       // Hide the video.


### PR DESCRIPTION
URLs are incorrect in these examples. Non-temporary fix should be in p5.js, and I'll add this and other issues I've found to https://github.com/processing/p5.js/pull/7739