### PR TITLE
Fix search bar placeholder font-size to match Language/Accessibility dropdowns.

### DIFF
--- a/src/components/SearchForm/index.astro
+++ b/src/components/SearchForm/index.astro
@@ -20,7 +20,7 @@ const t = await getUiTranslator(currentLocale);
     type="search"
     placeholder={t("Search") as string}
     name="term"
-    class="border-accent-type-color border outline-offset-0 placeholder-accent-type-color bg-transparent pl-gutter-md py-[6px] md:py-[4px] lg:py-[8px] h-full w-full rounded-[20px] peer"
+   class="border-accent-type-color border outline-offset-0 placeholder-accent-type-color bg-transparent pl-gutter-md py-[6px] md:py-[4px] lg:py-[8px] h-full w-full rounded-[20px] peer text-base"
     aria-label="Search through site content"
     required
   />


### PR DESCRIPTION
Fixes #1481

The "Search" placeholder text was larger than the "Language" and "Accessibility" dropdown labels on desktop. Added the `text-base` Tailwind class to the search input to match the `font-size: 1rem` used by the dropdown component, so all three now render at the same size.