### PR TITLE
Fix framebuffer blur vertex shader for p5.js 2.0

### DIFF
--- a/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
+++ b/src/content/examples/en/11_3D/06_Framebuffer_Blur/code.js
@@ -1,6 +1,7 @@
 // Vertex shader code
 let vertexShader = `
-uniform mat4 uModelViewMatrix;
+uniform mat4 uModelMatrix;
+uniform mat4 uViewMatrix;
 uniform mat4 uProjectionMatrix;
 
 attribute vec3 aPosition;
@@ -16,7 +17,7 @@ void main() {
   // copy position with a fourth coordinate for projection (1.0 is normal)
   vec4 positionVec4 = vec4(aPosition, 1.0);
 
-  gl_Position = uProjectionMatrix * uModelViewMatrix * positionVec4;
+  gl_Position = uProjectionMatrix * uViewMatrix * uModelMatrix * positionVec4;
 }`;
 
 // Fragment shader code


### PR DESCRIPTION
Updates the Framebuffer Blur example vertex shader to use separate uModelMatrix + uViewMatrix uniforms instead of the deprecated uModelViewMatrix uniform. This fixes the incorrect matrix multiplication order that caused crescent-shaped distortion.

Fixes #8940