### PR TITLE
Fix Search Cancel button does not delete query text

### DIFF
--- a/src/components/SearchResults/index.tsx
+++ b/src/components/SearchResults/index.tsx
@@ -98,6 +98,7 @@ const SearchResults = ({
     if (inputRef.current) {
       inputRef.current.value = "";
     }
+    onSearchChange("")
   };
   const submitInput = () => {
     if (inputRef.current) {


### PR DESCRIPTION
Fixes #949 

### Previous Behavior
When users clicked the X to clear the search input, the visual field was cleared but the search state in the parent component remained unchanged. This caused old search results to reappear when typing again.

### Solution
Updated `clearInput()` to call `onSearchChange("")` so the parent component's search state is properly reset along with the input field.