### PR TITLE
Fix #1030: p5.sound reference pages link to correct GitHub repository

### DIFF
--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -292,7 +292,16 @@ const convertToMDX = async (
 
   try {
     // Add YAML comment to the frontmatter
-    const comment = `# This file was auto-generated. Please do not edit it manually!\n# To make changes, edit the comments in the corresponding source file:\n# https://github.com/processing/p5.js/blob/v${p5Version}/${doc.file.replace(/\\/g, '/')}#L${doc.line}`;
+    const repo =
+  doc.module === "p5.sound"
+    ? "processing/p5.sound"
+    : "processing/p5.js";
+
+const comment =
+  `# This file was auto-generated. Please do not edit it manually!\n` +
+  `# To make changes, edit the comments in the corresponding source file:\n` +
+  `# https://github.com/${repo}/blob/v${p5Version}/${doc.file.replace(/\\/g, '/') }#L${doc.line}`;
+
     
     // Convert the frontmatter to a string
     const frontmatter = matter.stringify("", frontMatterArgs);


### PR DESCRIPTION
### Summary
Fixes incorrect GitHub source links on p5.sound reference pages by routing them to the `processing/p5.sound` repository instead of `processing/p5.js`.

### Changes
- Updated reference builder logic to select the correct repository based on module type

### Testing
- Verified generated links point to the correct GitHub repositories

Fixes #1030
