### PR TITLE
feat: Add alt text to CC BY-NC-SA license badge in ExampleLayout

### DIFF
--- a/src/layouts/ExampleLayout.astro
+++ b/src/layouts/ExampleLayout.astro
@@ -91,7 +91,7 @@ const { showBanner, englishUrl } = checkTranslationBanner(
       <Content />
     </div>
     <div class="rendered-markdown">
-      <img src="/images/by-nc-sa.svg" />
+      <img src="/images/by-nc-sa.svg" alt="Creative Commons BY-NC-SA license badge" />
 
       <p>
 


### PR DESCRIPTION
Resolves #1128.

## Summary
  - Adds descriptive alt text to the Creative Commons BY-NC-SA license badge image in ExampleLayout
