### PR TITLE
Add rough custom 404 page in astro with quick search

### DIFF
--- a/.github/workflows/beta_deploy.yml
+++ b/.github/workflows/beta_deploy.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Build website

--- a/.github/workflows/beta_deploy.yml
+++ b/.github/workflows/beta_deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy beta to Netlify
+name: Deploy beta to Cloudflare
 
 on:
   # Trigger the workflow every time you push to the `main` branch
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm ci
       - name: Build website
         run: npm run build
       - name: Deploy to Cloudflare Workers

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,9 +1,8 @@
 ---
 import Head from "@components/Head/index.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { getCurrentLocale, getUiTranslator } from "../i18n/utils.ts";
+import { getCurrentLocale } from "../i18n/utils.ts";
 const currentLocale = getCurrentLocale(Astro.url.pathname);
-// const t = await getUiTranslator(currentLocale);
 ---
 
 <Head title="404: Page Not Found" locale={currentLocale} />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,52 @@
+---
+import Layout from "../layouts/BaseLayout.astro";
+
+/**
+ * Returns the last (non-empty) segment from the slash-separated path, or ""
+ * 
+ * @param path string to extract the last part of
+ * @returns the last non-empty segment or an empty string
+ * 
+ * @example 
+ * an input of `/reference/p5/basematerialshader/` will return `basematerialshader`
+ */
+function getLastPathElementOrEmptyString(path: string): string {
+    return path.split("/").filter(Boolean).pop() ?? "";
+}
+
+
+const currentPath = Astro.url.pathname;
+const finalTerm = getLastPathElementOrEmptyString(currentPath);
+---
+
+<Layout title="404: Page Not Found">
+    <main class="error-container">
+        <p>Sorry, we couldn't find your exact page <code>{currentPath}</code>.</p>
+
+        <div class="actions">
+            <a
+                href={`https://beta.p5js.org/search/?term=${finalTerm}`}
+                class="btn secondary"
+            >
+                Search here for <code>{finalTerm}</code>
+            </a>
+or
+            <a href="/" class="btn">go home</a>
+        </div>
+    </main>
+</Layout>
+<style>
+  .error-container {
+    display: flex;
+    flex-direction:column;
+    align-items: flex-start;
+    padding: 2rem 1rem;    
+    gap: 2rem;
+  }
+  .actions {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    justify-content: center;
+  }
+</style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,7 +7,7 @@ const currentLocale = getCurrentLocale(Astro.url.pathname);
 
 <Head title="404: Page Not Found" locale={currentLocale} />
 
-<BaseLayout title="About">
+<BaseLayout title="404: Page Not Found">
     <section class="flex flex-col items-start gap-8 py-8 px-2 prose max-w-none">
         <p>
             Sorry, we couldn't find your exact page

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,45 +1,49 @@
 ---
 import Layout from "../layouts/BaseLayout.astro";
-
-/**
- * Returns the last (non-empty) segment from the slash-separated path, or ""
- *
- * Discards any hash part of the URL before splitting it.
- * 
- * @param path string to extract the last part of
- * @returns the last non-empty segment or an empty string
- *
- * @example
- * An input of `/reference/p5/basematerialshader/` will return `basematerialshader`
- * An input of `/reference/p5.Vector/dist/#Examples` will return `dist`
- */
-function getLastPathElementOrEmptyString(path: string): string {
-  //Get the part of the path before the (first) hash
-  const preHashPath = path.split("#")[0] ?? "";
-  //Then get the last non-empty slash-separated segment from that
-  return preHashPath.split("/").filter(Boolean).pop() ?? "";
-}
-
-const currentPath = Astro.url.pathname;
-const finalTerm = getLastPathElementOrEmptyString(currentPath);
 ---
 
 <Layout title="404: Page Not Found">
     <main class="flex flex-col items-start gap-8 py-8 px-2 prose max-w-none">
         <p>
             Sorry, we couldn't find your exact page
-            <code>{currentPath}</code>.
+            <code id="display-path"></code>.
 
             <div class="flex flex-col gap-4">
-                <a
-                    href={`https://beta.p5js.org/search/?term=${finalTerm}`}
-                    class="btn"
-                >
-                    Search here for <code>{finalTerm}</code>
+                <a id="search-link" href="/search/" class="btn">
+                    Search here for <code id="display-search-term"></code>
                 </a>
                 or
                 <a href="/" class="btn secondary">go home</a>
             </div>
         </p>
     </main>
+    <script is:inline>
+        (function update404PageDetails() {
+            function getLastPathSegment(path) {
+                return path.split("/").filter(Boolean).pop() ?? "";
+            }
+
+            // 1. Get the last meaningful segment from the URL path, excluding hash part
+            // 2. Use that in the link href to the search
+            // 3. Also display it and the failed path
+
+            //(This .pathname already strips away any hash part)
+            const realPath = window.location.pathname;
+            const term = getLastPathSegment(realPath);
+
+            const displayPathEl = document.getElementById("display-path");
+            const searchLinkEl = document.getElementById("search-link");
+            const displaySearchTermEl = document.getElementById("display-search-term");
+
+            if (displayPathEl) {
+                displayPathEl.textContent = realPath;
+            }
+            if (displaySearchTermEl) {
+                displaySearchTermEl.textContent = term;
+            }
+            if (searchLinkEl) {
+                searchLinkEl.href = `/search/?term=${encodeURIComponent(term)}`;
+            }
+        })();
+    </script>
 </Layout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,9 +1,15 @@
 ---
