### PR TITLE
fix: vertically align nav arrow with p5 logo using flexbox

### DIFF
--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -71,7 +71,7 @@
       padding: 0;
       margin-bottom: 10px;
       a {
-        height: unset;
+        height: 100%;
       }
     }
 

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -66,6 +66,7 @@
     .logo {
       height: 50px;
       display: flex;
+      align-items: center;
       gap: var(--spacing-xs);
       padding: 0;
       margin-bottom: 10px;
@@ -113,7 +114,6 @@
     display: none;
     @media (min-width: variables.$breakpoint-tablet) {
       display: block;
-      margin-top: 7.5px;
     }
   }
 


### PR DESCRIPTION
Closes #1295

## Changes
- Added `align-items: center` to `.logo` flex container on desktop
- Removed manual `margin-top: 7.5px` from `.desktopMenuLabel`
- Set `height: 100%` on logo anchor tag to prevent SVG collapse

## Before
<img width="242" height="257" alt="image" src="https://github.com/user-attachments/assets/96eac010-162e-4e99-9572-eea31662d4b2" />

## After  
<img width="246" height="269" alt="image" src="https://github.com/user-attachments/assets/254c1086-859a-4a85-86f5-6722277281af" />

## Testing
- Verified on desktop viewport at localhost:4321/reference/
- Arrow is vertically centered with p5 logo
- Logo renders correctly with no collapse