### PR TITLE
fix: multiple small documentation issues across tutorials and reference

### DIFF
--- a/src/components/PageHeader/RootPage.astro
+++ b/src/components/PageHeader/RootPage.astro
@@ -12,7 +12,7 @@ const borderStyle = isFilterRoute ? "" : "border-b border-sidebar-type-color";
 ---
 
 <div
-  class=`content-grid-simple min-h-[350px] h-[50vh] pt-[11.25rem] lg:pt-4xl bg-accent-color text-accent-type-color pb-md px-5 md:px-lg ${borderStyle}`
+  class=`content-grid-simple min-h-[350px] pt-[11.25rem] lg:pt-4xl bg-accent-color text-accent-type-color pb-md px-5 md:px-lg ${borderStyle}`
 >
   <h1 class="whitespace-pre-line col-span-full mb-5">{title}</h1>
   <p class="text-h3 !mt-0 mb-3xl col-span-2">{subtitle}</p>

--- a/src/content/tutorials/en/conditionals-and-interactivity.mdx
+++ b/src/content/tutorials/en/conditionals-and-interactivity.mdx
@@ -524,7 +524,7 @@ function draw() {
 
   fill("green");
 
-  rect(0, horizon, 400, 400);
+  rect(0, horizon, 400, 200);
 
 }
 ```

--- a/src/content/tutorials/en/repeating-with-loops.mdx
+++ b/src/content/tutorials/en/repeating-with-loops.mdx
@@ -199,7 +199,7 @@ Above `setup()`:
 In `draw()`:
 
 - After the code that draws the finish line, declare a new local variable `x` to position all the body segments: `let x = circX;`
-- Add a *for loop* using: `for (let i = 0; i < length; i += 1) { }`
+- Add a *for loop* using: `for (let i = 0; i < segments; i += 1) { }`
   - A *for loop* will repeat the code we write inside the curly brackets multiple times. 
   - Move the lines of code that draw the `circle()` into the curly brackets of the *for loop*.
 - After the for loop, add: `circX += spacing` 
@@ -936,7 +936,7 @@ function moveCaterpillars() {
   for (let i = 0; i < numCaterpillars; i += 1) {
     //Give each caterpillar a
     //random speed.
-    move = random(5, 30);
+    let move = random(5, 30);
     caterpillarEnds[i] += move;
   }
 }
@@ -1001,7 +1001,7 @@ function moveCaterpillars() {
   for (let i = 0; i < numCaterpillars; i += 1) {
     //Give each caterpillar a
     //random speed.
-    move = random(5, 30);
+    let move = random(5, 30);
 
     // Update caterpillars' x-coordinates
     caterpillarEnds[i] += move;

--- a/src/pages/_utils-node.ts
+++ b/src/pages/_utils-node.ts
@@ -45,11 +45,11 @@ export const removeNestedReferencePaths = (route: string): string =>
   route.replace(/constants\/|types\//, "")
 
 export const rewriteRelativeLink = (url: string): string => {
-  let updatedUrl: string;
+  let updatedUrl: string = url;
 
-  if (/^((https?:\/)?)\//.exec(url) || url.startsWith('mailto:')) {
-    // Leave absolute paths alone
-    updatedUrl = url;
+  if (/^(https?:|mailto:|\/\/)/.exec(url)) {
+    // Leave external URLs  alone
+    return url;
   } else if (url.startsWith('#')) {
     // Leave links to headings alone
     updatedUrl = url;

--- a/src/pages/_utils-node.ts
+++ b/src/pages/_utils-node.ts
@@ -48,10 +48,10 @@ export const rewriteRelativeLink = (url: string): string => {
   let updatedUrl: string = url;
 
   if (/^(https?:|mailto:|\/\/)/.exec(url)) {
-    // Leave external URLs  alone
+    // Skip rewriting for external URLs (http(s), mailto)
     return url;
-  } else if (url.startsWith('#')) {
-    // Leave links to headings alone
+  } else if (url.startsWith('#')||url.startsWith('/')) {
+    // Skip rewriting for heading links and root-relative internal paths
     updatedUrl = url;
   } else {
     // Convert relative paths to '../' (because pages that started as files in the same directory


### PR DESCRIPTION
resolves #1057 

fixes several small documentation issues found while going through the p5.js docs and tutorials.

changes
- fix incorrect height value in conditionals-and-interactivity tutorial.
- fix "Filter by keyword" input overlapping text.
- replace loop length with segments and declare move in repeating-with-loops tutorial.

- all changes are documentation-only and independent.
- the Google Color Picker link is not fixed yet, it’ll be replaced based on maintainers preference.
