### PR TITLE
Update donation label wording for clarity.

### DIFF
--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -42,7 +42,7 @@ Returns: Returns
 Related References: Related References
 Related Examples: Related Examples
 Show Code: Show Code
-Donate to p5.js: Donate to p5.js
+Donate to p5.js: Contribute to p5.js
 Download p5.js: Download p5.js
 No Results: No entries found for that search.
 No alt text: No alt text


### PR DESCRIPTION
This PR updates the label text from "Donate to p5.js" to Contribute to p5.js" in en.yaml to ensure consistent and inclusive wording across the website. Resolves no existing issue; minor text improvement.