### PR TITLE
Partially revert "fix: properly escape inline <code> tags...in reference pages"

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -152,7 +152,9 @@ export const Dropdown = ({
           </div>
           <button
             onClick={() => handleOptionClick(option)}
-            ref={(el) => (optionRefs.current[index] = el as HTMLButtonElement)}
+            ref={(el) => {
+              optionRefs.current[index] = el as HTMLButtonElement;
+            }}
             onBlur={handleBlur}
           >
             <span>{option.label}</span>

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -152,9 +152,7 @@ export const Dropdown = ({
           </div>
           <button
             onClick={() => handleOptionClick(option)}
-            ref={(el) => {
-              optionRefs.current[index] = el as HTMLButtonElement;
-            }}
+            ref={(el) => (optionRefs.current[index] = el as HTMLButtonElement)}
             onBlur={handleBlur}
           >
             <span>{option.label}</span>

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -230,9 +230,7 @@ export const getRefEntryTitleConcatWithParen = (
  */
 export const escapeCodeTagsContent = (htmlString: string): string => {
   // Load the HTML string into Cheerio
-  const $ = load(htmlString, {
-    xmlMode: true
-  });
+  const $ = load(htmlString);
   // Loop through all <code> tags
   $("code").each(function () {
     // Don't escape code in multiline blocks, as these will already


### PR DESCRIPTION
This partially reverts commit https://github.com/processing/p5.js-website/commit/f7e667e03471cf4d73cfd32c5ed6e9174d5e8bba which caused bug #1240

This removes the fix for #1163 (to be solved elsewhere).

The commit also had some unrelated minor fix for the dropdown component - this has been preserved.
