### PR TITLE
Set iframe srcdoc attribute to blank to prevent iframe navigation

### DIFF
--- a/src/components/CodeEmbed/frame.tsx
+++ b/src/components/CodeEmbed/frame.tsx
@@ -161,7 +161,7 @@ export const CodeFrame = (props: CodeFrameProps) => {
           htmlBody: props.htmlBodyCode,
           base: props.base,
           scripts: props.scripts,
-        }) : undefined}
+        }) : ""}
         sandbox="allow-scripts allow-popups allow-modals allow-forms allow-same-origin"
         aria-label="Code Preview"
         title="Code Preview"


### PR DESCRIPTION
Resolves #822

Instead of setting iframe srcdoc to `undefined` which cause a navigation event, set it to a blank string which only change the inner content of the same iframe without navigation.