### PR TITLE
update tutorial snippet to pass vTexCoord and remove vVertexColor

### DIFF
--- a/src/content/tutorials/ko/intro-to-glsl.mdx
+++ b/src/content/tutorials/ko/intro-to-glsl.mdx
@@ -621,7 +621,6 @@ p5.js가 제공하는 유니폼의 전체 목록은 [p5.js WebGL Mode Architectu
   ${begin('texcoord')}
   attribute vec2 aTexCoord;
   ${end('texcoord')}
-  attribute vec4 aVertexColor;
 
   uniform mat4 uModelViewMatrix;
   uniform mat4 uProjectionMatrix;
@@ -629,14 +628,14 @@ p5.js가 제공하는 유니폼의 전체 목록은 [p5.js WebGL Mode Architectu
   ${begin('varying')}
   varying vec2 vTexCoord;
   ${end('varying')}
-  varying vec4 vVertexColor;
+  
   void main() {
     // 카메라 변환을 적용합니다
     vec4 viewModelPosition = uModelViewMatrix * vec4(aPosition, 1.0);
     // 이 정점이 어디에 그려질지 WebGL에 알려 줍니다
     gl_Position = uProjectionMatrix * viewModelPosition;
   ${begin('assign')}
-    vVertexColor = aVertexColor;
+    vTexCoord = aTexCoord;
   ${end('assign')}
   }
 `}>


### PR DESCRIPTION
Reolves #1497 

## Description
This is a follow-up PR to this PR https://github.com/processing/p5.js-website/pull/1122#pullrequestreview-4376662395 where it was mentioned that the same fix should be applied to the `ko` tutorial code as well.

## Changes
Remove references to the `vVertexColor` varying in the tutorial snippet for "Varyings: Passing data from vertex to fragment shader" and instead pass `vTexCoord` varying to the fragment shader.