### PR TITLE
Fix inline <code> escaping in reference pages (2.0 branch)

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -152,8 +152,8 @@ export const Dropdown = ({
           </div>
           <button
             onClick={() => handleOptionClick(option)}
-            ref={el => {
-              optionRefs.current[index] = el as HTMLButtonElement
+            ref={(el) => {
+              optionRefs.current[index] = el as HTMLButtonElement;
             }}
             onBlur={handleBlur}
           >

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -245,7 +245,9 @@ export const getRefEntryTitleConcatWithParen = (
  */
 export const escapeCodeTagsContent = (htmlString: string): string => {
   // Load the HTML string into Cheerio
-  const $ = load(htmlString);
+  const $ = load(htmlString, {
+    xmlMode: true
+  });
   // Loop through all <code> tags
   $("code").each(function () {
     // Don't escape code in multiline blocks, as these will already


### PR DESCRIPTION
Backports the inline code escaping fix from #1164 to the 2.0 branch.

This ensures escaped entities like &lt; and &gt; render correctly in reference pages.

Tested locally on affected pages.