### PR TITLE
fix: show preview for the last example in createCapture() docs

### DIFF
--- a/src/content/reference/en/p5/createCapture.mdx
+++ b/src/content/reference/en/p5/createCapture.mdx
@@ -133,7 +133,7 @@ example:
     </code>
     </div>
 
-    <div class='notest norender'>
+    <div class='notest'>
     <code>
     function setup() {
       createCanvas(480, 120);

--- a/src/content/reference/es/p5/createCapture.mdx
+++ b/src/content/reference/es/p5/createCapture.mdx
@@ -130,7 +130,7 @@ example:
     </code>
     </div>
 
-    <div class='notest norender'>
+    <div class='notest'>
     <code>
     function setup() {
       createCanvas(480, 120);

--- a/src/content/reference/hi/p5/createCapture.mdx
+++ b/src/content/reference/hi/p5/createCapture.mdx
@@ -78,7 +78,7 @@ example:
     </code>
     </div>
 
-    <div class='notest norender'>
+    <div class='notest'>
     <code>
     function setup() {
       createCanvas(480, 120);

--- a/src/content/reference/ko/p5/createCapture.mdx
+++ b/src/content/reference/ko/p5/createCapture.mdx
@@ -63,7 +63,7 @@ example:
     </code>
     </div>
 
-    <div class='notest norender'>
+    <div class='notest'>
     <code>
     function setup() {
       createCanvas(480, 120);

--- a/src/content/reference/zh-Hans/p5/createCapture.mdx
+++ b/src/content/reference/zh-Hans/p5/createCapture.mdx
@@ -117,7 +117,7 @@ example:
     </code>
     </div>
 
-    <div class='notest norender'>
+    <div class='notest'>
     <code>
     function setup() {
       createCanvas(480, 120);


### PR DESCRIPTION
Fixes #1366

The preview for the last example on the `createCapture()` reference page was missing. This happened because the example had a norender class assigned to it.

This PR simply removes the `norender` class from the `createCapture.mdx` files across all languages, which enables the live webcam preview to show up correctly on the website.