### PR TITLE
fix: Fixed scrollbar in example output frame (cherry-pick from #745)

### DIFF
--- a/src/components/CodeEmbed/frame.tsx
+++ b/src/components/CodeEmbed/frame.tsx
@@ -165,9 +165,8 @@ export const CodeFrame = (props: CodeFrameProps) => {
         sandbox="allow-scripts allow-popups allow-modals allow-forms allow-same-origin"
         aria-label="Code Preview"
         title="Code Preview"
-        height={props.height}
-        width={props.width}
         loading={props.lazyLoad ? "lazy" : "eager"}
+        style={{width: "100%", height: "100%"}}
       />
     </div>
   );


### PR DESCRIPTION
Fixes #716

This is a clean cherry-pick of the relevant fix from #745 by @Its-sunny69 whose branch had carried over unrelated commits.

The fix removes the hardcoded width and height from the iframe in src/components/CodeEmbed/frame.tsx and lets it fill its parent container instead. Before this change, both the parent and the iframe were declaring the same size separately. Now, only the parent controls the size, which removes the confusion that was likely causing Chrome to show unnecessary scrollbars at certain zoom levels.

Note: I could not reproduce the bug locally or on the live site. I also found that index.jsx line 94 already has overflow-hidden on the parent container, which may explain why the bug is hard to reproduce consistently. The fix is still worth merging as it makes the code cleaner.
