### PR TITLE
add MDX heading permalinks for tutorial pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3882,6 +3882,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3921,6 +3922,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3941,6 +3943,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3961,6 +3964,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3981,6 +3985,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4001,6 +4006,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4021,6 +4027,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4041,6 +4048,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4061,6 +4069,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4081,6 +4090,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4101,6 +4111,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4121,6 +4132,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4141,6 +4153,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4161,6 +4174,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18034,6 +18048,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -23484,6 +23499,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/Dropdown/styles.module.scss
+++ b/src/components/Dropdown/styles.module.scss
@@ -1,4 +1,4 @@
-@import "/styles/variables.scss";
+@use "/styles/variables" as *;
 
 .container {
   position: relative;

--- a/src/components/HeadingPermalink/index.tsx
+++ b/src/components/HeadingPermalink/index.tsx
@@ -1,0 +1,62 @@
+import type { ComponentChildren, HTMLAttributes, VNode } from "preact";
+
+type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+type HeadingProps = HTMLAttributes<HTMLHeadingElement> & {
+  as: HeadingTag;
+  children?: ComponentChildren;
+  id?: string;
+};
+
+type HeadingOverrideProps = Omit<HeadingProps, "as">;
+
+const joinClasses = (...classes: unknown[]) =>
+  classes
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+
+export const HeadingPermalink = ({
+  as: Tag,
+  children,
+  class: classProp,
+  className,
+  id,
+  ...props
+}: HeadingProps) => {
+  const hasPermalink = typeof id === "string" && id.length > 0;
+
+  const mergedClassName = joinClasses(
+    "heading-permalink",
+    hasPermalink && "heading-permalink--enabled",
+    classProp,
+    className,
+  );
+
+  return (
+    <Tag {...props} id={id} class={mergedClassName}>
+      {hasPermalink ? (
+        <a href={`#${id}`} class="heading-permalink__link">
+          {children}
+        </a>
+      ) : (
+        children
+      )}
+    </Tag>
+  );
+};
+
+const createHeadingOverride = (as: HeadingTag) => {
+  const Component = (props: HeadingOverrideProps): VNode => (
+    <HeadingPermalink {...props} as={as} />
+  );
+
+  Component.displayName = `HeadingPermalink${as.toUpperCase()}`;
+  return Component;
+};
+
+export const HeadingPermalinkH1 = createHeadingOverride("h1");
+export const HeadingPermalinkH2 = createHeadingOverride("h2");
+export const HeadingPermalinkH3 = createHeadingOverride("h3");
+export const HeadingPermalinkH4 = createHeadingOverride("h4");
+export const HeadingPermalinkH5 = createHeadingOverride("h5");
+export const HeadingPermalinkH6 = createHeadingOverride("h6");

--- a/src/components/HeadingPermalink/index.tsx
+++ b/src/components/HeadingPermalink/index.tsx
@@ -15,6 +15,48 @@ const joinClasses = (...classes: unknown[]) =>
     .filter((value): value is string => typeof value === "string")
     .join(" ");
 
+const isVNode = (child: ComponentChildren): child is VNode =>
+  typeof child === "object" && child !== null && "type" in child;
+
+const childrenContainAnchor = (children: ComponentChildren): boolean => {
+  if (Array.isArray(children)) {
+    return children.some(childrenContainAnchor);
+  }
+
+  if (!isVNode(children)) {
+    return false;
+  }
+
+  if (children.type === "a") {
+    return true;
+  }
+
+  return childrenContainAnchor(children.props?.children);
+};
+
+const getChildText = (children: ComponentChildren): string => {
+  if (Array.isArray(children)) {
+    return children.map(getChildText).join("").trim();
+  }
+
+  if (typeof children === "string" || typeof children === "number") {
+    return String(children);
+  }
+
+  if (!isVNode(children)) {
+    return "";
+  }
+
+  if (children.type === "img") {
+    const imgProps = children.props as { alt?: unknown };
+    if (typeof imgProps.alt === "string") {
+      return imgProps.alt;
+    }
+  }
+
+  return getChildText(children.props?.children);
+};
+
 export const HeadingPermalink = ({
   as: Tag,
   children,
@@ -24,22 +66,32 @@ export const HeadingPermalink = ({
   ...props
 }: HeadingProps) => {
   const hasPermalink = typeof id === "string" && id.length > 0;
+  const hasNestedAnchor = childrenContainAnchor(children);
+  const headingText = getChildText(children);
 
   const mergedClassName = joinClasses(
     "heading-permalink",
     hasPermalink && "heading-permalink--enabled",
+    hasPermalink && hasNestedAnchor && "heading-permalink--with-marker",
     classProp,
     className,
   );
 
   return (
     <Tag {...props} id={id} class={mergedClassName}>
-      {hasPermalink ? (
+      {hasPermalink && !hasNestedAnchor ? (
         <a href={`#${id}`} class="heading-permalink__link">
           {children}
         </a>
       ) : (
         children
+      )}
+      {hasPermalink && hasNestedAnchor && (
+        <a href={`#${id}`} class="heading-permalink__marker">
+          <span class="sr-only">
+            {headingText ? `Permalink to ${headingText}` : "Permalink"}
+          </span>
+        </a>
       )}
     </Tag>
   );
@@ -60,3 +112,12 @@ export const HeadingPermalinkH3 = createHeadingOverride("h3");
 export const HeadingPermalinkH4 = createHeadingOverride("h4");
 export const HeadingPermalinkH5 = createHeadingOverride("h5");
 export const HeadingPermalinkH6 = createHeadingOverride("h6");
+
+export const headingPermalinkComponents = {
+  h1: HeadingPermalinkH1,
+  h2: HeadingPermalinkH2,
+  h3: HeadingPermalinkH3,
+  h4: HeadingPermalinkH4,
+  h5: HeadingPermalinkH5,
+  h6: HeadingPermalinkH6,
+};

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -1,5 +1,4 @@
-@import "/styles/variables.scss";
-@import "/styles/global.scss";
+@use "/styles/variables" as *;
 
 .container {
   height: fit-content;

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -1,6 +1,7 @@
 import type { ReferenceDocContentItem } from "@/src/content/types";
 import flask from "@src/content/ui/images/icons/flask.svg?raw";
 import warning from "@src/content/ui/images/icons/warning.svg?raw";
+import { HeadingPermalink } from "@components/HeadingPermalink";
 
 type ReferenceDirectoryEntry = ReferenceDocContentItem & {
   data: {
@@ -112,9 +113,13 @@ export const ReferenceDirectoryWithFilter = ({
             <h3 className="m-0 py-gutter-md">{subcat.name}</h3>
           </a>
         ) : (
-          <h3 className="m-0 py-gutter-md" id={subcat.name}>
+          <HeadingPermalink
+            as="h3"
+            className="m-0 py-gutter-md"
+            id={subcat.name}
+          >
             {subcat.name}
-          </h3>
+          </HeadingPermalink>
         )}
       </>
     );
@@ -123,7 +128,8 @@ export const ReferenceDirectoryWithFilter = ({
   const renderCategoryData = () => {
     return categoryData.map((category) => (
       <section key={category.name}>
-        <h2
+        <HeadingPermalink
+          as="h2"
           class={
             subcatShouldHaveHeading(category.subcats[0], category)
               ? "mb-0"
@@ -132,7 +138,7 @@ export const ReferenceDirectoryWithFilter = ({
           id={category.name}
         >
           {category.name}
-        </h2>
+        </HeadingPermalink>
         {category.subcats.map((subcat) => (
           <div key={subcat.name}>
             {getSubcatHeading(subcat, category)}

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -2,6 +2,7 @@ import type { ReferenceDocContentItem } from "@/src/content/types";
 import flask from "@src/content/ui/images/icons/flask.svg?raw";
 import warning from "@src/content/ui/images/icons/warning.svg?raw";
 import { HeadingPermalink } from "@components/HeadingPermalink";
+import { makeReferenceHeadingId } from "@pages/_utils";
 
 type ReferenceDirectoryEntry = ReferenceDocContentItem & {
   data: {
@@ -103,11 +104,13 @@ export const ReferenceDirectoryWithFilter = ({
       return null;
     }
 
+    const headingId = makeReferenceHeadingId(category.name, subcat.name);
+
     return (
       <>
         {subcat.entry ? (
           <a
-            id={subcat.name}
+            id={headingId}
             href={`/reference/${category.name === "p5.sound" ? "p5.sound" : "p5"}/${subcat.name}/`}
           >
             <h3 className="m-0 py-gutter-md">{subcat.name}</h3>
@@ -116,7 +119,7 @@ export const ReferenceDirectoryWithFilter = ({
           <HeadingPermalink
             as="h3"
             className="m-0 py-gutter-md"
-            id={subcat.name}
+            id={headingId}
           >
             {subcat.name}
           </HeadingPermalink>

--- a/src/components/Settings/styles.module.scss
+++ b/src/components/Settings/styles.module.scss
@@ -1,4 +1,4 @@
-@import "/styles/variables.scss";
+@use "/styles/variables" as *;
 
 .container {
   position: relative;

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -7,13 +7,17 @@ import GridItemPerson from "@components/GridItem/Person.astro";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 import { getCollectionInLocaleWithFallbacks } from "../pages/_utils";
 import { setJumpToState } from "../globals/state";
+import {
+  HeadingPermalink,
+  headingPermalinkComponents,
+} from "@components/HeadingPermalink";
 
 interface Props {
   entry: CollectionEntry<"text-detail">;
 }
 
 const { entry } = Astro.props;
-const { headings, Content } = await entry.render();
+const { headings, Content, components } = await entry.render();
 
 const currentLocale = getCurrentLocale(Astro.url.pathname);
 const t = await getUiTranslator(currentLocale);
@@ -64,11 +68,11 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
 
 <BaseLayout title="About" variant="root">
   <section class="rendered-markdown">
-    <Content />
+    <Content components={{ ...components, ...headingPermalinkComponents }} />
   </section>
 
   <section>
-    <h2 id="people">{t("People")}</h2>
+    <HeadingPermalink as="h2" id="people">{t("People")}</HeadingPermalink>
     <ul class="content-grid">
       {
         displayedFeaturedPeople.map((fp) => (
@@ -84,7 +88,7 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
   </section>
 
   <section>
-    <h2 id="contact">{t("Contact")}</h2>
+    <HeadingPermalink as="h2" id="contact">{t("Contact")}</HeadingPermalink>
     <div
       class="text-2xl grid grid-cols-6 lg:grid-cols-9 gap-x-gutter-sm md:gap-x-gutter-md mt-xl"
     >
@@ -106,7 +110,7 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
     </div>
   </section>
   <section>
-    <h2 id="supporters">Supporters</h2>
+    <HeadingPermalink as="h2" id="supporters">Supporters</HeadingPermalink>
     <ul class="text-2xl mt-xl">
       <li>
         <a href="https://processingfoundation.org">Processing Foundation</a>
@@ -123,7 +127,9 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
     </ul>
   </section>
   <section>
-    <h2 id="processing-foundation">The Processing Ecosystem</h2>
+    <HeadingPermalink as="h2" id="processing-foundation">
+      The Processing Ecosystem
+    </HeadingPermalink>
     <ul class="text-2xl mt-xl">
       <li><a href="https://processing.org">Processing</a></li>
       <li><a href="https://py.processing.org/">Processing.py</a></li>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ import "@styles/base.scss";
 import type { CollectionEntry } from "astro:content";
 import { getCollectionInLocaleWithFallbacks } from "@pages/_utils";
 import { removeLocalePrefix } from "@i18n/utils";
+import { headingPermalinkComponents } from "@components/HeadingPermalink";
 
 interface Props {
   title: string;
@@ -42,9 +43,11 @@ const slug = title.toLowerCase().split(/\s+|\./).join('-');
 const pages = await getCollectionInLocaleWithFallbacks("pages", currentLocale);
 const headerPage = pages.find((page) => removeLocalePrefix(page.slug).slice(1) === slug);
 let HeaderContent: any = undefined;
+let headerComponents: Record<string, any> = {};
 if (headerPage) {
-  const { Content } = await headerPage.render();
+  const { Content, components } = await headerPage.render();
   HeaderContent = Content;
+  headerComponents = components ?? {};
 }
 
 const t = await getUiTranslator(currentLocale);
@@ -117,7 +120,12 @@ const headerTopic = topic
           HeaderContent && (
             <div class="px-5 md:px-lg pt-sm pb-lg">
               <div class="rendered-markdown">
-                <HeaderContent />
+                <HeaderContent
+                  components={{
+                    ...headerComponents,
+                    ...headingPermalinkComponents,
+                  }}
+                />
               </div>
             </div>
         )}

--- a/src/layouts/CommunityLayout.astro
+++ b/src/layouts/CommunityLayout.astro
@@ -6,6 +6,7 @@ import LinkButton from "@components/LinkButton/index.astro";
 import GridItemSketch from "@components/GridItem/Sketch.astro";
 import GridItemLibrary from "@components/GridItem/Library.astro";
 import GridItemEvent from "@components/GridItem/Event.astro";
+import { HeadingPermalink } from "@components/HeadingPermalink";
 import { getCurrentLocale, getUiTranslator } from "@i18n/utils";
 import { setJumpToState } from "../globals/state";
 import { type OpenProcessingCurationResponse } from "../api/OpenProcessing";
@@ -45,7 +46,7 @@ setJumpToState({
 
 <BaseLayout title="Community">
   <section>
-    <h2>{t("Sketches")}<a id="sketches"></a></h2>
+    <HeadingPermalink as="h2" id="sketches">{t("Sketches")}</HeadingPermalink>
     <ul class="content-grid-simple">
       {
         sketches.map((sk, i) => (
@@ -74,7 +75,7 @@ setJumpToState({
   </section>
 
   <section>
-    <h2>{t("Libraries")}<a id="libraries"></a></h2>
+    <HeadingPermalink as="h2" id="libraries">{t("Libraries")}</HeadingPermalink>
     <ul class="content-grid-simple">
       {
         libraries.map((lib) => (
@@ -94,7 +95,7 @@ setJumpToState({
   </section>
 
   <section>
-    <h2>{t("Events")}<a id="events"></a></h2>
+    <HeadingPermalink as="h2" id="events">{t("Events")}</HeadingPermalink>
     <ul class="content-grid-simple">
       {
         events.map((event, i) => (

--- a/src/layouts/ContributeLayout.astro
+++ b/src/layouts/ContributeLayout.astro
@@ -7,6 +7,7 @@ import BaseLayout from "./BaseLayout.astro";
 import { getCurrentLocale, getUiTranslator } from "@i18n/utils";
 import GridItemContributorDoc from "@components/GridItem/ContributorDoc.astro";
 import { setJumpToState, type JumpToLink } from "../globals/state";
+import { HeadingPermalink } from "@components/HeadingPermalink";
 
 interface Props {
   entries: CollectionEntry<"contributor-docs">[];
@@ -53,7 +54,9 @@ setJumpToState({
 
 <BaseLayout title="Contribute">
   <section>
-    <h2 id="docs">{t("Contributor Docs")}</h2>
+    <HeadingPermalink as="h2" id="docs">
+      {t("Contributor Docs")}
+    </HeadingPermalink>
     <div
       class="mb-md grid grid-cols-1 gap-x-gutter-sm md:gap-x-gutter-md lg:grid-cols-2"
     >
@@ -81,7 +84,7 @@ setJumpToState({
     </ul>
   </section>
   <section>
-    <h2 id="donate">{t("Donate")}</h2>
+    <HeadingPermalink as="h2" id="donate">{t("Donate")}</HeadingPermalink>
     <ul class="content-grid-simple">
       {
         // This is the same markup as in ContributorDocItem

--- a/src/layouts/ContributorDocLayout.astro
+++ b/src/layouts/ContributorDocLayout.astro
@@ -9,6 +9,14 @@ import {
   type JumpToState,
 } from "../globals/state";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
+import {
+  HeadingPermalinkH1,
+  HeadingPermalinkH2,
+  HeadingPermalinkH3,
+  HeadingPermalinkH4,
+  HeadingPermalinkH5,
+  HeadingPermalinkH6,
+} from "@components/HeadingPermalink";
 
 interface Props {
   entry: CollectionEntry<"contributor-docs">;
@@ -18,7 +26,7 @@ const currentLocale = getCurrentLocale(Astro.url.pathname);
 const t = await getUiTranslator(currentLocale);
 
 const { entry } = Astro.props;
-const { Content, headings } = await entry.render();
+const { Content, components, headings } = await entry.render();
 
 const jumpToLinks = headings
   .filter((heading: MarkdownHeading) => heading.depth <= 3)
@@ -45,6 +53,16 @@ setJumpToState(jumpToState);
   className="contribute"
 >
   <section class="rendered-markdown">
-    <Content />
+    <Content
+      components={{
+        ...components,
+        h1: HeadingPermalinkH1,
+        h2: HeadingPermalinkH2,
+        h3: HeadingPermalinkH3,
+        h4: HeadingPermalinkH4,
+        h5: HeadingPermalinkH5,
+        h6: HeadingPermalinkH6,
+      }}
+    />
   </section>
 </BaseLayout>

--- a/src/layouts/ContributorDocLayout.astro
+++ b/src/layouts/ContributorDocLayout.astro
@@ -9,14 +9,7 @@ import {
   type JumpToState,
 } from "../globals/state";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
-import {
-  HeadingPermalinkH1,
-  HeadingPermalinkH2,
-  HeadingPermalinkH3,
-  HeadingPermalinkH4,
-  HeadingPermalinkH5,
-  HeadingPermalinkH6,
-} from "@components/HeadingPermalink";
+import { headingPermalinkComponents } from "@components/HeadingPermalink";
 
 interface Props {
   entry: CollectionEntry<"contributor-docs">;
@@ -56,12 +49,7 @@ setJumpToState(jumpToState);
     <Content
       components={{
         ...components,
-        h1: HeadingPermalinkH1,
-        h2: HeadingPermalinkH2,
-        h3: HeadingPermalinkH3,
-        h4: HeadingPermalinkH4,
-        h5: HeadingPermalinkH5,
-        h6: HeadingPermalinkH6,
+        ...headingPermalinkComponents,
       }}
     />
   </section>

--- a/src/layouts/EventLayout.astro
+++ b/src/layouts/EventLayout.astro
@@ -10,6 +10,7 @@ import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 import { getRelatedEntriesinCollection } from "../pages/_utils";
 import OutdatedTranslationBanner from "@components/OutdatedTranslationBanner/index.astro";
 import { checkTranslationBanner } from "../utils/translationBanner";
+import { headingPermalinkComponents } from "@components/HeadingPermalink";
 
 interface Props {
   entry: CollectionEntry<"events">;
@@ -17,7 +18,7 @@ interface Props {
 }
 
 const { entry, title } = Astro.props;
-const { Content } = await entry.render();
+const { Content, components } = await entry.render();
 
 setJumpToState(null);
 
@@ -66,7 +67,9 @@ const { showBanner, englishUrl } = checkTranslationBanner(
   <div class="rendered-markdown">
     <Content
       components={{
+        ...components,
         img: FreeRatioImage,
+        ...headingPermalinkComponents,
       }}
     />
   </div>

--- a/src/layouts/ExampleLayout.astro
+++ b/src/layouts/ExampleLayout.astro
@@ -12,6 +12,7 @@ import EditableSketch from "@components/EditableSketch/index.astro";
 import RelatedItems from "@components/RelatedItems/index.astro";
 import OutdatedTranslationBanner from "@components/OutdatedTranslationBanner/index.astro";
 import { checkTranslationBanner } from "../utils/translationBanner";
+import { headingPermalinkComponents } from "@components/HeadingPermalink";
 
 interface Props {
   example: CollectionEntry<"examples">;
@@ -43,7 +44,7 @@ const relatedReferences =
       )
     : [];
 
-const { Content } = await example.render();
+const { Content, components } = await example.render();
 
 // Extract the collective attribution year. If multiple provided, uses last shown.
 const collectivelyAttributedSince = example.data.remix?.reduce(
@@ -88,7 +89,7 @@ const { showBanner, englishUrl } = checkTranslationBanner(
   {showBanner && <OutdatedTranslationBanner englishUrl={englishUrl} locale={currentLocale} />}
   <div class="mt-xl mb-4xl lg:mb-3xl max-w-[770px]">
     <div class="rendered-markdown">
-      <Content />
+      <Content components={{ ...components, ...headingPermalinkComponents }} />
     </div>
     <div class="rendered-markdown">
       <img src="/images/by-nc-sa.svg" alt="Creative Commons BY-NC-SA license badge" />

--- a/src/layouts/ExamplesLayout.astro
+++ b/src/layouts/ExamplesLayout.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "./BaseLayout.astro";
 import Head from "@components/Head/index.astro";
 import GridItemExample from "@components/GridItem/Example.astro";
+import { HeadingPermalink } from "@components/HeadingPermalink";
 import { getExampleCategory } from "../pages/_utils";
 import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 import { setJumpToState } from "../globals/state";
@@ -58,9 +59,13 @@ setJumpToState(jumpToState);
   {
     examplesByCategory.map((category, i) => (
       <section class="grid">
-        <h2 class="col-span-full">
-          {category.name} <a id={category.name.toLowerCase()} />
-        </h2>
+        <HeadingPermalink
+          as="h2"
+          id={category.name.toLowerCase()}
+          class="col-span-full"
+        >
+          {category.name}
+        </HeadingPermalink>
         <ul class="col-span-full content-grid-simple">
           {category.examples.map((exampleEntry, i) => (
             <li class="col-span-1">

--- a/src/layouts/HomepageLayout.astro
+++ b/src/layouts/HomepageLayout.astro
@@ -104,7 +104,7 @@ setJumpToState(null);
 </BaseLayout>
 
 <style lang="scss">
-  @import "../../styles/variables.scss";
+  @use "../../styles/variables" as *;
   h2 {
     @apply mb-sm mt-0;
     @media (min-width: $breakpoint-tablet) {

--- a/src/layouts/LibrariesLayout.astro
+++ b/src/layouts/LibrariesLayout.astro
@@ -9,6 +9,7 @@ import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 import { categories } from "../content/libraries/config";
 import Button from "@components/Button/index.astro";
 import _ from "lodash";
+import { HeadingPermalink } from "@components/HeadingPermalink";
 
 interface Props {
   entries: CollectionEntry<"libraries">[];
@@ -109,7 +110,7 @@ setJumpToState({
   {
     sections.map(({ slug, name, sectionEntries, allEntries }) => (
       <section>
-        <h2 id={slug}>{name}</h2>
+        <HeadingPermalink as="h2" id={slug}>{name}</HeadingPermalink>
         {full ? (
           <>
             {sectionEntries.map((entry: LibraryEntry) => (

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -4,6 +4,7 @@ import { getCurrentLocale, getUiTranslator } from "@i18n/utils";
 import Head from "@components/Head/index.astro";
 import {
   getRefEntryTitleConcatWithParen,
+  makeReferenceHeadingId,
   escapeCodeTagsContent,
   parseReferenceExamplesAndMetadata,
   normalizeReferenceRoute,
@@ -54,7 +55,7 @@ const relatedEntriesLinks = relatedEntries.map((relatedEntry: any) => {
 // Add link for submodule itself
 relatedEntriesLinks.unshift({
   label: entry.data.submodule,
-  url: `/reference/#${entry.data.submodule}`,
+  url: `/reference/#${makeReferenceHeadingId(entry.data.module, entry.data.submodule)}`,
 });
 // Put related links at top of the list
 jumpToState.links?.unshift(...relatedEntriesLinks);

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -6,6 +6,7 @@ import { ReferenceDirectoryWithFilter } from "@components/ReferenceDirectoryWith
 import { categories } from "../content/reference/config";
 import {
   getRefEntryTitleConcatWithParen,
+  makeReferenceHeadingId,
   normalizeReferenceRoute,
 } from "../pages/_utils";
 import {
@@ -134,16 +135,30 @@ const categoryData = (Astro.props.categories ?? categories).map((category) => {
   };
 });
 
-const jumpCategoryData = categoryData.length === 1
-  ? [...categoryData, ...categoryData[0].subcats]
-  : categoryData;
+const pageJumpToLinks: JumpToLink[] = categoryData.flatMap((category) => {
+  const links: JumpToLink[] = [];
+  const categoryName = category.name as string;
 
-const pageJumpToLinks: JumpToLink[] = jumpCategoryData
-  .filter((category) => !!category.name)  // REMOVE undefined ones
-  .map((category) => ({
-    label: category.name as string,
-    url: `#${category.name}`,
-  }));
+  if (categoryName) {
+    links.push({
+      label: categoryName,
+      url: `#${categoryName}`,
+    });
+  }
+
+  if (categoryData.length === 1) {
+    links.push(
+      ...category.subcats
+        .filter((subcat) => !!subcat.name)
+        .map((subcat) => ({
+          label: subcat.name as string,
+          url: `#${makeReferenceHeadingId(categoryName, subcat.name as string)}`,
+        })),
+    );
+  }
+
+  return links;
+});
 
 const pageJumpToState: JumpToState = {
   links: pageJumpToLinks,

--- a/src/layouts/TextDetailLayout.astro
+++ b/src/layouts/TextDetailLayout.astro
@@ -6,13 +6,14 @@ import { setJumpToState } from "../globals/state";
 import { getCurrentLocale } from "../i18n/utils";
 import OutdatedTranslationBanner from "@components/OutdatedTranslationBanner/index.astro";
 import { checkTranslationBanner } from "../utils/translationBanner";
+import { headingPermalinkComponents } from "@components/HeadingPermalink";
 
 interface Props {
   page: CollectionEntry<"text-detail">;
 }
 
 const { page } = Astro.props;
-const { Content } = await page.render();
+const { Content, components } = await page.render();
 
 const pageTopic = Astro.url.pathname.includes("donate")
   ? "contribute"
@@ -42,6 +43,6 @@ const { showBanner, englishUrl } = checkTranslationBanner(
 >
   {showBanner && <OutdatedTranslationBanner englishUrl={englishUrl} locale={currentLocale} />}
   <div class="max-w-[770px] [&>*:first-child]:mt-0 rendered-markdown pb-[80px]">
-    <Content />
+    <Content components={{ ...components, ...headingPermalinkComponents }} />
   </div>
 </BaseLayout>

--- a/src/layouts/TutorialLayout.astro
+++ b/src/layouts/TutorialLayout.astro
@@ -8,14 +8,7 @@ import PreProxy from "@components/PreProxy/index.astro";
 import CodeBlockWrapper from "@components/CodeBlockWrapper/index.astro";
 import LinkWrapper from "@components/LinkWrapper/index.astro";
 import RelatedItems from "@components/RelatedItems/index.astro";
-import {
-  HeadingPermalinkH1,
-  HeadingPermalinkH2,
-  HeadingPermalinkH3,
-  HeadingPermalinkH4,
-  HeadingPermalinkH5,
-  HeadingPermalinkH6,
-} from "@components/HeadingPermalink";
+import { headingPermalinkComponents } from "@components/HeadingPermalink";
 import {
   generateJumpToState,
   getRelatedEntriesinCollection,
@@ -90,12 +83,7 @@ const { showBanner, englishUrl } = checkTranslationBanner(
         img: FreeRatioImage,
         pre: PreProxy,
         a: LinkWrapper,
-        h1: HeadingPermalinkH1,
-        h2: HeadingPermalinkH2,
-        h3: HeadingPermalinkH3,
-        h4: HeadingPermalinkH4,
-        h5: HeadingPermalinkH5,
-        h6: HeadingPermalinkH6,
+        ...headingPermalinkComponents,
       }}
     />
   </div>

--- a/src/layouts/TutorialLayout.astro
+++ b/src/layouts/TutorialLayout.astro
@@ -9,6 +9,14 @@ import CodeBlockWrapper from "@components/CodeBlockWrapper/index.astro";
 import LinkWrapper from "@components/LinkWrapper/index.astro";
 import RelatedItems from "@components/RelatedItems/index.astro";
 import {
+  HeadingPermalinkH1,
+  HeadingPermalinkH2,
+  HeadingPermalinkH3,
+  HeadingPermalinkH4,
+  HeadingPermalinkH5,
+  HeadingPermalinkH6,
+} from "@components/HeadingPermalink";
+import {
   generateJumpToState,
   getRelatedEntriesinCollection,
 } from "../pages/_utils";
@@ -82,6 +90,12 @@ const { showBanner, englishUrl } = checkTranslationBanner(
         img: FreeRatioImage,
         pre: PreProxy,
         a: LinkWrapper,
+        h1: HeadingPermalinkH1,
+        h2: HeadingPermalinkH2,
+        h3: HeadingPermalinkH3,
+        h4: HeadingPermalinkH4,
+        h5: HeadingPermalinkH5,
+        h6: HeadingPermalinkH6,
       }}
     />
   </div>

--- a/src/layouts/TutorialsLayout.astro
+++ b/src/layouts/TutorialsLayout.astro
@@ -7,6 +7,7 @@ import { getCurrentLocale, getUiTranslator } from "../i18n/utils";
 import { categories } from "../content/tutorials/config";
 import LinkButton from "@components/LinkButton/index.astro";
 import GridItemTutorial from "@components/GridItem/Tutorial.astro";
+import { HeadingPermalink } from "@components/HeadingPermalink";
 
 type TutorialEntry = CollectionEntry<"tutorials">;
 
@@ -35,7 +36,7 @@ const pageJumpToLinks = categories
   .concat([
     {
       url: "#education-resources",
-      label: t("tutorialCategories", "education-resources"), // ✅ changed from tutorialsPage
+      label: t("tutorialCategories", "education-resources"), // changed from tutorialsPage
     },
   ]);
 
@@ -50,9 +51,13 @@ setJumpToState({
   {
     sections.map(({ slug, name, sectionEntries }) => (
       <section>
-        <h2 id={slug} class="mb-gutter-md mt-0">
+        <HeadingPermalink
+          as="h2"
+          id={slug}
+          class="mb-gutter-md mt-0"
+        >
           {name}
-        </h2>
+        </HeadingPermalink>
         <ul class="content-grid border-b border-sidebar-type-color last:border-0">
           {sectionEntries.map((entry: TutorialEntry, i: number) => (
             <li class="col-span-3">
@@ -65,9 +70,13 @@ setJumpToState({
   }
 
   <section>
-    <h2 class="mb-gutter-md mt-0">
-      {t("tutorialCategories", "education-resources")}<a id="education-resources"></a> <!-- ✅ changed from tutorialsPage -->
-    </h2>
+    <HeadingPermalink
+      as="h2"
+      id="education-resources"
+      class="mb-gutter-md mt-0"
+    >
+      {t("tutorialCategories", "education-resources")}
+    </HeadingPermalink>
     <p>{t("tutorialsPage", "education-resources-snippet")}</p>
     <LinkButton url="/education-resources" variant="link" class="mt-lg">
       {t("tutorialsPage", "view-education-resources")}

--- a/src/pages/[locale]/education-resources/index.astro
+++ b/src/pages/[locale]/education-resources/index.astro
@@ -7,6 +7,7 @@ import { setJumpToState, type JumpToLink } from "@/src/globals/state";
 import { getCurrentLocale, getUiTranslator } from "@i18n/utils";
 import { categories } from "@/src/content/tutorials/config";
 import { removeLocalePrefix } from "@i18n/utils";
+import { headingPermalinkComponents } from "@components/HeadingPermalink";
 
 export async function getStaticPaths() {
   const pages = nonDefaultSupportedLocales.map(async (locale) => ({
@@ -25,7 +26,7 @@ export async function getStaticPaths() {
 const { pages, locale } = Astro.props;
 const page = pages.find((page) => removeLocalePrefix(page.slug).slice(1) === 'education-resources')!
 
-const { Content } = await page.render();
+const { Content, components } = await page.render();
 
 const currentLocale = getCurrentLocale(Astro.url.pathname);
 const t = await getUiTranslator(currentLocale);
@@ -54,5 +55,5 @@ setJumpToState({
   variant="item"
   topic="tutorials"
 >
-  <Content />
+  <Content components={{ ...components, ...headingPermalinkComponents }} />
 </BaseLayout>

--- a/src/pages/_utils.ts
+++ b/src/pages/_utils.ts
@@ -155,6 +155,18 @@ export const getExampleCategory = (slug: string): string =>
 export const normalizeReferenceRoute = (route: string): string =>
   removeNestedReferencePaths(removeLocaleAndExtension(route));
 
+/**
+ * Creates a context-aware anchor id for reference page headings.
+ * This keeps repeated subcategory names unique within the page.
+ */
+export const makeReferenceHeadingId = (...parts: string[]): string =>
+  parts
+    .filter(Boolean)
+    .join("-")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
 export const removeLocaleAndExtension = (id: string): string =>
   removeContentFileExt(removeLeadingSlash(removeLocalePrefix(id)));
 

--- a/styles/base.scss
+++ b/styles/base.scss
@@ -1,4 +1,4 @@
-@import "./variables.scss";
-@import "./global.scss";
-@import "./code-editor.scss";
-@import "./markdown.scss";
+@use "./variables";
+@use "./global";
+@use "./code-editor";
+@use "./markdown";

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -1,4 +1,4 @@
-@import "variables.scss";
+@use "/styles/variables" as *;
 
 @font-face {
   font-family: "National Park";

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -1,6 +1,6 @@
 // Default styles to apply to markdown generated content
 
-@import "variables.scss";
+@use "variables" as *;
 
 .rendered-markdown {
   & > *,
@@ -105,6 +105,44 @@
 
   section.footnotes {
     padding-bottom: 0;
+  }
+}
+
+.tutorials .rendered-markdown,
+.contribute .rendered-markdown {
+  .heading-permalink--enabled {
+    scroll-margin-top: var(--heading-scroll-margin-top, 100px);
+  }
+
+  .heading-permalink__link {
+    display: inline;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .heading-permalink__link::after {
+    content: "#";
+    margin-left: 0.22em;
+    opacity: 0;
+    color: #d14;
+    font-weight: normal;
+    transition:
+      opacity 0.15s ease-in-out,
+      color 0.15s ease-in-out;
+
+    .dark-theme & {
+      color: #ff5c8a;
+    }
+  }
+
+  .heading-permalink__link:hover,
+  .heading-permalink__link:focus-visible {
+    text-decoration: underline;
+  }
+
+  .heading-permalink:hover .heading-permalink__link::after,
+  .heading-permalink__link:focus-visible::after {
+    opacity: 1;
   }
 }
 

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -108,42 +108,58 @@
   }
 }
 
-.tutorials .rendered-markdown,
-.contribute .rendered-markdown {
-  .heading-permalink--enabled {
-    scroll-margin-top: var(--heading-scroll-margin-top, 100px);
-  }
+.heading-permalink--enabled {
+  scroll-margin-top: var(--heading-scroll-margin-top, 100px);
+}
 
-  .heading-permalink__link {
-    display: inline;
+.heading-permalink > .heading-permalink__link {
+  display: inline;
+  color: inherit;
+  text-decoration: none;
+
+  .dark-theme & {
     color: inherit;
-    text-decoration: none;
   }
+}
 
-  .heading-permalink__link::after {
-    content: "#";
-    margin-left: 0.22em;
-    opacity: 0;
-    color: #d14;
-    font-weight: normal;
-    transition:
-      opacity 0.15s ease-in-out,
-      color 0.15s ease-in-out;
+.heading-permalink > .heading-permalink__marker {
+  display: inline;
+  color: inherit;
+  text-decoration: none;
 
-    .dark-theme & {
-      color: #ff5c8a;
-    }
+  .dark-theme & {
+    color: inherit;
   }
+}
 
-  .heading-permalink__link:hover,
-  .heading-permalink__link:focus-visible {
-    text-decoration: underline;
-  }
+.heading-permalink > .heading-permalink__link::after,
+.heading-permalink > .heading-permalink__marker::after {
+  content: "#" / "";
+  margin-left: 0.22em;
+  opacity: 0;
+  color: #d14;
+  font-weight: normal;
+  transition:
+    opacity 0.15s ease-in-out,
+    color 0.15s ease-in-out;
 
-  .heading-permalink:hover .heading-permalink__link::after,
-  .heading-permalink__link:focus-visible::after {
-    opacity: 1;
+  .dark-theme & {
+    color: #ff5c8a;
   }
+}
+
+.heading-permalink > .heading-permalink__link:hover,
+.heading-permalink > .heading-permalink__link:focus-visible,
+.heading-permalink > .heading-permalink__marker:hover,
+.heading-permalink > .heading-permalink__marker:focus-visible {
+  text-decoration: underline;
+}
+
+.heading-permalink:hover .heading-permalink__link::after,
+.heading-permalink:hover .heading-permalink__marker::after,
+.heading-permalink > .heading-permalink__link:focus-visible::after,
+.heading-permalink > .heading-permalink__marker:focus-visible::after {
+  opacity: 1;
 }
 
 


### PR DESCRIPTION
## Summary
Adds MDX heading permalinks for tutorial pages using component overrides in `TutorialLayout.astro`.

Closes #1398 

## Changes
- Introduced reusable `HeadingPermalink` component (Preact)
- Overrode `h1–h6` in tutorial MDX rendering only
- Preserved Astro-generated heading IDs
- Made entire heading clickable (links to `#fragment`)
- Added improved hover UX:
  - `#` indicator appears on hover/focus (left side, subtle color)
  - heading text underlines on hover
- Scoped styles under `.tutorials .rendered-markdown`
- Avoided nested anchor issues

## Demo
Short demo showing heading hover, permalink visibility, and fragment navigation:  
https://github.com/user-attachments/assets/ab1f6c54-a9a5-423d-860e-360aec349cd9

## Testing
- `npm run check` passes (no errors)
- `npm run build` succeeds
- Verified:
  - hovering a heading shows `#` indicator
  - clicking heading updates URL fragment
  - direct `#fragment` navigation scrolls correctly
  - headings without IDs do not break
  - headings with inline links do not create nested anchors

## Notes
- Service worker 404 seen in dev console is unrelated to this change
- No changes to routes, schemas, or global markdown behavior