### PR TITLE
replace deprecated dirent.path with dirent.parentPath (on main). fixes #1111

### DIFF
--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -232,7 +232,7 @@ export const sanitizeName = (name: string) =>
  * @returns full path to the entry
  */
 export const fullPathFromDirent = (dirent: Dirent): string =>
-  path.join(dirent.path, dirent.name);
+  path.join(dirent.parentPath, dirent.name);
 
 /**
  * Returns the absolute path of the files within a directory
@@ -253,7 +253,7 @@ export const getFilepathsWithinDir = async (
       [dirAbsolutePath]
     : // readdir returns relative filepaths 🥴
       (await readdir(dirAbsolutePath)).map((p) =>
-        path.join(dir.path, dir.name, p),
+        path.join(dir.parentPath, dir.name, p),
       );
 };
 


### PR DESCRIPTION
Fixes #1111 on main branch, allows building contributor-docs on current version of node (v24)

* dirent.path is removed in node v24
* Per deprecation warning: https://nodejs.org/docs/latest-v20.x/api/fs.html#direntpath
* dirent.path has been an alias for dirent.parentPath since node v20