### PR TITLE
fix: preserve locale casing in content collection entry IDs after Ast… [2.0]

### DIFF
--- a/src/content/banner/config.ts
+++ b/src/content/banner/config.ts
@@ -1,9 +1,14 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
+import { generateEntryId } from "../shared";
 
 export const bannerCollection = defineCollection({
-  loader: glob({ pattern: '**/*.mdx', base: "./src/content/banner" }),
+  loader: glob({
+    pattern: '**/*.mdx',
+    base: "./src/content/banner",
+    generateId: generateEntryId,
+  }),
   schema: () =>
     z.object({
       title: z.string(),

--- a/src/content/contributor-docs/config.ts
+++ b/src/content/contributor-docs/config.ts
@@ -1,12 +1,17 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
+import { generateEntryId } from "../shared";
 
 /**
  * Content collection for the Contribute section of the site.
  */
 export const contributorDocsCollection = defineCollection({
-  loader: glob({ pattern: '**/*.mdx', base: "./src/content/contributor-docs" }),
+  loader: glob({
+    pattern: '**/*.mdx',
+    base: "./src/content/contributor-docs",
+    generateId: generateEntryId,
+  }),
   schema: z.object({
     title: z.string(),
     description: z.string(),

--- a/src/content/events/config.ts
+++ b/src/content/events/config.ts
@@ -1,9 +1,14 @@
 import { defineCollection, reference } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
+import { generateEntryId } from "../shared";
 
 export const eventsCollection = defineCollection({
-  loader: glob({ pattern: '**/*.mdx', base: "./src/content/events" }),
+  loader: glob({
+    pattern: '**/*.mdx',
+    base: "./src/content/events",
+    generateId: generateEntryId,
+  }),
   schema: ({ image }) =>
     z.object({
       title: z.string(),

--- a/src/content/examples/config.ts
+++ b/src/content/examples/config.ts
@@ -1,6 +1,7 @@
 import { defineCollection, reference } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
+import { generateEntryId } from "../shared";
 
 /**
  * Content collection for the Examples section of the site.
@@ -9,7 +10,8 @@ import { z } from "astro/zod";
 export const examplesCollection = defineCollection({
   loader: glob({
     pattern: '**/*.mdx',
-    base: "./src/content/examples"
+    base: "./src/content/examples",
+    generateId: generateEntryId,
   }),
   schema: ({ image }) =>
     z.object({

--- a/src/content/homepage/config.ts
+++ b/src/content/homepage/config.ts
@@ -1,9 +1,14 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
+import { generateEntryId } from "../shared";
 
 export const homepageCollection = defineCollection({
-  loader: glob({ pattern: '**/*.yaml', base: "./src/content/homepage" }),
+  loader: glob({
+    pattern: '**/*.yaml',
+    base: "./src/content/homepage",
+    generateId: generateEntryId,
+  }),
   schema: ({ image }) =>
     z.object({
       title: z.string(),

--- a/src/content/libraries/config.ts
+++ b/src/content/libraries/config.ts
@@ -1,7 +1,7 @@
 import { defineCollection } from "astro:content";
 import { z } from "astro/zod";
 import { glob } from "astro/loaders";
-import { author } from "../shared";
+import { author, generateEntryId } from "../shared";
 
 export const categories = [
   "drawing",
@@ -29,7 +29,11 @@ export const categories = [
  * Content collection for the Libraries section of the site.
  */
 export const librariesCollection = defineCollection({
-  loader: glob({ pattern: '**/*.yaml', base: "./src/content/libraries" }),
+  loader: glob({
+    pattern: '**/*.yaml',
+    base: "./src/content/libraries",
+    generateId: generateEntryId,
+  }),
   schema: ({ image }) =>
     z.object({
       // Name of the library

--- a/src/content/pages/config.ts
+++ b/src/content/pages/config.ts
@@ -1,9 +1,14 @@
 import { defineCollection } from "astro:content";
 import { z } from "astro/zod";
 import { glob } from "astro/loaders";
+import { generateEntryId } from "../shared";
 
 export const pagesCollection = defineCollection({
-  loader: glob({ pattern: '**/*.mdx', base: "./src/content/pages" }),
+  loader: glob({
+    pattern: '**/*.mdx',
+    base: "./src/content/pages",
+    generateId: generateEntryId,
+  }),
   schema: () => z.object({
     title: z.string(),
   }),

--- a/src/content/people/config.ts
+++ b/src/content/people/config.ts
@@ -1,6 +1,7 @@
 import { defineCollection } from "astro:content";
 import { z } from "astro/zod";
 import { glob } from "astro/loaders";
+import { generateEntryId } from "../shared";
 
 const peopleCategories = ["lead", "mentor", "alumni", "contributor"] as const;
 
@@ -9,7 +10,11 @@ const peopleCategories = ["lead", "mentor", "alumni", "contributor"] as const;
  *
  */
 export const peopleCollection = defineCollection({
-  loader: glob({ pattern: '**/*.yaml', base: "./src/content/people" }),
+  loader: glob({
+    pattern: '**/*.yaml',
+    base: "./src/content/people",
+    generateId: generateEntryId,
+  }),
   schema: ({ image }) =>
     z
       .object({

--- a/src/content/reference/config.ts
+++ b/src/content/reference/config.ts
@@ -1,7 +1,7 @@
 import { defineCollection } from "astro:content";
 import { z } from "astro/zod";
 import { glob } from "astro/loaders";
-import { relatedContent } from "../shared";
+import { generateEntryId, relatedContent } from "../shared";
 
 // Categories, ordered in a (rough) general-to-specific sequence for easier
 // reading. Some bits that we haven't finished revising are moved lower down
@@ -93,6 +93,10 @@ export const referenceSchema = z.object({
 });
 
 export const referenceCollection = defineCollection({
-  loader: glob({ pattern: '**/*.mdx', base: "./src/content/reference" }),
+  loader: glob({
+    pattern: '**/*.mdx',
+    base: "./src/content/reference",
+    generateId: generateEntryId,
+  }),
   schema: referenceSchema,
 });

--- a/src/content/shared.ts
+++ b/src/content/shared.ts
@@ -1,6 +1,15 @@
 import { reference } from "astro:content";
 import { z } from "astro/zod";
 
+/**
+ * Generates an entry ID that preserves the original file path casing.
+ * Astro's default glob() loader lowercases IDs via github-slugger, which
+ * breaks locale matching for codes like "zh-Hans". Using the raw path
+ * (without extension) keeps IDs consistent with the folder structure.
+ */
+export const generateEntryId = ({ entry }: { entry: string }): string =>
+  entry.replace(/\.(mdx|yaml)$/, "");
+
 /*
  * A zod type for an author.
  * has a name and an optional URL to link to

--- a/src/content/text-detail/config.ts
+++ b/src/content/text-detail/config.ts
@@ -1,9 +1,14 @@
 import { defineCollection } from "astro:content";
 import { z } from "astro/zod";
 import { glob } from "astro/loaders";
+import { generateEntryId } from "../shared";
 
 export const textDetailCollection = defineCollection({
-  loader: glob({ pattern: '**/*.mdx', base: "./src/content/text-detail" }),
+  loader: glob({
+    pattern: '**/*.mdx',
+    base: "./src/content/text-detail",
+    generateId: generateEntryId,
+  }),
   schema: ({ image }) =>
     z.object({
       title: z.string(),

--- a/src/content/tutorials/config.ts
+++ b/src/content/tutorials/config.ts
@@ -1,7 +1,7 @@
 import { defineCollection } from "astro:content";
 import { z } from "astro/zod";
 import { glob } from "astro/loaders";
-import { relatedContent } from "../shared";
+import { generateEntryId, relatedContent } from "../shared";
 
 export const categories = [
   "2.0",
@@ -19,7 +19,11 @@ export const categories = [
  * Content collection for the Sketches showcase section of the site.
  */
 export const tutorialsCollection = defineCollection({
-  loader: glob({ pattern: '**/*.mdx', base: "./src/content/tutorials" }),
+  loader: glob({
+    pattern: '**/*.mdx',
+    base: "./src/content/tutorials",
+    generateId: generateEntryId,
+  }),
   schema: ({ image }) =>
     z
       .object({


### PR DESCRIPTION
…ro 6 upgrade

Applyies https://github.com/processing/p5.js-website/pull/1447 to `2.0`

Addresses https://github.com/processing/p5.js-website/issues/1446 