### PR TITLE
Add CONTRIBUTING.md with reference to p5.js contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,25 @@ The guide includes:
 - Community guidelines
 
 Following these guidelines helps keep contributions consistent and welcoming for everyone.
+
+
+## Local Development Setup
+
+To set up the p5.js website locally:
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/processing/p5.js-website.git
+   cd p5.js-website
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing to p5.js Website
+
+Thank you for your interest in contributing to the p5.js website! 🎉
+
+This repository follows the contribution guidelines defined in the main p5.js repository.
+
+👉 Please read the official p5.js contribution guide here:
+https://github.com/processing/p5.js/blob/main/CONTRIBUTING.md
+
+The guide includes:
+- How to set up the development environment
+- Coding standards
+- How to submit issues and pull requests
+- Community guidelines
+
+Following these guidelines helps keep contributions consistent and welcoming for everyone.


### PR DESCRIPTION
This PR adds a CONTRIBUTING.md file to the repository that links to the main p5.js contribution guide,
making contribution guidelines more discoverable and aligned with GitHub recommendations.

Closes #1079
