### PR TITLE
Narrow the build:reference p5.sound yuidoc step to ONLY process src subdirectory (not everything!)

### DIFF
--- a/src/scripts/parsers/reference.ts
+++ b/src/scripts/parsers/reference.ts
@@ -67,7 +67,7 @@ export const parseLibraryReference =
         'https://github.com/processing/p5.sound.js.git',
         'main'
       );
-      await saveYuidocOutput('p5.sound.js', 'data-sound');
+      await saveYuidocOutput('p5.sound.js', 'data-sound', { inputPath: 'src' });
       const soundData = await getYuidocOutput('data-sound');
       if (!soundData) throw new Error('Error generating p5.sound reference data!');
 
@@ -154,7 +154,7 @@ const getYuidocOutput = async (outDirName: string): Promise<ParsedLibraryReferen
 };
 
 /**
- * Parses the p5.js library using YUIDoc and captures the output
+ * Parses the given library (e.g. p5.sound) using YUIDoc and captures the output
  */
 export const saveYuidocOutput = async (
   inDirName: string,


### PR DESCRIPTION
Fixes #1470

## changes
1. Pass 'src' as inputPath to saveYuidocOuput for p5.sound rather than defaulting to the too-wide '.'

2. (minor) correct comment on saveYuidocOutput which stated it parsed the p5.js library.  That's not true on 2.0 branch - it s seems it is currently ONLY used for p5.sound.