### PR TITLE
Fix: Remove quotes from multiple languages in tutorialCategories

### DIFF
--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -94,12 +94,12 @@ libraryCategories:
   export: "Export"
   utils: "Utilities"
 tutorialCategories:
-  introduction: "Introduction to p5.js"
-  drawing: "Drawing"
-  "web-design": "Web Design"
-  accessibility: "Accessibility"
-  webgl: "WebGL"
-  "advanced": "Advanced Topics"
+  introduction: Introduction to p5.js
+  drawing: Drawing
+  "web-design": Web Design
+  accessibility: Accessibility
+  webgl: WebGL
+  "advanced": Advanced Topics
 tutorialsPage:
   education-resources: Education Resources
   education-resources-snippet: "Every teaching experience has unique goals, messages, conditions, and environments. By documenting and sharing p5.js educational resources, such as workshops and classes, we aim to better connect the p5.js learner and educator communities worldwide. "

--- a/src/content/ui/es.yaml
+++ b/src/content/ui/es.yaml
@@ -81,12 +81,12 @@ referenceCategories:
     Random: Aleatorio
 
 tutorialCategories:
-  introduction: "Introducción a p5.js"
-  drawing: "Dibujo"
-  web-design: "Diseño web"
-  accessibility: "Accesibilidad"
-  criticalAI: "IA crítica"
-  webgl: "WebGL"
-  advanced: "Temas avanzados"
-  education-resources: "Recursos educativos"
+  introduction: Introducción a p5.js
+  drawing: Dibujo
+  web-design: Diseño web
+  accessibility: Accesibilidad
+  criticalAI: IA crítica
+  webgl: WebGL
+  advanced: Temas avanzados
+  education-resources: Recursos educativos
 

--- a/src/content/ui/hi.yaml
+++ b/src/content/ui/hi.yaml
@@ -82,12 +82,12 @@ referenceCategories:
 
 
 tutorialCategories:
-  introduction: "p5.js का परिचय"
-  drawing: "चित्रण"
-  web-design: "वेब डिज़ाइन"
-  accessibility: "अभिगम्यता"
-  criticalAI: "क्रिटिकल AI"
-  webgl: "वेबजीएल"
-  advanced: "उन्नत विषय"
-  education-resources: "शैक्षिक संसाधन"
+  introduction: p5.js का परिचय
+  drawing: चित्रण
+  web-design: वेब डिज़ाइन
+  accessibility: अभिगम्यता
+  criticalAI: क्रिटिकल AI
+  webgl: वेबजीएल
+  advanced: उन्नत विषय
+  education-resources: शैक्षिक संसाधन
 

--- a/src/content/ui/ko.yaml
+++ b/src/content/ui/ko.yaml
@@ -73,12 +73,12 @@ referenceCategories:
 
 
 tutorialCategories:
-  introduction: "p5.js 소개"
-  drawing: "드로잉"
-  web-design: "웹 디자인"
-  accessibility: "접근성"
-  criticalAI: "비판적 AI"
-  webgl: "웹지엘"
-  advanced: "고급 주제"
-  education-resources: "교육 자료"
+  introduction: p5.js 소개
+  drawing: 드로잉
+  web-design: 웹 디자인
+  accessibility: 접근성
+  criticalAI: 비판적 AI
+  webgl: 웹지엘
+  advanced: 고급 주제
+  education-resources: 교육 자료
 

--- a/src/content/ui/zh-Hans.yaml
+++ b/src/content/ui/zh-Hans.yaml
@@ -93,14 +93,14 @@ libraryCategories:
   export: "导出"
   utils: "工具"
 tutorialCategories:
-  introduction: "p5.js 入门"
-  drawing: "绘图"
-  "web-design": "网页设计"
-  accessibility: "无障碍"
-  criticalAI: "批判性人工智能"
-  webgl: "WebGL"
-  advanced: "高级主题"
-  education-resources: "教育资源"
+  introduction: p5.js 入门
+  drawing: 绘图
+  "web-design": 网页设计
+  accessibility: 无障碍
+  criticalAI: 批判性人工智能
+  webgl: WebGL
+  advanced: 高级主题
+  education-resources: 教育资源
 tutorialsPage:
   education-resources-snippet: "每个教学经验都有其独特的目标、信息、条件和环境。通过记录和分享 p5.js 教育资源，如工作坊和课程，我们旨在更好地连接全球的 p5.js 学习者和教育者社区。"
   view-education-resources: 查看教育资源


### PR DESCRIPTION
@perminder-17 @Homaid @ksen0 

- Removes quotes from YAML values to fix template engine parsing
- Resolves sidebar translation issue where categories stayed in English
- Fixes follow-up from PR #931

Following this discussion> https://github.com/processing/p5.js-website/pull/931#discussion_r2285673258

I think the quotes create issues that go beyond consistency.

Issue identified: YAML values with quotes are not being processed correctly by the template engine.

From live website:

- Working translations (no quotes): Main content renders correctly in es/ko/hi/zh-Hans
- Broken translations (with quotes): Tutorial sidebar categories remain in English only

The `tutorialCategories`section is using quoted values while other working sections use unquoted values. This suggests the p5.js template engine has a parsing issue with quoted YAML strings.

Proposed solution: Remove quotes from all `tutorialCategories` values.

Screenshots showing the issue across different languages:

<img width="882" height="880" alt="Screenshot 2025-08-19 171020" src="https://github.com/user-attachments/assets/12b9e6b3-5c16-47be-a164-c993f6d450c2" />
<img width="879" height="864" alt="Screenshot 2025-08-19 171034" src="https://github.com/user-attachments/assets/413d29f1-b7bb-429a-a88c-b11dc6dfd8c9" />
<img width="870" height="895" alt="Screenshot 2025-08-19 171049" src="https://github.com/user-attachments/assets/5fa3866b-23f1-49b8-a849-0d23ff73ef09" />
