### PR TITLE
fixed link on radians page that leads to constants/DEGREES

### DIFF
--- a/src/content/reference/en/p5/constants/RADIANS.mdx
+++ b/src/content/reference/en/p5/constants/RADIANS.mdx
@@ -21,7 +21,7 @@ description: >
 
   <a href="/reference/p5/angleMode/">angleMode()</a> has been set to
 
-  <a href="/reference/p5/DEGREES/">DEGREES</a>.</p>
+  <a href="/reference/p5/constants/DEGREES/">DEGREES</a>.</p>
 
   <p>Note: <code>TWO_PI</code> radians equals 360˚.</p>
 line: 89


### PR DESCRIPTION
- Readjusted the link to constant DEGREES from RADIANS page in 2.0 branch

Addresses #1353 