### PR TITLE
fix: add missing alt text for people portraits (2.0)

### DIFF
--- a/src/content/people/en/kenneth-lim.yaml
+++ b/src/content/people/en/kenneth-lim.yaml
@@ -2,7 +2,7 @@ name: Kenneth Lim
 url: https://limzykenneth.com/
 category: mentor
 image: ../images/kenneth-lim.jpeg
-imageAlt: WRITE ALT TEXT HERE
+imageAlt: Portrait of Kenneth Lim
 role: p5.js Mentor, 2023-present
 order: 4
 blurb: >

--- a/src/content/people/en/stalgia-grigg.yaml
+++ b/src/content/people/en/stalgia-grigg.yaml
@@ -1,7 +1,7 @@
 name: Stalgia Grigg
 category: alumni
 image: ../images/stalgia-grigg.png
-imageAlt: WRITE ALT TEXT HERE
+imageAlt: Portrait of Stalgia Grigg
 url: https://stalgiagrigg.name/
 role: p5.js Fellow 2019
 order: 9


### PR DESCRIPTION
Brings the alt text fix from #1306 to the 2.0 branch.

Adds missing imageAlt values for Kenneth Lim and 
Stalgia Grigg portrait images on the People page.

Replaces #1436 which contained unrelated files.