### PR TITLE
Update Node.js version from 18 to 22 in translation tracker

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Workflow has been failing due to Node version.