### PR TITLE
fix: remove defunct donation banner scripts and styles (#1189) [2.0]

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -84,12 +84,6 @@ const headerTopic = topic
       const htmlElement = document.documentElement;
       htmlElement.className = `${storedSettings.join(" ")} ${htmlElement.className}`;
     </script>
-    <link
-      rel="stylesheet"
-      href="https://foundation-donate-banner.netlify.app/static/css/main.css"
-    />
-    <script src="https://foundation-donate-banner.netlify.app/static/js/main.js"
-    ></script>
   </head>
   <body>
     <div class="top-layout-grid">


### PR DESCRIPTION
Applies https://github.com/processing/p5.js-website/pull/1190 to `2.0`