### PR TITLE
Add missing translations for tutorial section headings

### DIFF
--- a/src/content/ui/es.yaml
+++ b/src/content/ui/es.yaml
@@ -37,6 +37,7 @@ Related Examples: Ejemplos Relacionados
 Show Code: Mostrar el código
 Donate to p5.js: Dona a p5.js
 Download p5.js: Descarga p5.js
+
 briefPageDescriptions:
   Reference: Encuentra explicaciones sencillas para cada pieza de código de p5.js.
   Examples: Explora las posibilidades de p5.js con ejemplos cortos.
@@ -48,8 +49,10 @@ briefPageDescriptions:
   Libraries: Expande las posibilidades de p5.js con bibliotecas creadas por la comunidad.
   About: Aprende acerca de la misión, valores y personas detrás de p5.js.
   People: Conoce al equipo de p5.js.
+
 exampleCategories:
   Featured: Destacado
+
 referenceCategories:
   modules:
     Math: Matemáticas
@@ -76,3 +79,14 @@ referenceCategories:
     Loading & Displaying: Cargando y Mostrando
     Noise: Ruido
     Random: Aleatorio
+
+tutorialCategories:
+  introduction: "Introducción a p5.js"
+  drawing: "Dibujo"
+  web-design: "Diseño web"
+  accessibility: "Accesibilidad"
+  criticalAI: "IA crítica"
+  webgl: "WebGL"
+  advanced: "Temas avanzados"
+  education-resources: "Recursos educativos"
+

--- a/src/content/ui/hi.yaml
+++ b/src/content/ui/hi.yaml
@@ -85,9 +85,9 @@ tutorialCategories:
   introduction: "p5.js का परिचय"
   drawing: "चित्रण"
   web-design: "वेब डिज़ाइन"
-  accessibility: "सुलभता"
+  accessibility: "अभिगम्यता"
   criticalAI: "क्रिटिकल AI"
-  webgl: "वेबग्ल"
+  webgl: "वेबजीएल"
   advanced: "उन्नत विषय"
   education-resources: "शैक्षिक संसाधन"
 

--- a/src/content/ui/hi.yaml
+++ b/src/content/ui/hi.yaml
@@ -37,6 +37,7 @@ Related Examples: संबंधित उदाहरण
 Show Code: कोड दिखाएं
 Donate to p5.js: p5.js को दान करें
 Download p5.js: p5.js डाउनलोड करें
+
 briefPageDescriptions:
   Reference: p5.js कोड के प्रत्येक भाग के लिए आसान व्याख्या ढूंढें।
   Examples: p5.js की संभावनाओं का पता लगाएं छोटे उदाहरणों के साथ।
@@ -48,6 +49,10 @@ briefPageDescriptions:
   Libraries: p5.js की संभावनाओं का विस्तार करें समुदाय द्वारा बनाई गई लाइब्रेरीज़ के साथ।
   About: p5.js के पीछे मिशन, मूल्यों और लोगों के बारे में जानें।
   People: p5.js टीम को जानें।
+
+exampleCategories:
+  Featured: प्रमुख
+
 referenceCategories:
   modules:
     Typography: टाइपोग्राफी
@@ -64,7 +69,7 @@ referenceCategories:
     Trigonometry: त्रिकोणमिति
     Creating & Reading: बनाना और पढ़ना
     2D Primitives: 2D आदिम
-    Setting: स्थिरांक
+    Setting: सेटिंग
     DOM: डोम
     Constants: स्थिरांक
     Pixels: पिक्सल
@@ -74,3 +79,15 @@ referenceCategories:
     Attributes: गुण
     Noise: नॉइज़
     Random: यादृच्छिक
+
+
+tutorialCategories:
+  introduction: "p5.js का परिचय"
+  drawing: "चित्रण"
+  web-design: "वेब डिज़ाइन"
+  accessibility: "सुलभता"
+  criticalAI: "क्रिटिकल AI"
+  webgl: "वेबग्ल"
+  advanced: "उन्नत विषय"
+  education-resources: "शैक्षिक संसाधन"
+

