### PR TITLE
Revert "fix: properly escape inline <code> tags to preserve &lt; &gt;…

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -152,9 +152,7 @@ export const Dropdown = ({
           </div>
           <button
             onClick={() => handleOptionClick(option)}
-            ref={(el) => {
-              optionRefs.current[index] = el as HTMLButtonElement;
-            }}
+            ref={(el) => (optionRefs.current[index] = el as HTMLButtonElement)}
             onBlur={handleBlur}
           >
             <span>{option.label}</span>

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -230,9 +230,7 @@ export const getRefEntryTitleConcatWithParen = (
  */
 export const escapeCodeTagsContent = (htmlString: string): string => {
   // Load the HTML string into Cheerio
-  const $ = load(htmlString, {
-    xmlMode: true
-  });
+  const $ = load(htmlString);
   // Loop through all <code> tags
   $("code").each(function () {
     // Don't escape code in multiline blocks, as these will already


### PR DESCRIPTION
… in reference pages"

This reverts commit f7e667e03471cf4d73cfd32c5ed6e9174d5e8bba which caused bug https://github.com/processing/p5.js-website/issues/1240