### PR TITLE
Prepare for WebGPU docs

### DIFF
--- a/src/components/CodeEmbed/index.jsx
+++ b/src/components/CodeEmbed/index.jsx
@@ -39,7 +39,7 @@ export const CodeEmbed = (props) => {
   );
 
   let { previewWidth, previewHeight } = props;
-  const canvasMatch = /createCanvas\(\s*(\d+),\s*(\d+)\s*(?:,\s*(?:\w+\.)?(?:P2D|WEBGL)\s*)?\)/m.exec(initialCode);
+  const canvasMatch = /createCanvas\(\s*(\d+),\s*(\d+)\s*(?:,\s*(?:\w+\.)?(?:P2D|WEBGL|WEBGPU)\s*)?\)/m.exec(initialCode);
   if (canvasMatch) {
     previewWidth = previewWidth || parseFloat(canvasMatch[1]);
     previewHeight = previewHeight || parseFloat(canvasMatch[2]);

--- a/src/components/CodeEmbed/index.jsx
+++ b/src/components/CodeEmbed/index.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "preact/hooks";
 import { useLiveRegion } from '../hooks/useLiveRegion';
 import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
-import { cdnLibraryUrl, cdnSoundUrl } from "@/src/globals/globals";
+import { cdnLibraryUrl, cdnSoundUrl, cdnWebGPUUrl } from "@/src/globals/globals";
 
 import { CodeFrame } from "./frame";
 import { CopyCodeButton } from "../CopyCodeButton";
@@ -99,6 +99,7 @@ export const CodeEmbed = (props) => {
               lazyLoad={props.lazyLoad}
               scripts={[
                 ...(props.includeSound ? [cdnSoundUrl] : []),
+                ...(props.includeWebGPU ? [cdnWebGPUUrl] : []),
                 ...(props.scripts ?? []),
               ]}
             />

--- a/src/content/reference/config.ts
+++ b/src/content/reference/config.ts
@@ -87,6 +87,7 @@ export const referenceSchema = z.object({
     .or(z.literal("false").transform(() => false))
     .optional(),
   webgpu: z.coerce.boolean().optional(),
+  webgpuOnly: z.coerce.boolean().optional(),
 });
 
 export const referenceCollection = defineCollection({

--- a/src/content/reference/config.ts
+++ b/src/content/reference/config.ts
@@ -86,6 +86,7 @@ export const referenceSchema = z.object({
     .or(z.literal("true").transform(() => true))
     .or(z.literal("false").transform(() => false))
     .optional(),
+  webgpu: z.coerce.boolean().optional(),
 });
 
 export const referenceCollection = defineCollection({

--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -198,6 +198,7 @@ LibrariesLayout:
 experimentalApi:
   title: This API is experimental
   description: Its behavior may change in a future version of p5.js.
+webgpuAddon: This feature requires the p5.webgpu.js addon.
 attribution:
   Remixed by: Remixed by
   Revised in 2023 by: Revised in 2023 by

--- a/src/globals/globals.ts
+++ b/src/globals/globals.ts
@@ -26,3 +26,6 @@ export const cdnSoundUrl =
   (!!import.meta.env?.PUBLIC_P5_LIBRARY_PATH || p5Version.startsWith('2'))
     ? `https://cdn.jsdelivr.net/npm/p5.sound@${p5SoundVersion}/dist/p5.sound.min.js` as const
     : `https://cdn.jsdelivr.net/npm/p5@${p5Version}/lib/addons/p5.sound.min.js` as const
+export const cdnWebGPUUrl =
+  import.meta.env?.PUBLIC_P5_WEBGPU_LIBRARY_PATH ||
+  (`https://cdn.jsdelivr.net/npm/p5@${p5Version}/lib/p5.webgpu.min.js` as const);

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -113,6 +113,17 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
 >
   <div class="content-grid mt-0 max-w-[770px]">
     <div class="col-span-9 xl:min-w-[1000px]">
+      {entry.data.webgpuOnly && (
+        <div class="experimental">
+          <h5>
+            <div
+              class="inline-block mr-2 w-[20px] h-[20px] mb-[-2px]"
+              set:html={warning}
+            />
+            {t('webgpuAddon')}
+          </h5>
+        </div>
+      )}
       {entry.data.beta && (
         <div class="experimental">
           <h5>
@@ -123,17 +134,6 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
             {t('experimentalApi', 'title')}
           </h5>
           <p>{t('experimentalApi', 'description')}</p>
-        </div>
-      )}
-      {entry.data.webgpuOnly && (
-        <div class="experimental">
-          <h5>
-            <div
-              class="inline-block mr-2 w-[20px] h-[20px] mb-[-2px]"
-              set:html={warning}
-            />
-            {t('webgpuAddon')}
-          </h5>
         </div>
       )}
       {entry.data.deprecated && (

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -125,6 +125,17 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
           <p>{t('experimentalApi', 'description')}</p>
         </div>
       )}
+      {entry.data.webgpu && (
+        <div class="experimental">
+          <p>
+            <div
+              class="inline-block mr-2 w-[20px] h-[20px] mb-[-2px]"
+              set:html={flask}
+            />
+            {t('webgpuAddon')}
+          </p>
+        </div>
+      )}
       {entry.data.deprecated && (
         <div class="deprecated">
           <h5>
@@ -152,6 +163,7 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
               lazyLoad={false}
               allowSideBySide={true}
               includeSound={entry.data.module === 'p5.sound'}
+              includeWebGPU={entry.data.webgpu}
             />
           )
         } else if (part.startsWith('<pre>')) {
@@ -187,6 +199,7 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
                   lazyLoad={false}
                   allowSideBySide={true}
                   includeSound={entry.data.module === 'p5.sound'}
+                  includeWebGPU={entry.data.webgpu}
                 />
               );
             })}

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -127,13 +127,13 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
       )}
       {entry.data.webgpu && (
         <div class="experimental">
-          <p>
+          <h5>
             <div
               class="inline-block mr-2 w-[20px] h-[20px] mb-[-2px]"
-              set:html={flask}
+              set:html={warning}
             />
             {t('webgpuAddon')}
-          </p>
+          </h5>
         </div>
       )}
       {entry.data.deprecated && (

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -125,7 +125,7 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
           <p>{t('experimentalApi', 'description')}</p>
         </div>
       )}
-      {entry.data.webgpu && (
+      {entry.data.webgpuOnly && (
         <div class="experimental">
           <h5>
             <div
@@ -163,7 +163,7 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
               lazyLoad={false}
               allowSideBySide={true}
               includeSound={entry.data.module === 'p5.sound'}
-              includeWebGPU={entry.data.webgpu}
+              includeWebGPU={entry.data.webgpu || entry.data.webgpuOnly}
             />
           )
         } else if (part.startsWith('<pre>')) {
@@ -199,7 +199,7 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
                   lazyLoad={false}
                   allowSideBySide={true}
                   includeSound={entry.data.module === 'p5.sound'}
-                  includeWebGPU={entry.data.webgpu}
+                  includeWebGPU={entry.data.webgpu || entry.data.webgpuOnly}
                 />
               );
             })}

