### PR TITLE
Expand translation tracker content paths and add dry-run mode (addresses #1268)

### DIFF
--- a/.github/actions/translation-tracker/README.md
+++ b/.github/actions/translation-tracker/README.md
@@ -1,10 +1,11 @@
 # p5.js Translation Tracker
 
-Automatically tracks translation status for p5.js website examples, creates GitHub issues for outdated translations, and shows banners on the website.
+Automatically tracks translation status for p5.js website content, creates GitHub issues for outdated translations, and shows banners on the website.
 
 ## Features
 
-- Detects outdated/missing translations using Git commit comparison (currently focused on Examples content)
+- Detects outdated/missing translations using Git commit comparison
+- Tracks all content types: examples, tutorials, reference, text-detail, events, and libraries
 - Creates GitHub issues with diff snippets and action checklists
 - Shows localized banners on outdated translation pages
 - Supports Spanish, Hindi, Korean, and Chinese Simplified
@@ -30,6 +31,12 @@ cd .github/actions/translation-tracker && npm install
 node test-local.js
 ```
 
+### Dry Run (Preview Without Creating Issues)
+Scan all files and show what issues would be created, without actually creating them:
+```bash
+node .github/actions/translation-tracker/index.js --dry-run
+```
+
 ### Scan All Files (File-based)
 ```bash
 node .github/actions/translation-tracker/index.js
@@ -41,51 +48,29 @@ GITHUB_TOKEN=your_token GITHUB_REPOSITORY=owner/repo node .github/actions/transl
 ```
 
 ### GitHub Actions Workflow
-Create `.github/workflows/translation-sync.yml`:
+The workflow is defined in `.github/workflows/translation-sync.yml` and triggers on pushes to `main` that modify English content files in any of the tracked content types:
 
-```yaml
-name: Translation Sync Tracker
+- `src/content/examples/en/**`
+- `src/content/tutorials/en/**`
+- `src/content/reference/en/**`
+- `src/content/text-detail/en/**`
+- `src/content/events/en/**`
+- `src/content/libraries/en/**`
 
-on:
-  push:
-    branches: [main, week2]
-    paths: ['src/content/examples/en/**']
-  workflow_dispatch:
-
-jobs:
-  track-translation-changes:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-          
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          
-      - name: Install dependencies
-        run: npm ci
-        
-      - name: Install translation tracker dependencies
-        run: cd .github/actions/translation-tracker && npm install
-        
-      - name: Run translation tracker
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/actions/translation-tracker/index.js
-```
+It can also be triggered manually via `workflow_dispatch`.
 
 ## Environment Variables
 
 - `GITHUB_TOKEN` - Required for GitHub API and issue creation
 - `GITHUB_REPOSITORY` - Format: `owner/repo` (auto-detected in Actions)
 
+## CLI Flags
+
+- `--dry-run` - Preview mode: scans files and logs what issues would be created, but does not create them on GitHub
+
 ## What It Does
 
-1. **Scans** English example files for changes
+1. **Scans** English content files for changes
 2. **Compares** with translation files using Git commits
 3. **Creates** GitHub issues for outdated translations with:
    - Diff snippets showing what changed
@@ -94,6 +79,17 @@ jobs:
    - Proper labels (`needs translation`, `lang-es`, etc.)
 4. **Generates** manifest file for website banner system
 5. **Shows** localized banners on outdated translation pages
+
+## Supported Content Types
+
+| Content Type | Path | Description |
+|---|---|---|
+| `examples` | `src/content/examples/` | Code examples |
+| `tutorials` | `src/content/tutorials/` | Tutorial pages |
+| `reference` | `src/content/reference/` | API reference docs |
+| `text-detail` | `src/content/text-detail/` | Detailed text content |
+| `events` | `src/content/events/` | Event pages |
+| `libraries` | `src/content/libraries/` | Library documentation |
 
 ## Sample Output
 

--- a/.github/actions/translation-tracker/index.js
+++ b/.github/actions/translation-tracker/index.js
@@ -693,8 +693,13 @@ async function checkTranslationStatus(changedFiles, githubTracker = null, create
 async function main(testFiles = null, options = {}) {
   const hasToken = !!process.env.GITHUB_TOKEN;
   const isGitHubAction = !!process.env.GITHUB_ACTIONS; // Detect if running in GitHub Actions
-  const isProduction = hasToken && !testFiles;
+  const isDryRun = options.dryRun || process.argv.includes('--dry-run');
+  const isProduction = hasToken && !testFiles && !isDryRun;
   
+  if (isDryRun) {
+    console.log(`🧪 Dry run mode: scanning files but NOT creating GitHub issues`);
+  }
+
   if (testFiles) {
     console.log(`🧪 Test mode: Checking ${testFiles.length} predefined files`);
   } else if (isGitHubAction) {
@@ -786,7 +791,22 @@ async function main(testFiles = null, options = {}) {
         console.log(`     URL: ${issue.issueUrl}`);
       });
     } else if (needsUpdate.length > 0 || missing.length > 0) {
-      if (!hasToken) {
+      if (isDryRun) {
+        const fileTranslationMap = translationStatus.fileTranslationMap;
+        const wouldCreate = fileTranslationMap.size;
+        console.log(`\n🧪 Dry run: ${wouldCreate} issue(s) would be created:`);
+        for (const [englishFile, fileTranslations] of fileTranslationMap) {
+          const affectedLangs = [
+            ...fileTranslations.outdatedLanguages.map(l => l.language),
+            ...fileTranslations.missingLanguages.map(l => l.language)
+          ];
+          const langNames = affectedLangs.map(lang => 
+            githubTracker ? githubTracker.getLanguageDisplayName(lang) : lang
+          );
+          console.log(`   - 🌍 Update translations for ${path.basename(englishFile)}`);
+          console.log(`     Languages: ${langNames.join(', ')}`);
+        }
+      } else if (!hasToken) {
         console.log(`\n💡 Run with GITHUB_TOKEN to create GitHub issues`);
       }
     }

--- a/.github/actions/translation-tracker/test-local.js
+++ b/.github/actions/translation-tracker/test-local.js
@@ -1,14 +1,41 @@
 
-const { main } = require('./index.js');
+const { main, getAllEnglishContentFiles, CONTENT_TYPES } = require('./index.js');
 
-// Simple test with predefined files
+// Simple test with predefined files across multiple content types
 const testFiles = [
   'src/content/examples/en/01_Shapes_And_Color/00_Shape_Primitives/description.mdx',
   'src/content/examples/en/02_Animation_And_Variables/00_Drawing_Lines/description.mdx',
-  'src/content/examples/en/03_Imported_Media/00_Words/description.mdx'
+  'src/content/examples/en/03_Imported_Media/00_Words/description.mdx',
+  'src/content/tutorials/en/variables-and-change.mdx',
+  'src/content/tutorials/en/getting-started-with-nodejs.mdx'
 ];
 
-console.log('🧪 Testing Translation Tracker with predefined files');
-console.log('====================================================');
+const args = process.argv.slice(2);
 
-main(testFiles, { createIssues: false }); 
+if (args.includes('--scan-all')) {
+  // Full scan mode: check all English files across all content types
+  console.log('🔍 Full scan mode: checking all English content files');
+  console.log(`📦 Content types: ${CONTENT_TYPES.join(', ')}`);
+  console.log('====================================================\n');
+  main(null, { dryRun: true });
+} else if (args.includes('--content-type') && args[args.indexOf('--content-type') + 1]) {
+  // Scan a specific content type
+  const contentType = args[args.indexOf('--content-type') + 1];
+  if (!CONTENT_TYPES.includes(contentType)) {
+    console.error(`❌ Unknown content type: ${contentType}`);
+    console.log(`   Valid types: ${CONTENT_TYPES.join(', ')}`);
+    process.exit(1);
+  }
+  console.log(`🔍 Scanning all ${contentType} files`);
+  console.log('====================================================\n');
+  const files = getAllEnglishContentFiles(contentType);
+  main(files, { dryRun: true });
+} else {
+  // Default: test with predefined files
+  console.log('🧪 Testing Translation Tracker with predefined files');
+  console.log('====================================================');
+  console.log('  Tip: run with --scan-all to check all content');
+  console.log('  Tip: run with --content-type <type> to check a specific type');
+  console.log(`  Valid types: ${CONTENT_TYPES.join(', ')}\n`);
+  main(testFiles, { dryRun: true });
+}

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'src/content/examples/en/**'
       - 'src/content/tutorials/en/**'
+      - 'src/content/reference/en/**'
+      - 'src/content/text-detail/en/**'
+      - 'src/content/events/en/**'
+      - 'src/content/libraries/en/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Addresses #1268

The workflow was only triggering on examples and tutorials but the script supports 6 content types. So i expanded the paths to cover all of them (reference, text-detail, events, libraries).

Also added a --dry-run flag to index.js so contributors can preview what issues would be created without needing a GitHub token.Then i updated test-local.js with --scan-all and --content-type flags for easier local testing. Lastly, i  cleaned up the README to match.