### PR TITLE
docs: link to "previewing the p5.js reference" from technical overview

### DIFF
--- a/docs/technical_overview.md
+++ b/docs/technical_overview.md
@@ -68,3 +68,8 @@ And then view it locally with
 ```shellsession
 npm run preview
 ```
+
+
+## Previewing the p5.js reference for work-in-progress
+
+If you're developing the p5.js library and want to preview your documentation, there are some specific notes at ["Generating and previewing the reference"](https://beta.p5js.org/contribute/contributing_to_the_p5js_reference/#generating-and-previewing-the-reference).


### PR DESCRIPTION
To the technical overview doc, (which is mostly a getting-started for devs), 
this PR adds a link to the section "[generating and previewing the reference](https://beta.p5js.org/contribute/contributing_to_the_p5js_reference/#generating-and-previewing-the-reference)" in the guide contributing_to_the_p5js_reference.md.

### why?
Inevitably, some contributors will have arrived at the website technical overview (getting started) with the intent of generating and previewing the reference, without knowing the more specific guide exists.