### PR TITLE
fix: remove margin-bottom from .mainlinks ul 2.0 (#1423)

### DIFF
--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -46,7 +46,6 @@
     font-size: 1.5rem;
     line-height: 1.167;
     -webkit-text-stroke-width: 0.15px;
-    margin-bottom: var(--spacing-xs);
   }
 
   @media (min-width: variables.$breakpoint-tablet) {


### PR DESCRIPTION
2.0 version of the fix merged in #1432.

Removes the extra 8px margin below the Donate button in the side navigation.

Addresses #1423