-import Layout from "../layouts/BaseLayout.astro";
+import Head from "@components/Head/index.astro";
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { getCurrentLocale, getUiTranslator } from "../i18n/utils.ts";
+const currentLocale = getCurrentLocale(Astro.url.pathname);
+// const t = await getUiTranslator(currentLocale);
 ---
 
-<Layout title="404: Page Not Found">
-    <main class="flex flex-col items-start gap-8 py-8 px-2 prose max-w-none">
+<Head title="404: Page Not Found" locale={currentLocale} />
+
+<BaseLayout title="About">
+    <section class="flex flex-col items-start gap-8 py-8 px-2 prose max-w-none">
         <p>
             Sorry, we couldn't find your exact page
             <code id="display-path"></code>.
@@ -16,7 +22,7 @@ import Layout from "../layouts/BaseLayout.astro";
                 <a href="/" class="btn secondary">go home</a>
             </div>
         </p>
-    </main>
+    </section>
     <script is:inline>
         (function update404PageDetails() {
             function getLastPathSegment(path) {
@@ -46,4 +52,4 @@ import Layout from "../layouts/BaseLayout.astro";
             }
         })();
     </script>
-</Layout>
+</BaseLayout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,14 +4,20 @@ import Layout from "../layouts/BaseLayout.astro";
 /**
  * Returns the last (non-empty) segment from the slash-separated path, or ""
  *
+ * Discards any hash part of the URL before splitting it.
+ * 
  * @param path string to extract the last part of
  * @returns the last non-empty segment or an empty string
  *
  * @example
- * an input of `/reference/p5/basematerialshader/` will return `basematerialshader`
+ * An input of `/reference/p5/basematerialshader/` will return `basematerialshader`
+ * An input of `/reference/p5.Vector/dist/#Examples` will return `dist`
  */
 function getLastPathElementOrEmptyString(path: string): string {
-    return path.split("/").filter(Boolean).pop() ?? "";
+  //Get the part of the path before the (first) hash
+  const preHashPath = path.split("#")[0] ?? "";
+  //Then get the last non-empty slash-separated segment from that
+  return preHashPath.split("/").filter(Boolean).pop() ?? "";
 }
 
 const currentPath = Astro.url.pathname;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,50 +3,37 @@ import Layout from "../layouts/BaseLayout.astro";
 
 /**
  * Returns the last (non-empty) segment from the slash-separated path, or ""
- * 
+ *
  * @param path string to extract the last part of
  * @returns the last non-empty segment or an empty string
- * 
- * @example 
+ *
+ * @example
  * an input of `/reference/p5/basematerialshader/` will return `basematerialshader`
  */
 function getLastPathElementOrEmptyString(path: string): string {
     return path.split("/").filter(Boolean).pop() ?? "";
 }
 
-
 const currentPath = Astro.url.pathname;
 const finalTerm = getLastPathElementOrEmptyString(currentPath);
 ---
 
 <Layout title="404: Page Not Found">
-    <main class="error-container">
-        <p>Sorry, we couldn't find your exact page <code>{currentPath}</code>.</p>
+    <main class="flex flex-col items-start gap-8 py-8 px-2 prose max-w-none">
+        <p>
+            Sorry, we couldn't find your exact page
+            <code>{currentPath}</code>.
 
-        <div class="actions">
-            <a
-                href={`https://beta.p5js.org/search/?term=${finalTerm}`}
-                class="btn secondary"
-            >
-                Search here for <code>{finalTerm}</code>
-            </a>
-or
-            <a href="/" class="btn">go home</a>
-        </div>
+            <div class="flex flex-col gap-4">
+                <a
+                    href={`https://beta.p5js.org/search/?term=${finalTerm}`}
+                    class="btn"
+                >
+                    Search here for <code>{finalTerm}</code>
+                </a>
+                or
+                <a href="/" class="btn secondary">go home</a>
+            </div>
+        </p>
     </main>
 </Layout>
-<style>
-  .error-container {
-    display: flex;
-    flex-direction:column;
-    align-items: flex-start;
-    padding: 2rem 1rem;    
-    gap: 2rem;
-  }
-  .actions {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    justify-content: center;
-  }
-</style>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,8 @@
     "nodejs_compat"
   ],
   "assets": {
-    "directory": "dist"
+    "directory": "dist",
+    "not_found_handling": "404-page"
   },
   "env": {
     "beta": {


### PR DESCRIPTION

Addresses #1256 

### changes

1. adds custom 404 page with populated search link
2. configures cloudflare to look for it

#### 1. custom 404 page with populated search link

Adds a rough custom 404 page in astro (`/src/pages/404.astro`) which presents user with a quick search option to search the website (using the website) for pages matching the last part of their path.

Example:
When the user visits the broken URL: https://beta.p5js.org/reference/p5.font/texttocontours/
the custom 404 page includes a search link to: https://beta.p5js.org/search/?term=texttocontours

<img width="533" height="437" alt="image" src="https://github.com/user-attachments/assets/36151545-4823-4512-9055-3362ceb1a1d7" alt="example of the proposed 404 page which offers the user a link to search for part of their page path"/>

#### 2. Cloudflare config

per the astro docs for cloudflare deployment
https://docs.astro.build/en/guides/deploy/cloudflare/#404-behavior

this PR changes `wrangler.jsonc` to  set `not_found_handling` as follows:

```json
"assets": {
    "directory": "dist",
    "not_found_handling": "404-page"
  },
  ```
 
This will cause it to look for a 404 page in `.dist/404.html`.  I have confirmed locally astro build is putting our custom 404 page at that file path.

(Note to anyone testing with other their own astro stuff: the popular "starlight" theme will overwrite this page by default with its own 404 page.  (this can be disabled.))