### PR TITLE
Fixed the "edit source" links on p5.sound reference pages (beta.p5js.org) to point to the correct repository.

### DIFF
--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -272,7 +272,7 @@ const descriptionParts = description.split(
               };
 
               return (
-                <div class="text-body my-lg">
+                  <div class="text-body my-lg">
                   <a
                     href={`/reference/${methodValue.path}`}
                     class="text-body-large"
@@ -292,11 +292,13 @@ const descriptionParts = description.split(
            <div class="text-body [&_a]:text-type-magenta-dark [&_a]:!decoration-type-magenta-dark my-lg">
             Notice any errors or typos? <a href ="https://github.com/processing/p5.js/issues">Please let us know</a>. Please feel free to edit 
             <a
-                href={`https://github.com/processing/p5.js/blob/v${p5Version}/${entry.data.file}#L${entry.data.line}`}     
-                  >
-                  {entry.data.file}
-                  </a>
-                and open a pull request!
+              href={entry.data.module === 'p5.sound'
+              ? `https://github.com/processing/p5.sound.js/blob/main/${entry.data.file}#L${entry.data.line}`
+              : `https://github.com/processing/p5.js/blob/v${p5Version}/${entry.data.file}#L${entry.data.line}`}     
+            >
+              {entry.data.file}
+            </a>
+            and open a pull request!
            </div>
           </div>
         )

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -272,7 +272,7 @@ const descriptionParts = description.split(
               };
 
               return (
-                  <div class="text-body my-lg">
+                <div class="text-body my-lg">
                   <a
                     href={`/reference/${methodValue.path}`}
                     class="text-body-large"


### PR DESCRIPTION
## Summary
Fixed the "edit source" links on p5.sound reference pages (beta.p5js.org) to point to the correct repository.

## Problem
The source links on p5.sound reference pages were pointing to `processing/p5.js`, which resulted in 404 errors. For example:
- ❌ `https://github.com/processing/p5.js/blob/v2.1.2/src/sources/AudioIn.js` (404)

## Solution
Added a conditional check: when `entry.data.module === 'p5.sound'`, the link now points to `processing/p5.sound.js` repository with the `main` branch:
- ✅ `https://github.com/processing/p5.sound.js/blob/main/src/sources/AudioIn.js`