--- a/src/content/ui/ko.yaml
+++ b/src/content/ui/ko.yaml
@@ -78,7 +78,7 @@ tutorialCategories:
   web-design: "웹 디자인"
   accessibility: "접근성"
   criticalAI: "비판적 AI"
-  webgl: "웹글"
+  webgl: "웹지엘"
   advanced: "고급 주제"
   education-resources: "교육 자료"
 

--- a/src/content/ui/ko.yaml
+++ b/src/content/ui/ko.yaml
@@ -70,3 +70,15 @@ referenceCategories:
     Loading & Displaying: 불러오기 & 보이기
     Noise: 노이즈
     Random: 랜덤
+
+
+tutorialCategories:
+  introduction: "p5.js 소개"
+  drawing: "드로잉"
+  web-design: "웹 디자인"
+  accessibility: "접근성"
+  criticalAI: "비판적 AI"
+  webgl: "웹글"
+  advanced: "고급 주제"
+  education-resources: "교육 자료"
+

--- a/src/content/ui/zh-Hans.yaml
+++ b/src/content/ui/zh-Hans.yaml
@@ -97,10 +97,11 @@ tutorialCategories:
   drawing: "绘图"
   "web-design": "网页设计"
   accessibility: "无障碍"
-  webgl: "WebGL"
-  "advanced": "高级主题"
+  criticalAI: " 批判性人工智能"
+  webgl: "网页图形库"
+  advanced: "高级主题"
+  education-resources: "教育资源"
 tutorialsPage:
-  education-resources: 教育资源
   education-resources-snippet: "每个教学经验都有其独特的目标、信息、条件和环境。通过记录和分享 p5.js 教育资源，如工作坊和课程，我们旨在更好地连接全球的 p5.js 学习者和教育者社区。"
   view-education-resources: 查看教育资源
 exampleCategories:

--- a/src/content/ui/zh-Hans.yaml
+++ b/src/content/ui/zh-Hans.yaml
@@ -97,8 +97,8 @@ tutorialCategories:
   drawing: "绘图"
   "web-design": "网页设计"
   accessibility: "无障碍"
-  criticalAI: " 批判性人工智能"
-  webgl: "网页图形库"
+  criticalAI: "批判性人工智能"
+  webgl: "WebGL"
   advanced: "高级主题"
   education-resources: "教育资源"
 tutorialsPage:

--- a/src/layouts/TutorialsLayout.astro
+++ b/src/layouts/TutorialsLayout.astro
@@ -35,7 +35,7 @@ const pageJumpToLinks = categories
   .concat([
     {
       url: "#education-resources",
-      label: t("tutorialsPage", "education-resources"),
+      label: t("tutorialCategories", "education-resources"), // ✅ changed from tutorialsPage
     },
   ]);
 
@@ -63,10 +63,10 @@ setJumpToState({
       </section>
     ))
   }
+
   <section>
     <h2 class="mb-gutter-md mt-0">
-      {t("tutorialsPage", "education-resources")}<a id="education-resources"
-      ></a>
+      {t("tutorialCategories", "education-resources")}<a id="education-resources"></a> <!-- ✅ changed from tutorialsPage -->
     </h2>
     <p>{t("tutorialsPage", "education-resources-snippet")}</p>
     <LinkButton url="/education-resources" variant="link" class="mt-lg">


### PR DESCRIPTION
### Summary
This PR adds missing `tutorialCategories` translations to the following UI locale files:

- `hi.yaml` (Hindi)
- `es.yaml` (Spanish)
- `ko.yaml` (Korean)
- `zh-Hans.yaml` (Chinese)

### Details
The following keys were missing and have now been added:
- `webgl`
- `web-desgin`
- `drawing`
- `accessibility`
- `advanced-topics`
- `criticalAI`
- `education-resources`

This fixes the issue where some tutorial section headers were still appearing in English instead of the selected language.

### Related Issue
Closes #930

### Testing
Tested locally by switching the site language to all four and verifying that all tutorial section headers are now properly translated.

Let me know if anything else needs to be adjusted. Thanks!
