### PR TITLE
feat: add visually invisble h1 to search result page

### DIFF
--- a/src/layouts/SearchLayout.astro
+++ b/src/layouts/SearchLayout.astro
@@ -14,6 +14,7 @@ setJumpToState(null);
 <Head title={"Search"} locale={currentLocale} />
 
 <BaseLayout title={title} variant="search">
+  <h1 class="sr-only">Search Results</h1>
   <SearchProvider
     client:only
     currentLocale={currentLocale}


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/1126.

## Summary

  - Adds a visually hidden `<h1>` "Search Results" heading to the search page for accessibility

  ## Details

  The search page was missing a level-one heading, which is a WCAG best practice for proper document structure and assistive technology navigation. This change adds an `<h1>` element with the `sr-only` class to make it accessible to screen readers while keeping it visually hidden to maintain the current design.

  ## Changes

  - Added `<h1 class="sr-only">Search Results</h1>` to `src/layouts/SearchLayout.astro`