### PR TITLE
Rename conflicting sphere() functions to avoid shadowing p5.js built-in

### DIFF
--- a/src/content/tutorials/en/intro-to-p5-strands.mdx
+++ b/src/content/tutorials/en/intro-to-p5-strands.mdx
@@ -282,7 +282,7 @@ function instancingCallback() {
     return fract(sin(dot(seed, [12.9898, 78.233])) * 43758.5453123);
   }
 
-function sphere() {
+function getAnimatedSpherePosition() {
   let id = instanceID();
   let theta = rand([id, 0.1234])  * TWO_PI;
   // change the particle's position over time:
@@ -298,7 +298,7 @@ function sphere() {
 }
 
 getWorldInputs((inputs) => {
-  inputs.position += sphere();
+  inputs.position += getAnimatedSpherePosition();
   return inputs;
 });
 }

--- a/src/content/tutorials/en/intro-to-p5-strands.mdx
+++ b/src/content/tutorials/en/intro-to-p5-strands.mdx
@@ -210,7 +210,7 @@ function instancingCallback() {
   return fract(sin(dot(seed, [12.9898, 78.233])) * 43758.5453123);
 }
 
-function sphere() {
+function randomPositionOnSphere() {
   let id = instanceID();
   let theta = rand([id, 0.1234])  * TWO_PI;
   let phi = rand([id, 3.321]) * PI;
@@ -223,7 +223,7 @@ function sphere() {
 }
 
 getWorldInputs((inputs) => {
-  inputs.position += sphere();
+  inputs.position += randomPositionOnSphere();
   return inputs;
   });
 }


### PR DESCRIPTION
**Description:**
This PR resolves a naming conflict in the `intro-to-p5-strands` tutorial page. A custom helper function named `sphere()` was shadowing the built-in p5.js `sphere()` function, causing confusion. This renames two user-defined functions named `sphere()` to `randomPositionOnSphere()` and `getAnimatedSpherePosition()`

**Verification:**
- Verified that renaming `sphere()` to `randomPositionOnSphere()` and `getAnimatedSpherePosition()` does not affect functionality.
- Confirmed no naming conflicts or runtime errors related to the original `sphere()` function name.

Issue: Closes #868 