### PR TITLE
Fix properties not having beta tags

### DIFF
--- a/src/scripts/builders/reference.ts
+++ b/src/scripts/builders/reference.ts
@@ -327,6 +327,9 @@ const getClassItemFrontmatter = (doc: ReferenceClassItem) => {
     alt,
     example,
     class: doc.class,
+    beta: doc.beta ? !!doc.beta : undefined,
+    webgpu: doc.webgpu ? !!doc.webgpu : undefined,
+    webgpuOnly: doc.webgpuOnly ? !!doc.webgpuOnly : undefined,
   };
 };
 

--- a/types/parsers.interface.ts
+++ b/types/parsers.interface.ts
@@ -127,7 +127,7 @@ interface MethodOverload {
 }
 
 /* Represents a property within a class */
-export interface ReferenceClassItemProperty extends BaseClassItem, Deprecatable {
+export interface ReferenceClassItemProperty extends BaseClassItem, Deprecatable, MaybeBeta, Deprecatable {
   type: string;
 }
 


### PR DESCRIPTION
I noticed that the items of the p5.strands category that weren't functions didn't have beta tags.
<img width="1362" height="605" alt="image" src="https://github.com/user-attachments/assets/9b2f60cf-b07b-41a3-ab58-d6fc50086459" />

While some of them actually are missing `@beta` in the docs, the rest do have it, but just weren't showing it on the site. This PR corrects that by making sure class items read that tag.

Now:
<img width="1375" height="528" alt="image" src="https://github.com/user-attachments/assets/177fd92c-3b0c-498e-a64b-361d688bd9e2" />
