### PR TITLE
Upgrade GitHub actions from node 20

### DIFF
--- a/.github/workflows/beta_deploy.yml
+++ b/.github/workflows/beta_deploy.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 22.22.x
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install dependencies
         run: npm ci
       - name: Build website

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 22.22.x
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install dependencies
         run: npm ci
       - name: Build website

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
       - name: Install dependencies
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
       - name: Install dependencies
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
       - name: Install dependencies
@@ -50,9 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
       - name: Install dependencies


### PR DESCRIPTION
addresses: #1248 

Changed beta_deploy.yml and test.yml and deploy.yml to use:
* actions/checkout v4 -> v5
* actions/setup-node v4 -> v5, or  (leave where already @v6.3.0)

Both of the above v5's are based on node 24, where the v4s were based on the soon-unsupported node 20.

### testing: 
* Tested `Test, typecheck, and lint`and all 4 jobs ran fine, with no warning  about action node versions.
* Tested build_deploy, which ran fine to cloudflare.   however this workflow got a warning as the `cloudflare/wrangler-action@v3` we are using in deployment is node-20 based.  There isn't an updated one, yet.