### PR TITLE
Add margin below example headings for better spacing (resolves #975) [2.0]

### DIFF
--- a/styles/global.scss
+++ b/styles/global.scss
@@ -230,7 +230,7 @@ section,
   h2,
   .text-h2 {
     margin-top: var(--gutter-md);
-    margin-bottom: 0px;
+    margin-bottom: var(--spacing-md);
   }
 
   h2,


### PR DESCRIPTION
Applies https://github.com/processing/p5.js-website/pull/976 to branch `2.0`