### PR TITLE
Revert "Fix inline <code> escaping in reference pages (2.0 branch)"

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -152,8 +152,8 @@ export const Dropdown = ({
           </div>
           <button
             onClick={() => handleOptionClick(option)}
-            ref={(el) => {
-              optionRefs.current[index] = el as HTMLButtonElement;
+            ref={el => {
+              optionRefs.current[index] = el as HTMLButtonElement
             }}
             onBlur={handleBlur}
           >

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -245,9 +245,7 @@ export const getRefEntryTitleConcatWithParen = (
  */
 export const escapeCodeTagsContent = (htmlString: string): string => {
   // Load the HTML string into Cheerio
-  const $ = load(htmlString, {
-    xmlMode: true
-  });
+  const $ = load(htmlString);
   // Loop through all <code> tags
   $("code").each(function () {
     // Don't escape code in multiline blocks, as these will already


### PR DESCRIPTION
This reverts commit c5937a93bb8ef093263a1fc44767a4ff54e939f7 which caused bug https://github.com/processing/p5.js-website/issues/1240