### PR TITLE
fix: remove mobile dropdown font-size override

### DIFF
--- a/src/components/Dropdown/styles.module.scss
+++ b/src/components/Dropdown/styles.module.scss
@@ -122,8 +122,6 @@ button.chevron {
   padding-right: 38px;
   display: inline-block;
   width: 100%;
-  // 0.75rem font-size for mobile to fit content in smaller screens
-  font-size: 0.75rem;
 
   @media (min-width: variables.$breakpoint-tablet) {
     font-size: 1rem;


### PR DESCRIPTION
## Summary

The dropdown labels had a hardcoded `font-size: 0.75rem` on mobile, while the Search input inherited its font size from the parent. This removes the hardcoded font size so the dropdowns inherit from the parent, matching the Search input and keeping the typography consistent on mobile.
Tested on a 320×568 viewport to ensure the labels still fit without clipping or overlapping.

Before :
<img width="322" height="565" alt="image" src="https://github.com/user-attachments/assets/f886e699-d427-429b-8542-5e50e5bafbbd" />

After : 
<img width="321" height="567" alt="image" src="https://github.com/user-attachments/assets/a7eedbe7-3723-4840-899f-373bea5a8807" />

Fixes #1507
