### PR TITLE
Add custom 404 page for missing text-detail routes

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,32 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+
+const rawPath = Astro.url.pathname;
+
+const cleanPath =
+  rawPath !== "/" ? rawPath.replace(/\/$/, "") : rawPath;
+
+const searchText =
+  cleanPath.split("/").filter(Boolean).pop() || "";
+---
+<BaseLayout title="404: Page Not Found">
+  <section class="flex flex-col gap-8 items-start max-w-none prose px-2 py-8">
+
+    <p>
+      Sorry, we couldn't find your exact page <code>{cleanPath}</code>.
+    </p>
+
+    <div class="flex flex-col gap-4">
+      <a class="btn" href={`/search/?term=${searchText}`}>
+        Search here for <code>{searchText}</code>
+      </a>
+
+      <span>or</span>
+
+      <a class="btn secondary" href="/">
+        go home
+      </a>
+    </div>
+
+  </section>
+</BaseLayout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,32 +1,60 @@
 ---
+import Head from "@components/Head/index.astro";
 import BaseLayout from "@layouts/BaseLayout.astro";
-
-const rawPath = Astro.url.pathname;
-
-const cleanPath =
-  rawPath !== "/" ? rawPath.replace(/\/$/, "") : rawPath;
-
-const searchText =
-  cleanPath.split("/").filter(Boolean).pop() || "";
+import { getCurrentLocale } from "../i18n/utils.ts";
+const currentLocale = getCurrentLocale(Astro.url.pathname);
 ---
+
+<Head title="404: Page Not Found" locale={currentLocale} />
+
 <BaseLayout title="404: Page Not Found">
-  <section class="flex flex-col gap-8 items-start max-w-none prose px-2 py-8">
+    <section class="flex flex-col items-start gap-8 py-8 px-2 prose max-w-none">
+        
+        <p>
+            Sorry, we couldn't find your exact page
+            <code id="display-path"></code>.
+        </p>
 
-    <p>
-      Sorry, we couldn't find your exact page <code>{cleanPath}</code>.
-    </p>
+        <div class="flex flex-col gap-4">
+            <a id="search-link" href="/search/" class="btn">
+                Search here for <code id="display-search-term"></code>
+            </a>
 
-    <div class="flex flex-col gap-4">
-      <a class="btn" href={`/search/?term=${searchText}`}>
-        Search here for <code>{searchText}</code>
-      </a>
+            <p>or</p>
 
-      <span>or</span>
+            <a href="/" class="btn secondary">
+                go home
+            </a>
+        </div>
 
-      <a class="btn secondary" href="/">
-        go home
-      </a>
-    </div>
+    </section>
+    <script is:inline>
+        (function update404PageDetails() {
+            function getLastPathSegment(path) {
+                return path.split("/").filter(Boolean).pop() ?? "";
+            }
 
-  </section>
+            // 1. Get the last meaningful segment from the URL path, excluding hash part
+            // 2. Use that in the link href to the search
+            // 3. Also display it and the failed path
+
+            //(This .pathname already strips away any hash part)
+            const realPath = window.location.pathname;
+            const term = getLastPathSegment(realPath);
+
+            const displayPathEl = document.getElementById("display-path");
+            const searchLinkEl = document.getElementById("search-link");
+            const displaySearchTermEl = document.getElementById("display-search-term");
+
+            if (displayPathEl) {
+                displayPathEl.textContent = realPath;
+            }
+            if (displaySearchTermEl) {
+                displaySearchTermEl.textContent = term;
+            }
+            if (searchLinkEl) {
+                searchLinkEl.href = `/search/?term=${encodeURIComponent(term)}`;
+            }
+        })();
+    </script>
 </BaseLayout>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -26,6 +26,8 @@ export const getStaticPaths = async () => {
 };
 
 const { page } = Astro.props;
+if (!page) {
+  return Astro.redirect("/404");
+}
 ---
-
 <TextDetailLayout page={page} />


### PR DESCRIPTION
## Summary
This PR adds a custom 404 page and integrates it into the text-detail routing.

## Changes
- Added `src/pages/404.astro` with UI consistent with existing layout of the beta.p5js.org
- Updated [slug].astro to render custom 404 when content is not found
- Fixed search link to respect `trailingSlash: "always"` configuration

## Notes
- Routes without trailing slash (e.g. `/reference/whatever`) are handled by Astro and do not reach page-level logic.
- Custom 404 is applied correctly for valid routed paths (e.g. `/reference/whatever/`).

## Result
- Improved UX for missing pages
- Consistent styling with existing site (beta.p5js.org)