### PR TITLE
Make CI build depends on test job in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         run: npm run check
   build:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4


### PR DESCRIPTION
This change is a follow-up of #971 and releated to #955 

This PR adds a dependency to the build job in our GitHub Actions CI workflow, ensuring it only runs after the test job has successfully completed.

Previously, the `build` job ran in parallel with the `test` job. While a test failure would eventually stop the workflow, the build process might have already started, consuming resources and time unnecessarily. This was particularly a concern with caching-related tests, where the build could make excessive API calls due to the unexpected caching behavior before confirming caching-related tests.

By adding `needs: test` to the build job, we now guarantee a sequential flow. The build process will only begin after all tests have passed, which leads to a more robust and efficient CI pipeline by preventing resource waste and ensuring that only code that meets our quality standards proceeds to the build stage.