### PR TITLE
fix broken links on contribute sections

### DIFF
--- a/src/pages/_utils-node.ts
+++ b/src/pages/_utils-node.ts
@@ -65,8 +65,10 @@ export const rewriteRelativeLink = (url: string): string => {
     }
 
     // Relative links to md files should be turned into pages
-    if (updatedUrl.endsWith('.md')) {
-      updatedUrl = updatedUrl.replace(/\.md$/, '');
+    // Use includes() instead of endsWith() to handle cases like "file.md#section"
+    // Use lookahead (?=#|$) to avoid breaking .mdx, etc.
+    if (updatedUrl.includes('.md')) {
+      updatedUrl = updatedUrl.replace(/\.md(?=#|$)/, '/');
     }
   }
 

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -293,16 +293,31 @@ export const rewriteRelativeMdLinks = (markdownText: string): string => {
    * Regex to find relative links to a markdown document in a string of Markdown
    * Has 2 capture groups:
    * 1. Text for the link
-   * 2. Link url (but not the .md extension at the end)
+   * 2. Link url (including the .md extension and hash)
    */
-  const regexPattern: RegExp = /(!?)\[([^\]]+)\]\(([^)]+)\)/g;
-  return markdownText.replace(regexPattern, (match, img, linkText, url: string) => {
+  const inlineLinkRegexPattern: RegExp = /(!?)\[([^\]]+)\]\(([^)]+)\)/g;
+  let out = markdownText.replace(inlineLinkRegexPattern, (match, img, linkText, url: string) => {
     // Don't convert images
     if (img) return match;
 
     const updatedUrl = rewriteRelativeLink(url);
     return `[${linkText}](${updatedUrl})`;
   });
+
+  /**
+   * Regex to find reference links to a markdown document in a string of Markdown
+   * Has 2 capture groups:
+   * 1. Text for the link
+   * 2. Link url (including the .md extension and hash)
+   */
+
+  const referenceLinkRegexPattern: RegExp = /^(\[[^\]]+\]):\s*(\.[^\s]+)$/gm;
+  out = out.replace(referenceLinkRegexPattern, (match, linkText, fullUrl: string) => {
+    const updatedUrl = rewriteRelativeLink(fullUrl);
+    return `${linkText}: ${updatedUrl}`;
+  });
+
+  return out;
 };
 /**
  * Deletes the contents of the given directory.

--- a/test/scripts/utils.test.ts
+++ b/test/scripts/utils.test.ts
@@ -38,3 +38,29 @@ test("rewriteRelativeMdLinks", () => {
   - [external](https://p5js.org/)
   `);
 });
+
+test("rewriteRelativeMdLinks with reference links", () => {
+  expect(
+    rewriteRelativeMdLinks(`
+# Documentation
+
+See [our guide][guide] and [access statement][access].
+
+You can also check [external link][external].
+
+[guide]: ./contributing_guide.md
+[access]: ./access.md#intro
+[external]: https://p5js.org/
+    `),
+  ).toEqual(`
+# Documentation
+
+See [our guide][guide] and [access statement][access].
+
+You can also check [external link][external].
+
+[guide]: ../contributing_guide/
+[access]: ../access/#intro
+[external]: https://p5js.org/
+    `);
+});


### PR DESCRIPTION
Related to #527

This PR resolves broken links on:

**https://p5js.org/contribute/friendly_error_system/**
- _friendlyFileLoadError() | https://p5js.org/contribute/friendly_error_system/fes_contribution_guide.md#_friendlyerror
- _validateParameters() | https://p5js.org/contribute/friendly_error_system/fes_contribution_guide.md#_validateparameters
- Dev Notes | https://p5js.org/contribute/friendly_error_system/fes_contribution_guide.md#-development-notes

**https://p5js.org/contribute/steward_guidelines/**
- p5.js' design principles | https://p5js.org/contribute/contributor_guidelines.md#software-design-principles
- design principles | https://p5js.org/contribute/contributor_guidelines.md#software-design-principles
- contributor's guidelines | https://p5js.org/contribute/contributor_guidelines.md#working-on-p5js-codebase

## What this PR does

- **Adds support for reference-style links**: Fixed `rewriteRelativeMdLinks` function which previously only handled inline links but not reference-style markdown links
- **Corrects misleading comment**: Updated comment for `inlineLinkRegexPattern` to accurately describe what it captures
- **Fixes hash fragment handling**: Resolved issue where `.md` extension wasn't being removed from relative links when followed by hash fragments (e.g., `file.md#section`)

## What this PR does not address

- **Pre-existing malformed links**: Links without proper relative paths (e.g., `[Issues](steward_guidelines.md#issues)`) still result in incorrect URLs due to the `../` prefix being added by existing logic. These were already broken before this PR.
- **Typos in source content**: The broken link [`_fesErrorMonitor()`] on the friendly error system page is a typo in the source documentation from the p5.js repository. This will be addressed in a separate PR to the main p5.js repo.