### PR TITLE
solves docs issue 837 for p5.js 2.x

### DIFF
--- a/src/content/tutorials/en/getting-started-with-nodejs.mdx
+++ b/src/content/tutorials/en/getting-started-with-nodejs.mdx
@@ -7,7 +7,7 @@ featuredImage: ../images/featured/node.png
 featuredImageAlt: A p5.js logo with musical notes above it has arrows labeled with HTTP methods pointing to a cloud labeled “Internet”. Above the cloud is an icon that reads “http\://”. Arrows point from the cloud to a pink cube labeled “Web Server” with the Node.js logo above it.
 relatedContent:
   references:
-   - en/p5/preload
+   - en/p5/async_await
    - en/p5/loadjson
 authors:
   - Layla Quiñones
@@ -197,9 +197,8 @@ let songs;
 
 async function setup() {
   createCanvas(400, 400);
-  // Fetch the list of songs from the server
-  const response = await fetch('/songs');
-  songs = await response.json();
+  // Fetch the list of songs from the server via loadJSON
+  songs = await loadJSON('/songs');
   console.log(songs);
 }
 

--- a/src/content/tutorials/en/getting-started-with-nodejs.mdx
+++ b/src/content/tutorials/en/getting-started-with-nodejs.mdx
@@ -14,7 +14,7 @@ authors:
   - Nick McIntyre
 ---
 
-In this guide, we'll explore the fusion of p5.js and [Node.js](http://node.js) to create dynamic applications that save and retrieve user-generated drawings, animations, and sound projects! For example, you can create a [Simple Melody App](/tutorials/simple-melody-app/) where you save files with melodies you create by interacting with the canvas! Node.js allows you to easily save, replay, and edit these files right from your browser!
+In this guide, we'll explore the fusion of p5.js and [Node.js](http://nodejs.org) to create dynamic applications that save and retrieve user-generated drawings, animations, and sound projects! For example, you can create a [Simple Melody App](/tutorials/simple-melody-app/) where you save files with melodies you create by interacting with the canvas! Node.js allows you to easily save, replay, and edit these files right from your browser!
 
 
 ![A p5.js logo with musical notes above it has arrows labeled with HTTP methods pointing to a cloud labeled “Internet”. Above the cloud is an icon that reads “http://”. Arrows point from the cloud to a pink cube labeled “Web Server” with the Node.js logo above it.](../images/advanced/node.png)

--- a/src/content/tutorials/en/getting-started-with-nodejs.mdx.todo
+++ b/src/content/tutorials/en/getting-started-with-nodejs.mdx.todo
@@ -175,13 +175,13 @@ let fs = require('fs');
 
 // API endpoint to get list of songs
 app.get('/songs', (req, res) => {
-  fs.readdir('songs', (err, files) => {
-    if (err) {
-      res.status(500).send('Error reading song files');
-    } else {
-      res.json({ files });
-    }
-  });
+  fs.readdir('songs', (err, files) => {
+    if (err) {
+      res.status(500).send('Error reading song files');
+    } else {
+      res.json({ files });
+    }
+  });
 });
 ```
 
@@ -189,23 +189,18 @@ The code above initializes the [file system module (`fs`)](https://nodejs.org/ap
 
 Now that you have instructed the GET request on how to read the songs folder filenames, we can upload filenames as a JSON object in `sketch.js`.
 
-- Use `preload()` and `loadJSON()` to load files from the songs folder in a global variable named `songs`. Visit the [p5.js reference](/reference) to learn more about [`preload()`](/reference/p5/preload) and [`loadJSON()`](/reference/p5/loadJSON).
-- Use `console.log(songs)` in `setup()` to print the contents of the JSON array.
+**Note:** In p5.js 2.x, the `preload()` function and synchronous loading methods have been removed. Instead, you should use `async`/`await` and the browser's `fetch` API to load data before using it in your sketch. Here is how you can update your `sketch.js`:
 
-Your sketch.js file should look like this:
 
 ```js
-//variable for JSON object with file names
 let songs;
 
-function preload() {
-  //load and save the songs folder as JSON
-  songs = loadJSON("/songs");
-}
-
-function setup() {
-  createCanvas(400, 400);
-  console.log(songs)
+async function setup() {
+  createCanvas(400, 400);
+  // Fetch the list of songs from the server
+  const response = await fetch('/songs');
+  songs = await response.json();
+  console.log(songs);
 }
 
 function draw() {
@@ -216,13 +211,11 @@ function draw() {
 View your browser’s console to make sure the output of the `songs` variable looks something like this:
 
 ```
-Object i
-  files: Array(3)
-    0: "C Major Scale.json"
-    1: "Frere Jacques.json"
-    2: "Mary's Lamb.json"
-    length: 3
-// ...prototype
+{ files: [
+  "C Major Scale.json",
+  "Frere Jacques.json",
+  "Mary's Lamb.json"
+] }
 ```
 
 Now you are ready to build the [Melody App](https://docs.google.com/document/u/0/d/1mzJv-7qU1_CmkWI0ZFeqf3CeBfpOOVIrvPRZtxqFxRI/edit)! You can access completed code for this guide in [this Github repository](https://github.com/MsQCompSci/melodyAppNodeStarter/tree/main).


### PR DESCRIPTION
Actual Behavior
The “Getting Started with Node.js” tutorial is still using p5.js 1.x patterns (e.g. preload(), old APIs, external sketches locked to 1.x). Legacy p5.js 1.x APIs (e.g. old shape-drawing signatures) remain in the code samples. Several external Web Editor sketches are locked to p5.js 1.x and won’t run under 2.x.

Expected Behavior
Since p5.js 2.0 has removed preload() and other legacy methods in favor of async/await and updated several APIs, we need to refresh this tutorial so it only uses supported 2.x functionality. Every linked sketch should has been forked (or updated) to use p5.js 2.x so examples execute correctly.

Hence I updated the docs for the required 2.x version

I have tested, linted and ran the code locally to ensure no breakage occurs

addresses pull request: https://github.com/processing/p5.js-website/pull/877
issue: https://github.com/processing/p5.js-website/issues/837