### PR TITLE
remove "Component rendered" console output on playing embedded sketch

### DIFF
--- a/src/components/CopyCodeButton/index.tsx
+++ b/src/components/CopyCodeButton/index.tsx
@@ -36,8 +36,6 @@ export const CopyCodeButton = ({
     }
   };
 
-  console.log('Component rendered, isCopied:', isCopied);
-
   return (
     <>
       <CircleButton


### PR DESCRIPTION
Removes unnecessary console logging that was occurring each time any embedded sketch was played.