### PR TITLE
beta_deploy: have astro build action use node 22

### DIFF
--- a/.github/workflows/beta_deploy.yml
+++ b/.github/workflows/beta_deploy.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
         uses: withastro/action@v2
+        with:
+          node-version: 22
         
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3.0


### PR DESCRIPTION
Addresses: #1233 

Changes beta_deploy.yml build-deploy job to explicitly tell the astro build action which version of node.js to use.  

This is necessary because that astro build action will do an `npm install` which will fail if it's not at least on node 22.

The action's [documentation is here](https://github.com/withastro/action/tree/v2) (for v2 of the action).  (I note v5 of the action already defaults to run on node.js v24, but it's better we state it explicitly so maintainers are aware of what's being used and can easily control it).