--- a/src/scripts/branchTest.ts
+++ b/src/scripts/branchTest.ts
@@ -17,7 +17,7 @@ if (!match) {
 const repoUrl = match[1];
 const branch = match[2];
 
-const envVars = [`PUBLIC_P5_LIBRARY_PATH='/p5.min.js'`, `P5_REPO_URL='${repoUrl}'`, `P5_BRANCH='${branch}'`];
+const envVars = [`PUBLIC_P5_LIBRARY_PATH='/p5.min.js'`, `PUBLIC_P5_WEBGPU_LIBRARY_PATH='/p5.webgpu.js'`, `P5_REPO_URL='${repoUrl}'`, `P5_BRANCH='${branch}'`];
 const env = envVars.join(' ');
 
 const envFilePath = path.join(__dirname, '../../.env');

--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -315,6 +315,7 @@ const getMethodFrontmatter = (doc: ReferenceClassItemMethod) => {
     chainable: doc.chainable === 1,
     beta: doc.beta ? !!doc.beta : undefined,
     webgpu: doc.webgpu ? !!doc.webgpu : undefined,
+    webgpuOnly: doc.webgpuOnly ? !!doc.webgpuOnly : undefined,
   };
 };
 

--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -314,6 +314,7 @@ const getMethodFrontmatter = (doc: ReferenceClassItemMethod) => {
     itemtype,
     chainable: doc.chainable === 1,
     beta: doc.beta ? !!doc.beta : undefined,
+    webgpu: doc.webgpu ? !!doc.webgpu : undefined,
   };
 };
 

