### PR TITLE
Fix: Replace duplicate callout headings with ARIA-labeled sections

### DIFF
--- a/src/components/Callout/index.astro
+++ b/src/components/Callout/index.astro
@@ -14,7 +14,12 @@ const currentLocale = getCurrentLocale(Astro.url.pathname);
 const t = await getUiTranslator(currentLocale);
 ---
 
-<div class={`callout ${props.title ? 'callout-note' : ''}`}>
-  <h5>{t('calloutTitles', props.title || "Try this!")}</h5>
+<section 
+  class={`callout ${props.title ? 'callout-note' : ''}`} 
+  role="region" 
+  aria-label={String(t('calloutTitles', props.title || "Try this!"))}>
+  <div class="callout-heading" style="font-weight: bold;">
+    {t('calloutTitles', props.title || "Try this!")}
+  </div>
   <slot />
-</div>
+</section>


### PR DESCRIPTION
### Description

This PR addresses issue #871 by replacing repeated heading elements (`<h5>Tip</h5>`, `<h5>Note</h5>`, etc.) used in callout blocks with `<section>` elements that include accessible ARIA labels instead.

### Changes Made

- Modified `src/components/callout/index.astro`:
  - Replaced `<h5>` heading with `<section role="region" aria-label="...">`
  - Ensured the title is passed as an ARIA label instead of a heading element.
  - Removed heading tags to prevent unnecessary duplication in the document outline.

### Before vs After

- **Before**: Multiple `<h5>Tip</h5>` or `<h5>Note</h5>` headings were present, cluttering the document structure and affecting accessibility.
- **After**: Replaced with `<section aria-label="Tip">...</section>` and similar, improving semantic clarity and screen reader navigation.

### Screenshot

Before
![3](https://github.com/user-attachments/assets/8de54179-ca57-4e10-a760-6e2b4b6d177e)

After
![4](https://github.com/user-attachments/assets/eadba8e9-3de9-4f96-b1c4-2bd896fdfc83)

### Related Issue

Closes #871 