### PR TITLE
Support rest types in Syntax section of reference

### DIFF
--- a/src/components/MethodSignature/index.astro
+++ b/src/components/MethodSignature/index.astro
@@ -14,8 +14,13 @@ import { CopyCodeButton } from "../CopyCodeButton";
 
 const { params, name, overloads } = Astro.props;
 
-const formatParam = (param: ReferenceParam) =>
-  param.optional ? `[${param.name}]` : `${param.name}`;
+const formatParam = (param: ReferenceParam) => {
+  let formatted = param.optional ? `[${param.name}]` : `${param.name}`;
+  if (param.rest) {
+    formatted = `${param.name}1, ${param.name}2, ..., ${param.name}n`;
+  }
+  return formatted;
+};
 
 const signatures = params 
   ? [`${name}(${params.map(formatParam).join(", ")})`]

--- a/src/content/reference/config.ts
+++ b/src/content/reference/config.ts
@@ -28,6 +28,7 @@ const paramSchema = z.object({
   description: z.string().optional(),
   type: z.string().optional(),
   optional: z.coerce.boolean().optional(),
+  rest: z.coerce.boolean().optional(),
 });
 
 const returnSchema = z.object({

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -181,7 +181,10 @@ const descriptionParts = description.split(
               {entry.data.params &&
                 entry.data.params.map((param: ReferenceParam) => (
                   <div class="grid grid-cols-6 gap-gutter-md text-body">
-                    <span class="col-span-1 text-body whitespace-normal break-words overflow-wrap-break-word">{param.name}</span>
+                    <span class="col-span-1 text-body whitespace-normal break-words overflow-wrap-break-word">
+
+                      {param.rest ? `${param.name}1, ..., ${param.name}n` : param.name}
+                    </span>
                     <div
                           class="col-span-5 [&_p]:m-0 [&_p]:inline [&_a]:underline"
                     >
@@ -197,7 +200,9 @@ const descriptionParts = description.split(
                     seenParams[param.name] = true;
                     return (
                       <div class="grid grid-cols-6 gap-gutter-md text-body">
-                        <span class="col-span-1">{param.name}</span>
+                        <span class="col-span-1">
+                          {param.rest ? `${param.name}1, ..., ${param.name}n` : param.name}
+                        </span>
                         <div
                           class="col-span-5 [&_p]:m-0 [&_p]:inline [&_a]:underline"
                         >

--- a/types/parsers.interface.ts
+++ b/types/parsers.interface.ts
@@ -40,6 +40,7 @@ export interface ReferenceParam {
   description: string; // A description of the parameter.
   type: string; // The data type of the parameter.
   optional?: boolean; // Indicates if the parameter is optional.
+  rest?: boolean; // Whether or not this is a variadic parameter at the end of the arg list
 }
 
 export type ReferenceOverload = {


### PR DESCRIPTION
Some of our signatures now support rest types, e.g. createVector. We currently do not display or type check this correctly. I've made a PR here to support type checking https://github.com/processing/p5.js/pull/7803, and this adds the capability to display them in the reference.

It currently looks like this, using @GregStanton's idea borrowing from MDN the `x1, x2, ..., xn` syntax.
![image](https://github.com/user-attachments/assets/9b0e9b1a-5f1a-4fd7-9489-4bc5507bcc0a)

The `Number:` type is a little awkward here, but probably fine for now, and better than what we currently have.

### For reference, how some other things display variadic arguments:

#### JavaScript

If we want the syntax section to reflect how one would write this in your own function, it would be:
```js
createVector(...components)
```
...and also we'd document `components` as an *array*.

#### MDN

![image](https://github.com/user-attachments/assets/b1cde0fc-6c93-4266-9224-089381862022)

#### w3schools

![image](https://github.com/user-attachments/assets/cfb71382-f14b-4d19-a5b5-8a598c3b6fa6)


#### Three.js

![image](https://github.com/user-attachments/assets/449c965b-65d1-40be-b193-d2f21c86cd90)

#### Lodash

![image](https://github.com/user-attachments/assets/0632c67a-17e7-4a01-a733-04ad0ab49c3e)

#### Immutable.js

![image](https://github.com/user-attachments/assets/a37b44d0-5e64-406e-ad2a-f89899c06750)

#### Oracle Java docs

![image](https://github.com/user-attachments/assets/fe015141-b145-4221-ad1a-8bb0e913d9d0)

