### PR TITLE
fix: use <p> instead of <h3> for people page description text

### DIFF
--- a/src/layouts/PeopleLayout.astro
+++ b/src/layouts/PeopleLayout.astro
@@ -58,9 +58,9 @@ setJumpToState(null);
 <Head title={"People"} locale={currentLocale} />
 
 <BaseLayout title={title} variant="item" topic="about" className="about">
-  <h3 class="mb-xl max-w-[770px]">
+  <p class="mb-xl max-w-[770px] text-h3">
     {t("peoplePage", "PageDescription")}
-  </h3>
+  </p>
   {
     featuredEntries.map((category, i) => (
       <section>


### PR DESCRIPTION
Applies https://github.com/processing/p5.js-website/pull/1024 to 2.0 branch