### PR TITLE
FIx GitHub capitalization in contributor guidelines

### DIFF
--- a/src/content/contributor-docs/en/contributor_guidelines.mdx
+++ b/src/content/contributor-docs/en/contributor_guidelines.mdx
@@ -27,9 +27,9 @@ This is a relatively long and comprehensive document but we will try to signpost
     * [Discussion](#discussion)
 * [Working on p5.js codebase](#working-on-the-p5js-codebase)
   * [Quick Get Started For Developers](#quick-get-started-for-developers)
-  * [Using the Github edit functionality](#using-the-github-edit-functionality)
+  * [Using the GitHub edit functionality](#using-the-github-edit-functionality)
   * [Forking p5.js and working from your fork](#forking-p5js-and-working-from-your-fork)
-    * [Using Github Desktop](#using-github-desktop)
+    * [Using GitHub Desktop](#using-github-desktop)
     * [Using the git command line interface](#using-the-git-command-line-interface)
   * [Codebase breakdown](#codebase-breakdown)
   * [Build setup](#build-setup)
@@ -246,7 +246,7 @@ Working from your fork of the p5.js repository is necessary because you will lik
 
 ### Using GitHub Desktop
 
-GitHub Desktop is a program that lets you work with git via a graphical user interface rather than typing commands into a terminal. It is a good option if you are new to git, and you can always switch back and forth between Github Desktop and a terminal whenever you feel like it.
+GitHub Desktop is a program that lets you work with git via a graphical user interface rather than typing commands into a terminal. It is a good option if you are new to git, and you can always switch back and forth between GitHub Desktop and a terminal whenever you feel like it.
 
 First, [download and install GitHub Desktop.](https://desktop.github.com/) Once installed, open the application. It will ask you to sign in to your GitHub account. After you have signed in, it will list your projects, including your fork of p5.js. Select your fork, which will be named `yourUsername/p5.js`, and click the blue "Clone" button. It will ask for some details about where to place your project; you can either change them or leave the default settings and continue.
 
@@ -410,7 +410,7 @@ From GitHub Desktop, just to the right of the button to change branches in the h
 
 Once your code is uploaded, it will show a button prompting you to create a pull request. Clicking the button once will show a preview with another button to actually create the request. Press the "Create Pull Request" button to begin the process.
 
-![A screenshot of Github Desktop after pushing code. In the left sidebar, it says "0 changed items." In the right pane, below the "No local changes" header, a blue "Review Pull Request" button has been marked up with a red circle.](src/content/contributor-docs/images/preview-pull-request.png)
+![A screenshot of GitHub Desktop after pushing code. In the left sidebar, it says "0 changed items." In the right pane, below the "No local changes" header, a blue "Review Pull Request" button has been marked up with a red circle.](src/content/contributor-docs/images/preview-pull-request.png)
 
 From the terminal, run the following command:
 
@@ -422,7 +422,7 @@ Once the push is complete, you may see a link in the terminal that lets you open
 
 ![Screenshot of the git command line response after pushing a new branch. It includes a GitHub link to open a new pull request.](src/content/contributor-docs/images/new-branch.png)
 
-You may also see a button to open a pull request when you visit the p5.js Github repo. Clicking it will also work to open a new pull request.
+You may also see a button to open a pull request when you visit the p5.js GitHub repo. Clicking it will also work to open a new pull request.
 
 ![Cropped screenshot of the main page of the p5.js GitHub repository web page. A section near the top of the page is a yellow call to action box containing a green button with the text "Compare & pull request".](src/content/contributor-docs/images/recent-pushes.png)
 
@@ -468,7 +468,7 @@ You should now inspect the opened pull request and pay attention to a few things
 
 If any of the above is not true (there are more commits than you expected or there are conflicts), you may need to [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing/) or help resolve conflicts. Conflicts here mean that you have made changes to a file that also recently had changes applied to it, and git is not sure which set of changes to keep or leave out. If you are not confident in resolving these issues, let us know and we'll guide you through the process. Basic instruction is as below.
 
-Sometimes, Github lets you resolve conflicts directly in the browser by showing you a Resolve Conflicts button:![A screenshot of a GitHub pull request with merge conflicts. The conflicting filenames are listed, and there is a "Resolve conflicts" button highlighted.](src/content/contributor-docs/images/resolve-conflicts.png)
+Sometimes, GitHub lets you resolve conflicts directly in the browser by showing you a Resolve Conflicts button:![A screenshot of a GitHub pull request with merge conflicts. The conflicting filenames are listed, and there is a "Resolve conflicts" button highlighted.](src/content/contributor-docs/images/resolve-conflicts.png)
 
 Conflicts are shown between `<<<<<<<` and `>>>>>>>`, separated by `=======`. One section shows your code, and the other section shows what has changed in the main branch.
 
@@ -482,7 +482,7 @@ When all files with conflicts have been resolved, you can commit your changes.
 
 ![The GitHub conflict resolution interface after all conflicts have been marked as resolved. A green "commit merge" button is enabled.](src/content/contributor-docs/images/commit-merge.png)
 
-Sometimes, the conflicts are too complicated for Github to show on the web. In this case, or if you just prefer the manual method, you can resolve your conflicts locally:
+Sometimes, the conflicts are too complicated for GitHub to show on the web. In this case, or if you just prefer the manual method, you can resolve your conflicts locally:
 
 1. Run `git remote add upstream https://github.com/processing/p5.js`
 2. Run `git fetch upstream`


### PR DESCRIPTION
The official name is "GitHub" with a capital H. Fixed a few instances of "Github" in the contributor guidelines. Left the ones inside links alone since changing those would break them.