### PR TITLE
Fix duplicate "the the" typos in steward guidelines and sine cosine example

### DIFF
--- a/src/content/contributor-docs/en/steward_guidelines.mdx
+++ b/src/content/contributor-docs/en/steward_guidelines.mdx
@@ -92,7 +92,7 @@ To remain a steward, you must contribute as a steward to at least 1 of the 2 mos
 
 ### Getting Started with Stewardship
 
-1. Keep this guideline handy as a reference - how to help with new issues, bugs, and features. For example, the "Feature request" section includes tips on how to use the the p5.js [access statement](../access/) as a steward.
+1. Keep this guideline handy as a reference - how to help with new issues, bugs, and features. For example, the "Feature request" section includes tips on how to use the p5.js [access statement](../access/) as a steward.
 2. When helping to answer technical questions or review, try to apply the Processing Foundation [guideline on answering questions](https://discourse.processing.org/t/guidelines-answering-questions/2145/) - these can be especially helpful for giving constructive technical feedback.
 3. Join the [p5.js Discord](https://discord.p5js.org)  - in the `#contribute-to-p5` you're welcome to ask any questions you have about this process - or suggest how it can be improved!
 

--- a/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
+++ b/src/content/examples/en/09_Angles_And_Motion/00_Sine_Cosine/description.mdx
@@ -25,7 +25,7 @@ This example demonstrates the
 mathematical functions.
 
 The animation shows uniform circular motion around the unit circle
-(circle with radius 1). Any angle measured from the the x-axis
+(circle with radius 1). Any angle measured from the x-axis
 determines a point on the circle. The cosine and sine of the angle
 are defined to be the x and y coordinates, respectively, of that
 point.


### PR DESCRIPTION
Noticed a couple repeated "the the" while reading through the docs. Small fix.