### PR TITLE
fix: use <p> instead of <h3> for people page description text

### DIFF
--- a/src/layouts/PeopleLayout.astro
+++ b/src/layouts/PeopleLayout.astro
@@ -58,9 +58,9 @@ setJumpToState(null);
 <Head title={"People"} locale={currentLocale} />
 
 <BaseLayout title={title} variant="item" topic="about" className="about">
-  <h3 class="mb-xl max-w-[770px]">
+  <p class="mb-xl max-w-[770px] text-h3">
     {t("peoplePage", "PageDescription")}
-  </h3>
+  </p>
   {
     featuredEntries.map((category, i) => (
       <section>


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/1022 .

### Description

This fixes HTML semantics where the people page description was using a heading element (`<h3>`) instead of a paragraph element.

### Changes
- Replaced `<h3>` with `<p>` for the page description text in `PeopleLayout.astro`.
- Added `text-h3` class to maintain the same visual styling.

### Demo

Before: WAVE report flags a `<h3>` element with "Skipped heading level" warning.

<img width="1861" height="930" alt="511654140-e268b19f-d68f-4ead-8f23-8b31a42c4523" src="https://github.com/user-attachments/assets/aebbcb7d-dcb9-4cf1-b03f-71790be61931" />

After: no more "Skipped heading level" warning in WAVE report.

<img width="1863" height="933" alt="Screenshot 2025-11-08 at 21 05 26" src="https://github.com/user-attachments/assets/a47fba3b-ce77-4326-9d19-f2d33a424003" />
