### PR TITLE
Fix tutorial content too wide

### DIFF
--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -137,7 +137,9 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
 </BaseLayout>
 
 <style lang="scss">
+  @reference "../../styles/global.css";
+
   a {
-    @reference text-type-magenta-dark;
+    @apply text-type-magenta-dark;
   }
 </style>

--- a/src/layouts/HomepageLayout.astro
+++ b/src/layouts/HomepageLayout.astro
@@ -102,8 +102,10 @@ const sketches = config.data.sketchIds.map(
 
 <style lang="scss">
   @use "../../styles/variables.scss";
+  @reference "../../styles/global.css";
+
   h2 {
-    @reference mb-sm mt-0;
+    @apply mb-sm mt-0;
     @media (min-width: variables.$breakpoint-tablet) {
       font-size: 3.5rem;
     }

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -5,7 +5,7 @@
 .rendered-markdown {
   & > *,
   & > astro-island > * {
-    @reference max-w-screen-md;
+    max-width: variables.$breakpoint-tablet;
   }
 
   & > .full-width,
@@ -15,7 +15,7 @@
 
   .full-width td,
   .full-width th {
-    @reference max-w-screen-md;
+    max-width: variables.$breakpoint-tablet;
   }
 
   a {


### PR DESCRIPTION
Resolves #1457

The PR fixes regressions introduced at 418975040234549851b6a90378330bf1ec5e21b5.

### Changes
- Applied max-width to `.rendered-markdown`
- Fixed [`@reference`](https://tailwindcss.com/docs/functions-and-directives#reference-directive) directives used in places of [`@apply`](https://tailwindcss.com/docs/functions-and-directives#apply-directive)

### Screencaps

#### max-width applied to tutorial pages
<img width="1855" height="960" alt="Screenshot 2026-06-21 at 14 13 03" src="https://github.com/user-attachments/assets/d1875032-80a5-4f4a-a824-9b6256ecd7de" />
</br>
</br>

#### Fix about page's link color (black → magenta)

Before
<img width="1859" height="958" alt="Screenshot 2026-06-21 at 14 05 45" src="https://github.com/user-attachments/assets/12d0a165-e043-44b5-af0d-2ddc2291b5b4" />

After
<img width="1854" height="957" alt="Screenshot 2026-06-21 at 14 06 15" src="https://github.com/user-attachments/assets/81eac3ed-d82e-4df9-af12-358a3daa8f54" />

#### Fix home page's h2 margin

Before

<img width="1860" height="960" alt="Screenshot 2026-06-21 at 14 09 13" src="https://github.com/user-attachments/assets/6eb1aec0-b808-40b2-b03b-21855b51db3f" />

After

<img width="1857" height="959" alt="Screenshot 2026-06-21 at 14 09 36" src="https://github.com/user-attachments/assets/e2709af2-5383-4a3c-8b69-de49330b3abe" />

