### PR TITLE
fix: wrap GridItemEvent in list item element

### DIFF
--- a/src/layouts/EventsLayout.astro
+++ b/src/layouts/EventsLayout.astro
@@ -25,7 +25,11 @@ setJumpToState(null);
 <BaseLayout title="Events" variant="item" topic="community">
   <section>
     <ul class="content-grid-simple">
-      {entries.map((entry) => <GridItemEvent item={entry} />)}
+      {entries.map((entry) => (
+        <li>
+          <GridItemEvent item={entry} />
+        </li>
+      ))}
     </ul>
     <PaginationNav
       maxNumItems={totalNumEvents}


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/1020.

### Description

Fixes invalid HTML structure in the events list where `<ul>` contained direct children that weren't `<li>`, `<script>`, or `<template>` elements.

This PR fixes issues in both `/events/` & `/events/page/1/` pages.

### Changes
- Wrapped `GridItemEvent` components in `<li>` tags within the events grid.