--- a/src/scripts/parsers/reference.ts
+++ b/src/scripts/parsers/reference.ts
@@ -44,7 +44,13 @@ export const parseLibraryReference =
     // If we're using a custom build of p5 instead of a public release, create
     // a build and copy it to the specified path
     if (process.env.PUBLIC_P5_LIBRARY_PATH) {
-      await createP5Build('p5.js', `../../../public${  process.env.PUBLIC_P5_LIBRARY_PATH}`);
+      await createP5Build('p5.js', `../../../public${process.env.PUBLIC_P5_LIBRARY_PATH}`);
+    }
+    if (process.env.PUBLIC_P5_WEBGPU_LIBRARY_PATH) {
+      await fs.cp(
+        path.join(__dirname, 'in', 'p5.js', 'lib', 'p5.webgpu.js'),
+        path.join(__dirname, `../../../public${process.env.PUBLIC_P5_WEBGPU_LIBRARY_PATH}`),
+      );
     }
 
     // Copy the reference output so we can process it

--- a/src/scripts/resetBranchTest.ts
+++ b/src/scripts/resetBranchTest.ts
@@ -29,6 +29,11 @@ async function main() {
   if (existsSync(p5BuildPath)) {
     rmSync(p5BuildPath);
   }
+
+  const p5WebGPUBuildPath = path.join(__dirname, '../../public/p5.webgpu.js');
+  if (existsSync(p5WebGPUBuildPath)) {
+    rmSync(p5WebGPUBuildPath);
+  }
 }
 
 main().then(() => process.exit(0))

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -311,6 +311,9 @@ pre.code-box,
   & h5 {
     font-weight: bold;
     margin-bottom: var(--spacing-sm);
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/types/parsers.interface.ts
+++ b/types/parsers.interface.ts
@@ -106,6 +106,7 @@ interface Return {
 
 interface MaybeBeta {
   beta?: number;
+  webgpu?: number;
 }
 
 /* Represents a method within a class */

--- a/types/parsers.interface.ts
+++ b/types/parsers.interface.ts
@@ -107,6 +107,7 @@ interface Return {
 interface MaybeBeta {
   beta?: number;
   webgpu?: number;
+  webgpuOnly?: number;
 }
 
 /* Represents a method within a class */


### PR DESCRIPTION
I've started writing some experimental compute shader reference docs in https://github.com/processing/p5.js/pull/8531. WebGPU docs are a little different from regular ones because you need to include an extra addon script. They're a little like p5.sound in that sense, but unlike p5.sound, which has its own reference page to itself, that will *probably* not be the case for WebGPU; instead, they will likely be mixed in with other categories, like p5.strands.

So this PR:
- Updates the `custom:dev` script to also copy over the webgpu addon from the branch it builds from
- Updates the reference builder to copy over the `webgpu?: boolean` property of reference data, which will indicate that the item will need the WebGPU script in its examples
- Updates the UI components to pass in the WebGPU addon script if necessary
- Updates the reference builder to copy over the `webgpuOnly?: boolean` property of reference data, which will indicate that the item is only available in the WebGPU addon. (e.g. some examples of `model()` may use webgpu, but the method itself doesn't need the addon; `buildComputeShader` *needs* the webgpu addon.)
- Adds a warning to WebGPU reference items saying that you need an extra addon script to use them.

Here's a preview:
<img width="1295" height="906" alt="image" src="https://github.com/user-attachments/assets/40ce7963-f4f6-4650-813b-c1a76e2971de" />

The double-warning of experimental + webgpu isn't super great UI, let me know if anyone has ideas on how to make that nicer!