### PR TITLE
fix typography 2.0 tutorial crash caused by space character passed in textToModel()

### DIFF
--- a/src/content/tutorials/en/typography-2.0.mdx
+++ b/src/content/tutorials/en/typography-2.0.mdx
@@ -3,7 +3,7 @@ title: "Greetings from p5.js 2.0: Animation, Interaction, and Typography in 2D a
 description: "Use new typography and 3D features of p5.js 2.0 to create an interactive postcard!"
 category: "2.0"
 featuredImage: ../images/featured/postcard.jpg
-featuredImageAlt: "An old-style postcard reading 'Greetings from P5.JS 2.0'"
+featuredImageAlt: "An old-style postcard reading 'Greetings from P5.JS-2.0'"
 relatedContent:
   references:
     - en/p5/loadfont
@@ -164,7 +164,7 @@ In p5.js 2.0, we can make 3D letters out of a font! We'll create three new varia
 let blockFont;
 let blockText;
 let blockTextSize = 130;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 ```
 
 The bold version of [Tilt Warp from Google Fonts](https://fonts.google.com/specimen/Tilt+Warp) will work nicely for some block text, so we'll load that the same way we loaded the cursive font, storing it into `blockFont`.
@@ -195,7 +195,7 @@ let cursiveTextSize = 40;
 let blockFont;
 let blockText;
 let blockTextSize = 130;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 async function setup() {
   createCanvas(600, 400, WEBGL);
@@ -254,7 +254,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 /////////////////////////////////////////////////////
 // Create a variable to store the background image
@@ -329,7 +329,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 let bgImg;
 
@@ -399,7 +399,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 let bgImg;
 
@@ -477,7 +477,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 let bgImg;
 
@@ -664,7 +664,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 let bgImg;
 /////////////////////////////////////////////////////
@@ -774,7 +774,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 let bgImg;
 let fgImg;
@@ -921,7 +921,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 let bgImg;
 let fgImg;
@@ -1084,7 +1084,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 
 let bgImg;
 let fgImg;
@@ -1265,7 +1265,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 /////////////////////////////////////////////////////
 // Split the greeting text into an array of letters
 /////////////////////////////////////////////////////
@@ -1472,7 +1472,7 @@ let blockText;
 
 let blockTextSize = 130;
 let cursiveTextSize = 40;
-let greeting = 'P5.JS 2.0';
+let greeting = 'P5.JS-2.0';
 let letters = greeting.split('');
 /////////////////////////////////////////////////////
 // Create an array with the start times for


### PR DESCRIPTION
This updates the greeting text in the Typography 2.0 tutorial to avoid calling `textToModel()` on a space character, which currently throws due to a regression.

This is a temporary workaround until the core [issue](https://github.com/processing/p5.js/issues/8428) is fixed in p5.js.

Closes #1099 