### PR TITLE
Add p5.strands bloom filter example to filter() reference

### DIFF
--- a/src/content/reference/en/p5/filter.mdx
+++ b/src/content/reference/en/p5/filter.mdx
@@ -264,6 +264,32 @@ example:
     }
     </code>
     </div>
+    <div>
+    <code>
+    let strands;
+
+    function setup() {
+      createCanvas(400, 400, WEBGL);
+      strands = new Strands();
+      strands.filter(bloom);
+    }
+
+    function draw() {
+      strands.draw(() => {
+        rotateY(millis() / 1000);
+        normalMaterial();
+        box(150);
+      });
+    }
+
+    function bloom(input) {
+      return input.blur(8).brighten(1.5).blend(input, ADD);
+    }
+
+    describe('A rotating 3D cube with a glow (bloom) effect using p5.strands.');
+    </code>
+    </div>
+
 class: p5
 overloads:
   - params:


### PR DESCRIPTION
##  Added Example: Bloom Effect on a Rotating 3D Cube using `p5.strands`

###  Description

This PR adds a new code example under the `filter()` reference that demonstrates how to apply a bloom (glow) effect using the `p5.strands` library. The example showcases a rotating 3D cube rendered in `WEBGL` mode with a subtle post-processing effect.

###  Code Summary

```js
let strands;

function setup() {
  createCanvas(400, 400, WEBGL);
  strands = new Strands();
  strands.filter(bloom);
}

function draw() {
  strands.draw(() => {
    rotateY(millis() / 1000);
    normalMaterial();
    box(150);
  });
}

function bloom(input) {
  return input.blur(8).brighten(1.5).blend(input, ADD);
}

describe('A rotating 3D cube with a glow (bloom) effect using p5.strands.');
