### PR TITLE
Update translation tracker to handle missing commit data

### DIFF
--- a/.github/actions/translation-tracker/index.js
+++ b/.github/actions/translation-tracker/index.js
@@ -371,6 +371,7 @@ class GitHubCommitTracker {
     const englishFile = fileTranslations.englishFile;
     const outdatedLanguages = fileTranslations.outdatedLanguages;
     const missingLanguages = fileTranslations.missingLanguages;
+    const englishCommit = fileTranslations.englishCommit;
 
     let body = `## 🌍 Translation Update Needed
 
@@ -378,7 +379,7 @@ class GitHubCommitTracker {
 **Branch**: \`${this.currentBranch}\`
 
 ### 📅 Timeline
-- **Latest English update**: ${fileTranslations.englishCommit.date.toLocaleDateString()} by ${fileTranslations.englishCommit.author}
+- **Latest English update**: ${englishCommit ? `${englishCommit.date.toLocaleDateString()} by ${englishCommit.author}` : 'Unknown (commit data unavailable)'}
 
 `;
 
@@ -420,7 +421,7 @@ class GitHubCommitTracker {
 - [ ] Ensure translation is accurate and culturally appropriate
 
 ### 📝 Summary of English File Changes
-**Last commit**: [${fileTranslations.englishCommit.message}](${fileTranslations.englishCommit.url})
+**Last commit**: ${englishCommit ? `[${englishCommit.message}](${englishCommit.url})` : 'Unavailable'}
 
 ${outdatedLanguages.length > 0 || missingLanguages.length > 0 ? `**Change Type**: English file was updated. ${outdatedLanguages.length > 0 ? `${outdatedLanguages.map(l => this.getLanguageDisplayName(l.language)).join(', ')} translation${outdatedLanguages.length > 1 ? 's' : ''} may be outdated.` : ''} ${missingLanguages.length > 0 ? `${missingLanguages.map(l => this.getLanguageDisplayName(l.language)).join(', ')} translation${missingLanguages.length > 1 ? 's are' : ' is'} missing.` : ''}` : ''}
 


### PR DESCRIPTION
When I merged a PR #1105 the CI test were failing, saying that no englishCommit data is available. 

```
TypeError: Cannot read properties of null (reading 'date')
    at GitHubCommitTracker.formatMultiLanguageIssueBody (/home/runner/work/p5.js-website/p5.js-website/.github/actions/translation-tracker/index.js:381:63)
    at GitHubCommitTracker.createMultiLanguageTranslationIssue (/home/runner/work/p5.js-website/p5.js-website/.github/actions/translation-tracker/index.js:306:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async checkTranslationStatus (/home/runner/work/p5.js-website/p5.js-website/.github/actions/translation-tracker/index.js:665:21)
    at async main (/home/runner/work/p5.js-website/p5.js-website/.github/actions/translation-tracker/index.js:737:31)
```

So, in this PR I just added a guard, when the data is null, it shouldn't crash. I haven't gone till the root cause of the problem, @Divyansh013 do you have any idea on this? Since I saw the latest commit to this file was from you. Thanks for the help. 