### PR TITLE
Prevent hover state from sticking on mobile accessibility toggles

### DIFF
--- a/src/components/Dropdown/styles.module.scss
+++ b/src/components/Dropdown/styles.module.scss
@@ -20,14 +20,13 @@
   width: 100%;
   height: 100%;
   cursor: pointer;
-    @media (hover: hover) and (pointer: fine) {
+  @media (hover: hover) and (pointer: fine) {
     &:hover {
       border: 1px solid var(--accent-color);
       background-color: var(--accent-type-color);
       color: var(--accent-color);
     }
   }
-
 }
 
 .options {

--- a/src/components/Dropdown/styles.module.scss
+++ b/src/components/Dropdown/styles.module.scss
@@ -20,11 +20,14 @@
   width: 100%;
   height: 100%;
   cursor: pointer;
-  &:hover {
-    border: 1px solid var(--accent-color);
-    background-color: var(--accent-type-color);
-    color: var(--accent-color);
+    @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      border: 1px solid var(--accent-color);
+      background-color: var(--accent-type-color);
+      color: var(--accent-color);
+    }
   }
+
 }
 
 .options {
@@ -93,10 +96,13 @@
   }
 }
 
-li[aria-selected="false"]:hover .icon {
-  svg {
-    background: var(--accent-type-color);
-    border-radius: 2rem;
+// Only apply hover styles on devices with true hover capability (not touch devices)
+@media (hover: hover) and (pointer: fine) {
+  li[aria-selected="false"]:hover .icon {
+    svg {
+      background: var(--accent-type-color);
+      border-radius: 2rem;
+    }
   }
 }
 


### PR DESCRIPTION
Resolves #1014 
Mobile accessibility options don't visually deselect when untoggled


## Changes
- Wrapped hover styles in `@media (hover: hover) and (pointer: fine)` to prevent sticky hover states on touch devices
- Modified `src/components/Dropdown/styles.module.scss` 

## Testing
- Tested on mobile devices accessibility toggles now properly show selected/unselected states
- Desktop hover functionality remains unchanged