### PR TITLE
Fix: Remove extra 8px margin below Donate button in nav

### DIFF
--- a/src/components/Nav/MainNavLinks.tsx
+++ b/src/components/Nav/MainNavLinks.tsx
@@ -79,7 +79,7 @@ export const MainNavLinks = ({
           </li>
         ))}
       </ul>
-      <ul class="flex flex-col gap-[15px]">
+      <ul class={`flex flex-col gap-[15px] ${styles.buttonsList}`}>
         <li>
           <a className={styles.buttonlink} href="https://editor.p5js.org">
             <div class="mr-xxs">

--- a/src/components/Nav/MainNavLinks.tsx
+++ b/src/components/Nav/MainNavLinks.tsx
@@ -79,7 +79,7 @@ export const MainNavLinks = ({
           </li>
         ))}
       </ul>
-      <ul class={`flex flex-col gap-[15px] ${styles.buttonsList}`}>
+      <ul class="flex flex-col gap-[15px]">
         <li>
           <a className={styles.buttonlink} href="https://editor.p5js.org">
             <div class="mr-xxs">

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -49,6 +49,10 @@
     margin-bottom: var(--spacing-xs);
   }
 
+  .buttonsList {
+    margin-bottom: 0;
+  }
+
   @media (min-width: variables.$breakpoint-tablet) {
     display: grid;
     grid-auto-flow: column;
@@ -288,4 +292,3 @@
 .jumpto ul li.linklabel:not(:global(.small), :first-child) {
   margin-top: 10px;
 }
-

--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -46,11 +46,6 @@
     font-size: 1.5rem;
     line-height: 1.167;
     -webkit-text-stroke-width: 0.15px;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .buttonsList {
-    margin-bottom: 0;
   }
 
   @media (min-width: variables.$breakpoint-tablet) {


### PR DESCRIPTION
Closes #1423

Fix
- **MainNavLinks.tsx** — Added styles.buttonsList CSS module class to the buttons `<ul>` for targeted styling.
- **styles.module.scss** — Added `.buttonsList` rule inside `.mainlinks` that overrides `margin-bottom: 0`, removing only the trailing gap while preserving the spacing between the two lists.