### PR TITLE
feat: add accTitle/accDescr to class diagram in WebGL architecture doc

### DIFF
--- a/src/content/contributor-docs/en/webgl_mode_architecture.mdx
+++ b/src/content/contributor-docs/en/webgl_mode_architecture.mdx
@@ -233,6 +233,11 @@ It also has the following per-vertex attributes:
 title: p5.js WebGL Classes
 ---
 classDiagram
+    accTitle: p5.js WebGL Class Diagram
+    accDescr {
+      "p5.Renderer" is the base class for "p5.Renderer2D" and "p5.RendererGL".
+      "p5.RendererGL" has a one-to-many composition relationship with multiple "p5.Shaders", "p5.Textures", and "p5.Framebuffers". Additionally, "p5.RendererGL" has a many-to-many aggregation relationship with "p5.Geometry".
+    }
     class Base["p5.Renderer"] {
     }
     class P2D["p5.Renderer2D"] {


### PR DESCRIPTION
## Summary
Adds accessibility tags (`accTitle` and `accDescr`) to the mermaid class diagram in the WebGL architecture documentation.

## Motivation
In response to discussion in https://github.com/processing/p5.js-website/issues/168#issuecomment-3616076425: Mermaid.js supports embedding accessibility metadata directly into generated SVG diagrams. This improves the experience for users with screen readers and other assistive technologies by providing a concise title and detailed description of the diagram's structure.

## References
- [Mermaid.js Accessibility Documentation](https://mermaid.ai/open-source/config/accessibility.html#accessible-title-and-description)

## Testing
- [x] Verified the mermaid diagram renders correctly for sighted users (no visual changes).
- [x] Confirmed `title` and `desc` tags are present in the generated SVG.
<img width="1863" height="933" alt="Screenshot 2025-12-27 at 14 18 42" src="https://github.com/user-attachments/assets/1f145468-3ae1-448e-83f6-0bb4e35cd7a4" />

-  [x] Tested with screen reader (macOS VoiceOver) to ensure title and description are announced properly.