### PR TITLE
Update animating-with-media-objects.mdx - remove mention of preload()

### DIFF
--- a/src/content/tutorials/en/animating-with-media-objects.mdx
+++ b/src/content/tutorials/en/animating-with-media-objects.mdx
@@ -92,10 +92,9 @@ JPEGs and PNGs are among the most common types of static images, which are image
 
 ## Step 2 – Load the images into the canvas
 
-- In the `preload()` function, type in `flower1 = loadImage("flower-1.png");`
 - Declare four global variables to represent each image: `let flower1, flower2, flower3, water;`
-- Make [`setup()`](/reference/p5/setup) an `async` function.
-  - This lets us load the image information into memory using the [`loadImage()`](/reference/p5/loadImage) function.
+- Mark the [`setup()`](/reference/p5/setup) function with the [`async`](/reference/p5/async_await) keyword
+  - This loads the image information into memory using [`await`](/reference/p5/async_await) [`loadImage()`](/reference/p5/loadImage).
   - The image is assigned to the global variable `flower1`.
   - Repeat this step for all the images.
 


### PR DESCRIPTION
Although the tutorial has been updated to use async/await, it still mentions preload() in one spot.Although the tutorial has been updated to use async/await, it still mentions preload() in one spot.