### PR TITLE
fix: remove redundant overrides causing npm install to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,6 @@
     "vitest": "^1.3.1"
   },
   "overrides": {
-    "react": "npm:@preact/compat@latest",
-    "react-dom": "npm:@preact/compat@latest",
     "astro-compress": {
       "sharp": "0.32.6"
     },


### PR DESCRIPTION
Fixes #1031 

## Changes
- Removed react and react-dom override

### PR Checklist
- [x] `npm run lint` passes
- [x] [Inline documentation] is included / updated 
- [x] [Unit tests] are included / updated 

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests

## Problem
Running `npm install` fails with the following error:

The `npm:@preact/compat@latest` syntax in the `overrides` section of `package.json` causes compatibility issues, preventing contributors from installing dependencies.

## Solution
The Preact alias overrides are actually redundant. The Astro Preact integration automatically handles react compatibility using `compat: true` option of `astro.config.mjs`:

```javascript
preact({
  compat: true,  // aliases react
}),
