### PR TITLE
Fix #870: apply underline styling to anchor element

### DIFF
--- a/src/components/Nav/JumpToLinks.tsx
+++ b/src/components/Nav/JumpToLinks.tsx
@@ -36,9 +36,11 @@ export const JumpToLinks = ({
           {links?.map((link) => (
             <li
               key={link.label}
-              class={`${styles.linklabel} ${link.size ?? ""} ${link.current ? "current" : ""}`}
+              class={`${styles.linklabel} ${link.size ?? ""}`}
             >
-              <a href={link.url}>{link.label}</a>
+              <a href={link.url} class={link.current ? "current" : ""}>
+                {link.label}
+              </a>
             </li>
           ))}
         </ul>

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -225,7 +225,9 @@
 }
 
 .linklabel {
-  &:global(.current) {
+  text-decoration: none;
+
+  a:global(.current) {
     text-decoration-line: underline;
   }
 


### PR DESCRIPTION
Applies fix for https://github.com/processing/p5.js-website/issues/870 to `2.0`