### PR TITLE
Add spacing between heading and image in example cards (fixes #975)

### DIFF
--- a/styles/global.scss
+++ b/styles/global.scss
@@ -229,8 +229,8 @@ section,
 
   h2,
   .text-h2 {
-    margin-top: var(--gutter-md);
-    margin-bottom: 0px;
+      padding-top: var(--spacing-md);
+  padding-bottom: var(--spacing-md);
   }
 
   h2,


### PR DESCRIPTION
This PR adds a small vertical gap between the example heading and image to improve readability.

Fixes #975