### PR TITLE
gitignore vscode local.code-workspace allowing users project-specific overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ translator/
 
 # Don't commit custom dev builds
 public/p5.min.js
+
+# optional local preferences for vscode
+local.code-workspace


### PR DESCRIPTION
Add `local.code-workspace` to .gitignore

This allows user to safely add a local code-workspace to the project to override project-specific settings that don't work for them, (without changing .vscode/settings.json which is git-tracked)

fixes #1145 