### PR TITLE
Fix Tutorials page grid layout and Header overflow on mobile

### DIFF
--- a/src/components/PageHeader/RootPage.astro
+++ b/src/components/PageHeader/RootPage.astro
@@ -6,13 +6,13 @@ const { title, subtitle } = Astro.props;
 // to the header only when the filter by keyword is not present.
 const routesWithFilter = ["/reference"];
 const isFilterRoute = routesWithFilter.some((route) =>
-  Astro.url.pathname.includes(route)
+  Astro.url.pathname.includes(route),
 );
 const borderStyle = isFilterRoute ? "" : "border-b border-sidebar-type-color";
 ---
 
 <div
-  class=`content-grid-simple min-h-[350px] h-[50vh] pt-[11.25rem] lg:pt-4xl bg-accent-color text-accent-type-color pb-md px-5 md:px-lg ${borderStyle}`
+  class=`content-grid-simple min-h-[350px] min-h-[50vh] h-auto pt-[11.25rem] lg:pt-4xl bg-accent-color text-accent-type-color pb-md px-5 md:px-lg ${borderStyle}`
 >
   <h1 class="whitespace-pre-line col-span-full mb-5">{title}</h1>
   <p class="text-h3 !mt-0 mb-3xl col-span-2">{subtitle}</p>

--- a/src/layouts/TutorialsLayout.astro
+++ b/src/layouts/TutorialsLayout.astro
@@ -21,7 +21,7 @@ const sections = categories.map((slug) => {
     .filter((e: TutorialEntry) => e.data.category === slug)
     .sort(
       (a: TutorialEntry, b: TutorialEntry) =>
-        (a.data.categoryIndex ?? 1000) - (b.data.categoryIndex ?? 1000)
+        (a.data.categoryIndex ?? 1000) - (b.data.categoryIndex ?? 1000),
     );
 
   return { slug, name, sectionEntries };
@@ -55,7 +55,7 @@ setJumpToState({
         </h2>
         <ul class="content-grid border-b border-sidebar-type-color last:border-0">
           {sectionEntries.map((entry: TutorialEntry, i: number) => (
-            <li class="col-span-3">
+            <li class="col-span-6 md:col-span-3">
               <GridItemTutorial item={entry} lazyLoad={i > 3} />
             </li>
           ))}
@@ -66,7 +66,9 @@ setJumpToState({
 
   <section>
     <h2 class="mb-gutter-md mt-0">
-      {t("tutorialCategories", "education-resources")}<a id="education-resources"></a> <!-- ✅ changed from tutorialsPage -->
+      {t("tutorialCategories", "education-resources")}<a
+        id="education-resources"></a>
+      <!-- ✅ changed from tutorialsPage -->
     </h2>
     <p>{t("tutorialsPage", "education-resources-snippet")}</p>
     <LinkButton url="/education-resources" variant="link" class="mt-lg">


### PR DESCRIPTION
This PR resolves two visual layout issues on the Tutorials page for mobile users: squashed grid items and header text overflow.
### Issues
1.  **Squashed Grid Items:** The tutorials list was using `col-span-3` in a 6-column grid on all screen sizes. On small mobile screens, this forced two items per row, making the cards look squashed and unreadable.
2.  **Header Overflow (Grey Box):** The `RootPageHeader` had a fixed height (`h-[50vh]`) combined with large top padding. On mobile devices, long subtitles would overflow the grey background box, rendering text outside the styled container.
### Fixes
- **Layout:** Updated `src/layouts/TutorialsLayout.astro`. Changed grid items to `col-span-6 md:col-span-3`. This enforces a single-column stacked layout (full width) on mobile and reverts to the two-column layout on tablets and desktops.
- **Header:** Updated `src/components/PageHeader/RootPage.astro`. Changed `h-[50vh]` to `min-h-[50vh] h-auto`. This ensures the header background expands dynamically to fit the content if the text is long, preventing overflow.
### Verification
- **Mobile View:** Verified that tutorial cards are stacked vertically and readable. Verified that the header grey background expands to contain the full subtitle text.
- **Desktop View:** Verified that the layout remains unchanged (2 cards per row) on larger screens.

Before :
<img width="257" height="453" alt="Screenshot From 2026-01-27 13-45-55" src="https://github.com/user-attachments/assets/ed5f80c1-17cd-4d9b-afae-f88b490e01cb" />
After:
<img width="257" height="453" alt="Screenshot From 2026-01-27 14-47-04" src="https://github.com/user-attachments/assets/47dd007d-848e-48ed-894b-e55478a6b3e4" />
<img width="257" height="453" alt="Screenshot From 2026-01-27 14-47-13" src="https://github.com/user-attachments/assets/c9f93164-51cf-4d21-804d-5f42504e2660" />
