### PR TITLE
Update tutorial snippet to pass proper varying from vertex shader to

### DIFF
--- a/src/content/tutorials/en/intro-to-glsl.mdx
+++ b/src/content/tutorials/en/intro-to-glsl.mdx
@@ -635,7 +635,7 @@ For example, you may want to use a shape's texture coordinates in the fragment s
     // Tell WebGL where the vertex goes
     gl_Position = uProjectionMatrix * viewModelPosition;
   ${begin('assign')}
-  vTexCoord = aTexCoord;
+    vTexCoord = aTexCoord;
   ${end('assign')}
   }
 `}>

--- a/src/content/tutorials/en/intro-to-glsl.mdx
+++ b/src/content/tutorials/en/intro-to-glsl.mdx
@@ -618,29 +618,24 @@ You can see the complete list of uniforms that p5.js provides for you in the [p5
 For example, you may want to use a shape's texture coordinates in the fragment shader. These come in the form of a `vec2`, where coordinates go between 0 and 1. This initially comes in an `attribute` from p5.js, and those are only accessible in the vertex shader. Let's look at what our standard vertex shader does to pass that to fragment shaders:
 
 <AnnotatedCode lang="glsl" code={({ begin, end }) =>
-`
-  precision highp float;
+`precision highp float;
 
   attribute vec3 aPosition;
   ${begin('texcoord')}
   attribute vec2 aTexCoord;
   ${end('texcoord')}
-  attribute vec4 aVertexColor;
-
   uniform mat4 uModelViewMatrix;
   uniform mat4 uProjectionMatrix;
-
   ${begin('varying')}
   varying vec2 vTexCoord;
   ${end('varying')}
-  varying vec4 vVertexColor;
   void main() {
     // Apply the camera transform
     vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
     // Tell WebGL where the vertex goes
     gl_Position = uProjectionMatrix * viewModelPosition;
   ${begin('assign')}
-    vVertexColor = aVertexColor;
+  vTexCoord = aTexCoord;
   ${end('assign')}
   }
 `}>


### PR DESCRIPTION
Resolves https://github.com/processing/p5.js-website/issues/1437

## Description
This is a follow-up PR to this PR https://github.com/processing/p5.js-website/pull/1122#pullrequestreview-4376662395 where it was mentioned that the same fix should be applied to the 2.0 branch.

## Changes
- Remove references to the `vVertexColor` varying in the tutorial snippet for "Varyings: Passing data from vertex to fragment shader" and instead pass `vTexCoord` varying to the fragment shader.
- Some white space changes to fix how the indentation and padding is displayed on the code blocks.
