### PR TITLE
Fix broken p5.* reference links in reference pages [2.0]

### DIFF
--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -92,13 +92,14 @@ const descriptionParts = description.split(
 
 // Normalizes malformed p5.* reference anchors (e.g. "#/p5.Element")
 // to proper reference routes ("/reference/p5/p5.Element/")
-function normalizeP5ReferenceLinks(html) {
+function normalizeP5ReferenceLinks(html: string | undefined): string | undefined {
   if (!html) return html;
   return html.replace(
     /href="#\/(p5\.[^"]+)"/g,
     'href="/reference/p5/$1/"'
   );
 }
+---
 
 <Head title={entry.data.title} locale={currentLocale} />
 

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -90,7 +90,15 @@ const descriptionParts = description.split(
   /(<pre><code class="language-js(?: example)?">[\s\S]+?<\/code><\/pre>)/gm
 );
 
----
+// Normalizes malformed p5.* reference anchors (e.g. "#/p5.Element")
+// to proper reference routes ("/reference/p5/p5.Element/")
+function normalizeP5ReferenceLinks(html) {
+  if (!html) return html;
+  return html.replace(
+    /href="#\/(p5\.[^"]+)"/g,
+    'href="/reference/p5/$1/"'
+  );
+}
 
 <Head title={entry.data.title} locale={currentLocale} />
 
@@ -208,7 +216,7 @@ const descriptionParts = description.split(
                           class="col-span-5 [&_p]:m-0 [&_p]:inline [&_a]:underline"
                     >
                       {param.type && <span>{param.type}: </span>}
-                      <span set:html={param.description} />
+                      <span set:html={normalizeP5ReferenceLinks(param.description)} />
                     </div>
                   </div>
                 ))}
@@ -226,7 +234,7 @@ const descriptionParts = description.split(
                           class="col-span-5 [&_p]:m-0 [&_p]:inline [&_a]:underline"
                         >
                           {param.type && <span>{param.type}: </span>}
-                          <span set:html={param.description} />
+                          <span set:html={normalizeP5ReferenceLinks(param.description)} />
                         </div>
                       </div>
                     )
@@ -246,7 +254,7 @@ const descriptionParts = description.split(
                       class="col-span-5 [&_p]:m-0 [&_p]:inline [&_a]:underline"
                 >
                   {entry.data.return.type && <span>{entry.data.return.type}: </span>}
-                  <span set:html={entry.data.return.description} />
+                  <span set:html={normalizeP5ReferenceLinks(entry.data.return.description)} />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Applies https://github.com/processing/p5.js-website/pull/1121 to `2.0`
Addresses https://github.com/processing/p5.js-website/issues/1120