### PR TITLE
Updating the docs for triangle_strip

### DIFF
--- a/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/code.js
+++ b/src/content/examples/en/09_Angles_And_Motion/02_Triangle_Strip/code.js
@@ -2,7 +2,10 @@ let insideRadius = 100;
 let outsideRadius = 150;
 
 function setup() {
-  createCanvas(720, 400);
+  createCanvas(720, 400, WEBGL);
+  label = createP('');
+  label.style('color', 'white');
+  label.position(20, 10);
   angleMode(DEGREES, 360, 255, 255);
   colorMode(HSB);
 
@@ -16,7 +19,7 @@ function draw() {
 
   let centerX = width / 2;
   let centerY = height / 2;
-
+  translate(-centerX, -centerY);
   // Set the number of points based on the mouse x position
   let pointCount = map(mouseX, 0, width, 6, 60);
 
@@ -24,10 +27,7 @@ function draw() {
   pointCount = round(pointCount);
 
   // Display the current pointCount
-  fill(255);
-  textSize(20);
-  text(`pointCount: ${pointCount}`, 30, 30);
-
+  label.html(`pointCount: ${pointCount}`);
   // Draw the triangle strip by specifying points on
   // the inside circle and outside circle alternately
 


### PR DESCRIPTION
Hi @ksen0 and @davepagurek,

The example in the docs now renders as a single solid colour instead of a rainbow because of [p5 issue #7722](https://github.com/processing/p5.js/issues/7722).
In p5 1.x, modes such as `TRIANGLES`, `TRIANGLE_STRIP`, `QUAD_STRIP`, and `QUADS` quietly split the geometry into many sub-shapes, so you could call fill() between vertex() calls and get different colours per polygon. The new 2-D shape engine in 2.0 treats each `beginShape()/endShape()` block as one path and therefore locks it to the initial fill/stroke. A future fix will probably restore per-polygon colouring for those modes (without interpolation, unlike WebGL) while keeping the single-colour fast path when the style doesn’t change.

Until that enhancement lands, the simplest way to keep the rainbow example working is to run it on a WEBGL canvas; WebGL still supports per-vertex colours. I’ve updated the PR accordingly so users won’t be puzzled by a solid-red ring in the docs. Once https://github.com/processing/p5.js/issues/7722 is resolved on dev-2.0, we can switch the example back to the standard 2-D renderer.