### PR TITLE
docs: update vscode extension to p5.js 2.0 compatible one

### DIFF
--- a/src/content/tutorials/en/setting-up-your-environment.mdx
+++ b/src/content/tutorials/en/setting-up-your-environment.mdx
@@ -303,13 +303,15 @@ Once your project is saved, you can share it!
 
 - Open VS Code and navigate to the extensions manager on the left toolbar.
 - Type [*p5.js 2.x Project Generator*](https://marketplace.visualstudio.com/items?itemName=Irti.p5js-project-generator) in the search bar, select the extension, and click the install button.
-- Familiarize yourself with details for this extension [here](https://github.com/antiboredom/p5.vscode/blob/master/README.md).
+- Familiarize yourself with details for this extension [here](https://github.com/IrtizaNasar/p5-2.vscode/blob/main/README.md).
 
 
 ### Step 3: Create a p5.js project
 
 - Click on *View* on the top toolbar and select Command Palette.
-- Type *Create p5.js Project* in the search bar and select the folder on your machine in which you would like to save your project.
+- Type *Create a new p5.js 2.x Project* in the search bar and select the command.
+- Follow the prompts to configure your project.
+- Select the folder on your machine where you would like to save your project.
 
 
 ### Step 4: View your first sketch

--- a/src/content/tutorials/en/setting-up-your-environment.mdx
+++ b/src/content/tutorials/en/setting-up-your-environment.mdx
@@ -302,7 +302,7 @@ Once your project is saved, you can share it!
 ### Step 2: Install the p5.js library extension
 
 - Open VS Code and navigate to the extensions manager on the left toolbar.
-- Type [*p5.vscode*](https://marketplace.visualstudio.com/items?itemName=samplavigne.p5-vscode) in the search bar, select the extension, and click the install button.
+- Type [*p5.js 2.x Project Generator*](https://marketplace.visualstudio.com/items?itemName=Irti.p5js-project-generator) in the search bar, select the extension, and click the install button.
 - Familiarize yourself with details for this extension [here](https://github.com/antiboredom/p5.vscode/blob/master/README.md).
 
 


### PR DESCRIPTION
This PR updates the VS Code extension recommended in the setup tutorial to [one](https://marketplace.visualstudio.com/items?itemName=Irti.p5js-project-generator) that explicitly supports p5.js 2.0.

fixes #1083 