### PR TITLE
In TutorialLayout send `pre` blocks to PreProxy which only calls CodeBlockWrapper if not mermaid Fixed #1066

### DIFF
--- a/src/components/PreProxy/index.astro
+++ b/src/components/PreProxy/index.astro
@@ -1,0 +1,20 @@
+---
+// Conditionally process pre blocks with CodeBlockWrapper or leave untouched.
+// Not all pre blocks should be rendered by the CodeBlockWrapper.
+// For example, mermaid diagram declarations should be left alone so that mermaid can process them.  
+//   In those cases, the diagram source isn't intended for the user.
+
+import CodeBlockWrapper from '../CodeBlockWrapper/index.astro';
+
+const props = Astro.props;
+
+// Check if this is a mermaid block
+// The 'data-language' or 'class' usually contains the language name
+const isMermaid = props.class?.includes('mermaid') || props['data-language'] === 'mermaid';
+---
+
+{isMermaid ? (
+  <pre {...props}><slot /></pre>
+) : (
+  <CodeBlockWrapper {...props}><slot /></CodeBlockWrapper>
+)}

--- a/src/layouts/TutorialLayout.astro
+++ b/src/layouts/TutorialLayout.astro
@@ -4,6 +4,7 @@ import Head from "@components/Head/index.astro";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 import { setJumpToState } from "../globals/state";
 import FreeRatioImage from "@components/Image/FreeRatioImage.astro";
+import PreProxy from "@components/PreProxy/index.astro";
 import CodeBlockWrapper from "@components/CodeBlockWrapper/index.astro";
 import LinkWrapper from "@components/LinkWrapper/index.astro";
 import RelatedItems from "@components/RelatedItems/index.astro";
@@ -79,7 +80,7 @@ const { showBanner, englishUrl } = checkTranslationBanner(
       components={{
         ...components,
         img: FreeRatioImage,
-        pre: CodeBlockWrapper,
+        pre: PreProxy,
         a: LinkWrapper,
       }}
     />


### PR DESCRIPTION
Changes TutorialLayout to send `pre` blocks not to CodeBlockWrapper directly, but to a new component `PreProxy`. 

This latter component will leave mermaid diagrams alone - allowing it to be processed by mermaid -  and send all other pre blocks to CodeBlockWrapper, as before.

Fixes #1066