### PR TITLE
Fix p5.sound reference pages linking to correct GitHub repository

### DIFF
--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -292,7 +292,12 @@ const convertToMDX = async (
 
   try {
     // Add YAML comment to the frontmatter
-    const comment = `# This file was auto-generated. Please do not edit it manually!\n# To make changes, edit the comments in the corresponding source file:\n# https://github.com/processing/p5.js/blob/v${p5Version}/${doc.file.replace(/\\/g, '/')}#L${doc.line}`;
+    const repo =
+  doc.module === "p5.sound"
+    ? "processing/p5.sound"
+    : "processing/p5.js";
+
+    const comment = `# This file was auto-generated. Please do not edit it manually!\n# To make changes, edit the comments in the corresponding source file:\n# https://github.com/${repo}/blob/v${p5Version}/${doc.file.replace(/\\/g, '/')}#L${doc.line}`;
     
     // Convert the frontmatter to a string
     const frontmatter = matter.stringify("", frontMatterArgs);


### PR DESCRIPTION
Fixes incorrect GitHub source links for p5.sound reference pages.

The reference builder now correctly points p5.sound docs to the
processing/p5.sound repository instead of processing/p5.js.

Fixes #1030
