### PR TITLE
feat: Add alt text to CC BY-NC-SA license badge in ExampleLayout [2.0]

### DIFF
--- a/src/layouts/ExampleLayout.astro
+++ b/src/layouts/ExampleLayout.astro
@@ -81,7 +81,7 @@ const remixHistoryHasCodeLinks = example.data.remix?.some(
       <Content />
     </div>
     <div class="rendered-markdown">
-      <img src="/images/by-nc-sa.svg" />
+      <img src="/images/by-nc-sa.svg" alt="Creative Commons BY-NC-SA license badge" />
 
       <p>
 


### PR DESCRIPTION
Applies https://github.com/processing/p5.js-website/pull/1127 to `2.0`