### PR TITLE
Reference parsing now also parse META comments

### DIFF
--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -150,12 +150,13 @@ const descriptionParts = description.split(
         examples && (
           <div class="mb-xl">
             <h2 class="text-h3">{t("Examples")}</h2>
-            {examples.map(({ src: exampleCode, classes }, i: number) => {
+            {examples.map(({ src: exampleCode, classes, meta }, i: number) => {
+              const previewable = !classes.norender && !meta.includes('norender');
               return (
                 <CodeEmbed
                   client:load
                   initialValue={exampleCode}
-                  previewable={!classes.norender}
+                  previewable={previewable}
                   editable
                   lazyLoad={false}
                   allowSideBySide={true}

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -196,7 +196,11 @@ export const getLibraryLink = (library: CollectionEntry<"libraries">) =>
  * @returns The examples separated into individual strings
  */
  // separateReferenceExamples
-export const parseReferenceExamplesAndMetadata = (examples: string[]): { src: string, classes: Record<string, any> }[] =>
+export const parseReferenceExamplesAndMetadata = (examples: string[]): {
+  src: string,
+  classes: Record<string, any>,
+  meta: string[]
+}[] =>
   examples
     ?.flatMap((example: string) => example.split("</div>"))
     .map((src: string) => {
@@ -210,7 +214,18 @@ export const parseReferenceExamplesAndMetadata = (examples: string[]): { src: st
       }
       return { classes, src }
     })
-    .map(({ src, classes }) => ({ classes, src: src.replace(/<\/?div[^>]*>|<\/?code>/g, "") }))
+    .map(({ src, classes }) => {
+      const metaMatch = src.match(/^\/\/ META:(.+)/);
+      let meta: string[] = [];
+      if(metaMatch !== null){
+        meta = metaMatch?.[1].split(",") ?? [];
+      }
+      return {
+        classes,
+        src: src.replace(/<\/?div[^>]*>|<\/?code>/g, "").replace(/^\/\/ META:(.+)/, ""),
+        meta
+      };
+    })
     .filter(({ src }) => src);
 
 /**


### PR DESCRIPTION
To move reference examples to being JS only (ie. no HTML tags), there needs to be a way to determine if a sketch code is meant to be rendered or not. With HTML tag it is done through a `norender` class on the `<div>` tag and by removing the HTML tags, this PR enables the no render flag to be defined through a meta tag defined as a comment at the top of the example.

```js
// META:norender
```

There can be additional meta tags separated by commas if needed in the future. The website build parser will parse the meta tags into a `meta` field as an array of strings and then strip the meta tag comment out from the source.

This probably can be merged independently of https://github.com/processing/p5.js/pull/8360 or it can wait until it is merged. This can only stay on the `2.0` branch and does not need to be propagated to the `main` branch for 1.x as only the 2.x reference examples are having their HTML tags strip out.