### PR TITLE
fix: homepage header taking full viewport, hiding hero image (#1459)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -94,7 +94,7 @@ const headerTopic = topic
     <div class="top-layout-grid">
       <Nav jumpToState={jumpToState} />
       <Settings hideSearch={variant === "search"} />
-      <header class={homepageConfig && "h-[100vh] md:min-h-[calc(378px+50vh)]"}>
+      <header class={homepageConfig && "homepage-header"}>
         {
           variant === "root" ? (
             <RootPageHeader

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -403,6 +403,21 @@ pre.code-box,
       margin-top: 0;
     }
   }
+
+  .homepage-header {
+    height: 100dvh;
+    min-height: 750px;
+
+    @supports not (height: 100dvh) {
+      height: 100vh;
+      min-height: 750px;
+    }
+
+    @media (min-width: variables.$breakpoint-tablet) {
+      height: auto;
+      min-height: calc(378px + 50vh);
+    }
+  }
 }
 
 .monochrome-theme {
@@ -473,7 +488,7 @@ th {
   @media (max-width: #{variables.$breakpoint-laptop - 1px}) {
     height: 100%;
     max-height: none;
-    min-height: 180px;
+    min-height: 375px;
   }
   @media (min-width: variables.$breakpoint-tablet) {
     left: calc(-1 * var(--spacing-lg));


### PR DESCRIPTION
### Description:

Fixes #1459
On mobile, the homepage header was set to 100vh, pushing the hero image below the fold. Users had to scroll to see it.

### Changes:

- Use 100dvh (dynamic viewport height) with vh fallback to account for mobile browser chrome
- Enforce 750px minimum total height per design spec
- Set hero image min-height to 375px to match the 50vh/50vh split requirement