### PR TITLE
fix: correct circle() diameter explanation in Get Started tutorial

### DIFF
--- a/src/content/tutorials/en/get-started.mdx
+++ b/src/content/tutorials/en/get-started.mdx
@@ -208,7 +208,7 @@ Some shape functions, such as [`circle()`](/reference/p5/circle), use numbers th
 
 - The first *argument* in the [`circle()`](/reference/p5/circle) function used in the code example above, the number 550, is the x-coordinate of the center point. This means that the center point is located 550 pixels to the right of the left edge of the canvas.
 - The second argument, the number 50, is the y-coordinate of the center point. This means that the center point is located 50 pixels below the top edge of the canvas.
-- The third argument, the number 100, is the size of the circle (width & height). This means that the circle is 50 pixels wide and 50 pixels high.
+- The third argument, the number 100, is the diameter of the circle. This means that the circle is 100 pixels wide and 100 pixels high.
 
 ![A diagram of a circle with a center point at (x,y) and diameter “size”. The syntax for the syntax for using the circle function is displayed above the diagram as: “circle(x, y, size);”](../images/introduction/circle-diagram.png)
 


### PR DESCRIPTION
### Summary
This PR fixes an incorrect explanation of the third parameter of the `circle()` function in the Get Started tutorial.

The tutorial previously stated that a value of 100 results in a circle that is 50 pixels wide and high, which is incorrect.

### Changes
- Updated the explanation to correctly describe the third parameter as the diameter.
- Clarified that a diameter of 100 results in a circle that is 100 pixels wide and 100 pixels high.

### Related Issue
Resolves #1095