### PR TITLE
Add missing tutorialCategories.education-resources to en.yaml

### DIFF
--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -100,6 +100,7 @@ tutorialCategories:
   accessibility: "Accessibility"
   webgl: "WebGL"
   "advanced": "Advanced Topics"
+  education-resources: "Education Resources"
 tutorialsPage:
   education-resources: Education Resources
   education-resources-snippet: "Every teaching experience has unique goals, messages, conditions, and environments. By documenting and sharing p5.js educational resources, such as workshops and classes, we aim to better connect the p5.js learner and educator communities worldwide. "


### PR DESCRIPTION
CI Test, typecheck, and lint passed, but the post-merge deploy workflow (“Deploy to GitHub Pages”) failed while building the site.

It happend in this PR : https://github.com/processing/p5.js-website/pull/931/files 

The main issue was, when we replaced "tutorialsPage" from "tutorialsCategories" 

> label: t("tutorialCategories", "education-resources"),

tutorialCategories does not contain education-resources (it lives under tutorialsPage only). The tutorialCategories block in `en.yaml` has: introduction, drawing, web-design, accessibility, webgl, advanced and no education-resources