### PR TITLE
replace the open call submission promo with the old-site banner alert

### DIFF
--- a/src/content/banner/en.mdx
+++ b/src/content/banner/en.mdx
@@ -1,16 +1,8 @@
 ---
 # Give each new message a unique title so we know which one a user closed
-# title: "old-site"
-# link: "https://archive.p5js.org"
-# hidden: false
-# ---
-#
-# Looking for the old p5.js site? Find it here!
-
-# Open Call Promo
-title: "open-call"
-link: "https://openprocessing.org/curation/89576"
+title: "old-site"
+link: "https://archive.p5js.org"
 hidden: false
 ---
 
-We’re accepting p5.js sketches for a special curation exploring mental health and the newest features in p5.js 2.0! Submit by July 20!
+Looking for the old p5.js site? Find it here!


### PR DESCRIPTION
**Summary**
This PR replaces the old-site alert message with a new open call submission promo.

**Details**

- Uncommented the old-site footer message
- Removed the alert text  inviting users to submit p5.js sketches for the p5.js 2.0 open call