### PR TITLE
replace old-site alert with open call submission promo

### DIFF
--- a/src/content/banner/en.mdx
+++ b/src/content/banner/en.mdx
@@ -1,8 +1,16 @@
 ---
 # Give each new message a unique title so we know which one a user closed
-title: "old-site"
-link: "https://archive.p5js.org"
+# title: "old-site"
+# link: "https://archive.p5js.org"
+# hidden: false
+# ---
+#
+# Looking for the old p5.js site? Find it here!
+
+# Open Call Promo
+title: "open-call"
+link: "https://openprocessing.org/curation/89576"
 hidden: false
 ---
 
-Looking for the old p5.js site? Find it here!
+We’re accepting p5.js sketches for a special curation exploring mental health and the newest features in p5.js 2.0! Submit by July 20!


### PR DESCRIPTION
**Summary**
This PR replaces the old-site alert message with a new open call submission promo.

**Details**

- Commented out the old-site footer message
- Updated the alert text to invite users to submit p5.js sketches for a curation exploring mental health and the new features in p5.js 2.0