### PR TITLE
[GSoC week 1] Add collapsible details to show the newly added content to the English version of the file

### DIFF
--- a/.github/actions/translation-tracker/index.js
+++ b/.github/actions/translation-tracker/index.js
@@ -410,9 +410,8 @@ class GitHubCommitTracker {
     // English diff. It shows the actual content changes in the English file.
     if (englishDiff && (englishDiff.compareUrl || englishDiff.patchSnippet)) {
       body += `### 🧩 Recent English Diff\n\n`;
-      if (englishDiff.compareUrl) {
-        body += `- [🔍 View full compare](${englishDiff.compareUrl})\n\n`;
-      }
+      body += `- [🔍 View full compare](${englishDiff.compareUrl})\n\n`; // provides url to compare the differences
+    
       if (englishDiff.patchSnippet) {
         body += `<details>\n<summary>Show patch snippet</summary>\n\n`;
         body += `\`\`\`diff\n${englishDiff.patchSnippet}\n\`\`\`\n\n`;

--- a/.github/actions/translation-tracker/index.js
+++ b/.github/actions/translation-tracker/index.js
@@ -407,7 +407,7 @@ class GitHubCommitTracker {
       });
     }
 
-    // English diff (optional best-effort)
+    // English diff. It shows the actual content changes in the English file.
     if (englishDiff && (englishDiff.compareUrl || englishDiff.patchSnippet)) {
       body += `### 🧩 Recent English Diff\n\n`;
       if (englishDiff.compareUrl) {
@@ -421,7 +421,7 @@ class GitHubCommitTracker {
         }
         body += `</details>\n\n`;
       } else {
-        body += `_(No preview of the differences is available for this change. Use the compare link above.)_\n\n`;
+        body += `_(Could't generate preview of the differences for this change. Use the compare link above to see the full diff.)_\n\n`;
       }
     }
 

--- a/.github/actions/translation-tracker/index.js
+++ b/.github/actions/translation-tracker/index.js
@@ -421,7 +421,7 @@ class GitHubCommitTracker {
         }
         body += `</details>\n\n`;
       } else {
-        body += `_(Could't generate preview of the differences for this change. Use the compare link above to see the full diff.)_\n\n`;
+        body += `_(Couldn't generate preview of the differences for this change. Use the compare link above to see the full diff.)_\n\n`;
       }
     }
 

--- a/.github/actions/translation-tracker/index.js
+++ b/.github/actions/translation-tracker/index.js
@@ -269,7 +269,7 @@ class GitHubCommitTracker {
       let isTruncated = false;
       if (patch) {
         const lines = patch.split('\n');
-        const maxLines = 80;
+        const maxLines = 50;
         if (lines.length > maxLines) {
           patchSnippet = lines.slice(0, maxLines).join('\n');
           isTruncated = true;
@@ -405,6 +405,24 @@ class GitHubCommitTracker {
         body += `- **${this.getLanguageDisplayName(lang.language)}**: Translation file does not exist${stewardsText}\n`;
         body += `  - Expected location: \`${translationPath}\`\n\n`;
       });
+    }
+
+    // English diff (optional best-effort)
+    if (englishDiff && (englishDiff.compareUrl || englishDiff.patchSnippet)) {
+      body += `### 🧩 Recent English Diff\n\n`;
+      if (englishDiff.compareUrl) {
+        body += `- [🔍 View full compare](${englishDiff.compareUrl})\n\n`;
+      }
+      if (englishDiff.patchSnippet) {
+        body += `<details>\n<summary>Show patch snippet</summary>\n\n`;
+        body += `\`\`\`diff\n${englishDiff.patchSnippet}\n\`\`\`\n\n`;
+        if (englishDiff.isTruncated) {
+          body += `_(Patch snippet truncated. Use the compare link above for the full diff.)_\n\n`;
+        }
+        body += `</details>\n\n`;
+      } else {
+        body += `_(No preview of the differences is available for this change. Use the compare link above.)_\n\n`;
+      }
     }
 
     body += `### 🔗 Quick Links

--- a/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
@@ -31,3 +31,5 @@ sets the color for the inside of shapes.
 turn off line color and inner color, respectively.
 
 Colors can be represented in many different ways. This example demonstrates several options.
+
+I've added this description.

--- a/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
+++ b/src/content/examples/en/01_Shapes_And_Color/01_Color/description.mdx
@@ -31,5 +31,3 @@ sets the color for the inside of shapes.
 turn off line color and inner color, respectively.
 
 Colors can be represented in many different ways. This example demonstrates several options.
-
-I've added this description.


### PR DESCRIPTION
**In-Issue Diffs:** Update the tracker (index.js) to parse the englishDiff patch snippet and render it within a collapsible `<details>` section inside the GitHub Issue body. This allows volunteer translators to see exactly what changed without navigating away.

> It looks like this.
<details> I'm the content that was added or removed </details>

This is my task from week 1: https://github.com/processing/p5.js-website/issues/1404