### PR TITLE
Basic case insensitive route matching

### DIFF
--- a/.github/workflows/beta_deploy.yml
+++ b/.github/workflows/beta_deploy.yml
@@ -18,8 +18,12 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v6.3.0
+        node-version: 22.22.x
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm run install
       - name: Build website
         run: npm run build
       - name: Deploy to Cloudflare Workers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,12 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v6.3.0
+        node-version: 22.22.x
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm run install
       - name: Build website
         run: npm run build
       - name: Deploy to Cloudflare Workers

--- a/src/pages/reference/[...id].astro
+++ b/src/pages/reference/[...id].astro
@@ -1,4 +1,5 @@
 ---
+import type { GetStaticPathsResult } from "astro";
 import ReferenceItemLayout from "@/src/layouts/ReferenceItemLayout.astro";
 import {
   getCollectionInDefaultLocale,
@@ -21,7 +22,16 @@ export async function getStaticPaths() {
           return relatedEntry.data.submodule === entry.data.submodule;
         }),
       },
-    }));
+    }))
+    .reduce<GetStaticPathsResult>((acc, entry) => {
+      acc.push(entry);
+      acc.push(Object.assign({}, entry, {
+        params: {
+          id: entry.params.id.toLowerCase()
+        }
+      }));
+      return acc;
+    }, []);
 }
 
 const { entry, relatedEntries } = Astro.props;


### PR DESCRIPTION
This addresses case insensitive route matching on the reference pages so that `https://beta.p5js.org/reference/p5/frameCount/` and `https://beta.p5js.org/reference/p5/framecount/` both show the same content. There are some limitations to this approach.

* All routes after `/reference/` will need to either have the correct case or be fully lower case. eg. `/p5.Vector/magSq/` and `/p5.vector/magsq/` will match but `/p5.vector/magSq/` and `/p5.Vector/magsq/` will not match.
* All reference route pages with capitalization will be duplicated with this approach, increasing the number of pages generated.

The reason for the limitations are because Astro is currently rendering all content as static pages, meaning to match something case insensitively, it will need to generate relevant folders and HTML files for case sensitive and case insensitive cases. `/p5.Vector/magSq/` and `/p5.vector/magsq/` are matching two different files with the same content.

To achieve full case insensitive routing, SSR will need to be used as only the server will be able to determine case insensitively what the route is trying to match. We can do this after #1243 is merged but will need some consideration on whether to do SSR or not.