### PR TITLE
fix: resolve visualID render crash in Sketch component

### DIFF
--- a/src/components/GridItem/Sketch.astro
+++ b/src/components/GridItem/Sketch.astro
@@ -13,6 +13,7 @@ interface Props {
 }
 
 const { item, lazyLoad, scale = 1 } = Astro.props;
+if(!item) return
 const imgSrc = await getSketchThumbnailSource(item.visualID)
 const width = Math.min(thumbnailDimensions * scale, 1500);
 const height = Math.min(


### PR DESCRIPTION
Closes #1191 
Description:
This PR adds a guard clause in `Sketch.astro`. Currently, when the OpenProcessing API fails (like a 403 or 500 error), the item variable becomes undefined, and the code tries to access `item.visualID`, which causes a `TypeError `and crashes the entire page. 

Changes:
The fix adds a simple check at the top: `if (!item) return` This means if item is undefined or null, the component stops rendering immediately and never tries to access `item.visualID` so the page loads safely without crashing. 

Verification:
The issue was already happening when the API failed when I run the server locally.

**Without fix:** API fails → `item` undefined → page crashes ❌  
**With fix:** API fails → guard clause stops execution → page loads safely ✅

Tested locally on real API failure. Works perfectly.