### PR TITLE
Allow 2.0 tutorials to use mermaid diagrams

### DIFF
--- a/src/components/PreProxy/index.astro
+++ b/src/components/PreProxy/index.astro
@@ -1,0 +1,20 @@
+---
+// Conditionally process pre blocks with CodeBlockWrapper or leave untouched.
+// Not all pre blocks should be rendered by the CodeBlockWrapper.
+// For example, mermaid diagram declarations should be left alone so that mermaid can process them.  
+//   In those cases, the diagram source isn't intended for the user.
+
+import CodeBlockWrapper from '../CodeBlockWrapper/index.astro';
+
+const props = Astro.props;
+
+// Check if this is a mermaid block
+// The 'data-language' or 'class' usually contains the language name
+const isMermaid = props.class?.includes('mermaid') || props['data-language'] === 'mermaid';
+---
+
+{isMermaid ? (
+  <pre {...props}><slot /></pre>
+) : (
+  <CodeBlockWrapper {...props}><slot /></CodeBlockWrapper>
+)}

--- a/src/layouts/TutorialLayout.astro
+++ b/src/layouts/TutorialLayout.astro
@@ -4,6 +4,7 @@ import Head from "@components/Head/index.astro";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 import { setJumpToState } from "../globals/state";
 import FreeRatioImage from "@components/Image/FreeRatioImage.astro";
+import PreProxy from "@components/PreProxy/index.astro";
 import CodeBlockWrapper from "@components/CodeBlockWrapper/index.astro";
 import LinkWrapper from "@components/LinkWrapper/index.astro";
 import RelatedItems from "@components/RelatedItems/index.astro";
@@ -68,7 +69,7 @@ const relatedExamples =
       components={{
         ...components,
         img: FreeRatioImage,
-        pre: CodeBlockWrapper,
+        pre: PreProxy,
         a: LinkWrapper,
       }}
     />


### PR DESCRIPTION
Changes: 
1. Change TutorialLayout ([src/layouts/TutorialLayout.astro](src/layouts/TutorialLayout.astro))
2. Add PreProxy [src/components/PreProxy/index.astro](src/components/PreProxy/index.astro)

In TutorialLayout, send `pre` blocks to a new `PreProxy` which _only_ calls CodeBlockWrapper if the block is not tagged `mermaid`.  Otherwise it leaves them untouched so that mermaid can interpret and convert correctly.

Prevents blocks such as the following being sent to CodeBlockWrapper:
````
```mermaid
//diagram here
```
````

Fixes #1066 for 2.0
(This is just a cherry-pick of previous fix for main branch  / p5 v1.x.)