### PR TITLE
fix: restore focus after search submission (#914)

### DIFF
--- a/src/components/SearchProvider/index.tsx
+++ b/src/components/SearchProvider/index.tsx
@@ -126,7 +126,6 @@ const SearchProvider = ({
       currentLocale={currentLocale as string}
       onSearchChange={handleSearchTermChange}
       uiTranslations={uiTranslations}
-      key={searchTerm}
     />
   );
 };

--- a/src/components/SearchResults/index.tsx
+++ b/src/components/SearchResults/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "preact/hooks";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { Icon } from "../Icon";
 
 type SearchResult = {
@@ -23,8 +23,24 @@ const SearchResults = ({
   uiTranslations,
 }: SearchResultProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const clearButtonRef = useRef<HTMLButtonElement>(null);
   const [currentFilter, setCurrentFilter] = useState("");
   const [isInputEdited, setInputEdited] = useState(false);
+  const prevIsInputEdited = useRef(isInputEdited);
+
+   // Reset filter and input state when search term changes
+  useEffect(() => {
+    setCurrentFilter("");
+    setInputEdited(false);
+  }, [searchTerm]);
+
+  // Focus clear button when transitioning from edited to not edited
+  useEffect(() => {
+    if (prevIsInputEdited.current && !isInputEdited && clearButtonRef.current) {
+      clearButtonRef.current.focus();
+    }
+    prevIsInputEdited.current = isInputEdited;
+  }, [isInputEdited]);
 
   const allUniqueCategoriesForResults = useMemo(() => {
     const categories = results.map((result) => result.category);
@@ -140,6 +156,7 @@ const SearchResults = ({
           </button>
         ) : (
           <button
+            ref={clearButtonRef}
             type="reset"
             class="absolute right-0 top-0 px-[22px] py-[13px]"
             onClick={clearInput}


### PR DESCRIPTION
## Summary

Fixes #914 - Restores focus management after search submission to improve keyboard navigation and screen reader accessibility.

**Problem:** When users clicked the "Submit search" button, focus was lost as the button disappeared from the DOM and was replaced with the "Clear search input" button. This created an accessibility barrier for keyboard and screen reader users who lost their place in the interface.

**Solution:** Implemented automatic focus transfer to the clear button after search submission using `useEffect` to track state transitions. Also removed the `key` prop that was causing component remounts so that we can preserve the state tracking required for focus management.

**Changes:**
  - Add `clearButtonRef` and focus management logic to automatically focus clear button after search submission.
  - Track previous `isInputEdited` state to detect transitions (prevents unwanted focus on initial render).
  - Remove `key={searchTerm}` prop from SearchResults - this was causing the component to unmount/remount on every search, which would clear the `prevIsInputEdited` state and break focus management. Replace remount-based state reset with `useEffect` for better performance and to preserve component state.

## Demo

After

https://github.com/user-attachments/assets/469b0ea3-dd25-4eea-8729-79f8b0881142

