### PR TITLE
Add welcome header to HomepageLayout

### DIFF
--- a/src/layouts/HomepageLayout.astro
+++ b/src/layouts/HomepageLayout.astro
@@ -36,6 +36,9 @@ setJumpToState(null);
 />
 
 <BaseLayout title="" variant="homepage" homepageConfig={config}>
+
+  <h1 class="text-5xl font-bold mb-xl col-span-full">Welcome to p5.js 2!</h1>
+
   <div class="content-grid-simple mb-xl">
     <div
       class="col-span-2 lg:col-span-3 order-1 grid grid-cols-subgrid content-start"


### PR DESCRIPTION
This adds an `h1` element to the landing page, which was a suggested accessibility improvement that I missed applying to `2.0` branch ([here it is on main](https://github.com/processing/p5.js-website/blob/main/src/layouts/HomepageLayout.astro#L40)).

In this case, I think it also makes sense to use this to indicate major version.