### PR TITLE
Fix `<ul>` and `<ol>` Direct Children for HTML Compliance

### DIFF
--- a/src/components/RelatedItems/index.astro
+++ b/src/components/RelatedItems/index.astro
@@ -26,21 +26,35 @@ const { title, items, class: className } = Astro.props;
   <section class={className}>
     <h2>{title}</h2>
     <ul class="content-grid-simple">
-      {
-        items.map((i) => {
-          if (isCurationResponse(i)) {
-            return <GridItemSketch item={i} />;
-          }
-          switch (i.collection) {
-            case "reference":
-              return <GridItemReference item={i} />;
-            case "examples":
-              return <GridItemExample item={i} />;
-            case "events":
-              return <GridItemEvent item={i} />;
-          }
-        })
-      }
+      {items.map((i) => {
+        if (isCurationResponse(i)) {
+          return (
+            <li>
+              <GridItemSketch item={i} />
+            </li>
+          );
+        }
+        switch (i.collection) {
+          case "reference":
+            return (
+              <li>
+                <GridItemReference item={i} />
+              </li>
+            );
+          case "examples":
+            return (
+              <li>
+                <GridItemExample item={i} />
+              </li>
+            );
+          case "events":
+            return (
+              <li>
+                <GridItemEvent item={i} />
+              </li>
+            );
+        }
+      })}
     </ul>
   </section>
 </div>

--- a/src/layouts/SketchesLayout.astro
+++ b/src/layouts/SketchesLayout.astro
@@ -26,7 +26,11 @@ const { entries, totalNumSketches, currentPage } = Astro.props;
 <BaseLayout title="Sketches" variant="item" topic="community">
   <section>
     <ul class="content-grid-simple">
-      {entries.map((entry) => <GridItemSketch item={entry} />)}
+      {entries.map((entry) => (
+        <li>
+          <GridItemSketch item={entry} />
+        </li>
+      ))}
     </ul>
     <PaginationNav
       maxNumItems={totalNumSketches}


### PR DESCRIPTION
This PR addresses issue #869 : ensuring that all `<ul>` and `<ol>` elements only have `<li>`, `<script>`, or `<template>` as direct children, as required by the HTML specification and accessibility guidelines.

## What was changed
- Refactored markup in three locations where `<ul>` or `<ol>` had non-`<li>` direct children.
- All content/components that were direct children of `<ul>` are now wrapped in `<li>` elements.
- Verified all other relevant files for similar issues; no further inconsistencies found.

## Why
- To comply with the HTML spec and improve accessibility (WCAG 1.3.1, H48, F43).
- Prevents inconsistent rendering and improves support for assistive technologies.

## How to test
- Review affected pages in the browser and inspect the DOM to ensure all `<ul>` and `<ol>` have only `<li>`, `<script>`, or `<template>` as direct children.
- Confirm that the UI and accessibility are not negatively impacted.

## Related Issue
Closes #869 

## Additional Notes
- If any similar issues are found elsewhere, please report or address them in follow-up PRs.