### PR TITLE
Banner script update to fix the missing banner

### DIFF
--- a/src/components/Banner/index.astro
+++ b/src/components/Banner/index.astro
@@ -12,7 +12,7 @@ const { link, title } = entry.data;
   <button id="hideBanner" aria-label="Hide banner"><Icon kind="close" /></button>
 </div>
 
-<script>
+<script is:inline>
 const banner = document.querySelector('.banner');
 const hideBannerBtn = document.querySelector('#hideBanner');
 if (banner && hideBannerBtn) {


### PR DESCRIPTION
### Changes
- Fixes the banner show functionality when script is loaded externally.
- Uses inline script to show the banner instead of the default external one.

### Why is this needed?
- External scripts failed since execution timing differed and inline scripts worked.
- The banner script was loaded using external script by astro. Here external script is not required as the HTML is parsed directly just before the script execution. Changing the default external script to inline fixes the bug.

### How was this tested?
- Manually tested in Firefox using npm build and preview

Fixes #967 
