### PR TITLE
fix spelling typos in p5.sound reference docs

### DIFF
--- a/src/content/reference/en/p5.Part/stop.mdx
+++ b/src/content/reference/en/p5.Part/stop.mdx
@@ -7,7 +7,7 @@ module: p5.sound
 submodule: p5.sound
 file: lib/addons/p5.sound.js
 description: >
-  <p>Stop the part and cue it to step 0. Playback will resume from the begining
+  <p>Stop the part and cue it to step 0. Playback will resume from the beginning
   of the Part when it is played again.</p>
 line: 9349
 isConstructor: false

--- a/src/content/reference/en/p5.sound/p5.Gain.mdx
+++ b/src/content/reference/en/p5.sound/p5.Gain.mdx
@@ -7,7 +7,7 @@ module: p5.sound
 submodule: p5.sound
 file: lib/addons/p5.sound.js
 description: |
-  <p>A gain node is usefull to set the relative volume of sound.
+  <p>A gain node is useful to set the relative volume of sound.
   It's typically used to build mixers.</p>
 line: 10973
 isConstructor: true

--- a/src/content/reference/en/p5.sound/p5.Part.mdx
+++ b/src/content/reference/en/p5.sound/p5.Part.mdx
@@ -97,7 +97,7 @@ methods:
   stop:
     description: >
       <p>Stop the part and cue it to step 0. Playback will resume from the
-      begining of the Part when it is played again.</p>
+      beginning of the Part when it is played again.</p>
     path: p5.Part/stop
   pause:
     description: |


### PR DESCRIPTION
Fixed "begining"  to "beginning" in p5.Part docs and "usefull" to "useful" in p5.Gain docs.