### PR TITLE
fix: add top spacing to p5.js logo in side navigation using margin

### DIFF
--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -68,6 +68,7 @@
       display: flex;
       gap: var(--spacing-xs);
       padding: 0;
+      margin-top: 20px;
       margin-bottom: 10px;
       a {
         height: unset;


### PR DESCRIPTION
Fixes #1293 

Fixes side nav logo top spacing using margin (≥770px)