### PR TITLE
Add every.org link to donate page (en)

### DIFF
--- a/src/content/text-detail/en/donate.mdx
+++ b/src/content/text-detail/en/donate.mdx
@@ -20,6 +20,8 @@ import donate6 from "../images/donate-6.jpeg";
 
 We need your help! p5.js is free, open-source software. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events. All of these efforts make our community as open and inclusive as possible.
 
+To donate using crypto, DAF, or stocks, visit our <strong><a href='https://www.every.org/processing-foundation?method=crypto,stocks,daf&success_url=https%3A%2F%2Fprocessing.org%2Fdonate&exit_url=https%3A%2F%2Fprocessing.org%2Fdonate&partner_metadata=eyJzb3VyY2UiOiAicHJvY2Vzc2luZy5vcmcifQ==#donate'>Every.org donation page</a></strong> instead.
+
 <DonorBoxWidget />
 
 The Processing Foundation was established in 2012 after more than a decade of work with the original Processing software. The Foundation’s mission is to promote software learning within the arts, artistic learning within technology-related fields, and to celebrate the diverse communities that make these fields vibrant, liberatory, and innovative. Our goal is to support people of all backgrounds in learning how to program and make creative work with code, especially those who might not otherwise have access to tools and resources. We also believe that some of the most radical futures and innovative technologies are being built by communities that have been pushed to the margins by dominant tech. We hope to support those who have been marginalized by technology in continued self-determination by providing time, space, and resources.


### PR DESCRIPTION
To enable donations outside of DonorBox, added a link to our every.org page:

<img width="819" height="856" alt="image" src="https://github.com/user-attachments/assets/92341b53-d1cc-4105-a0b2-e9e688ed69d2" />
