### PR TITLE
Fix broken YAML example link in contributing libraries docs

### DIFF
--- a/docs/contributing_libraries.md
+++ b/docs/contributing_libraries.md
@@ -3,7 +3,7 @@
 p5.js welcomes libraries contributed by others! <a href="https://github.com/processing/p5.js/blob/main/contributor_docs/creating_libraries.md">Check out the libraries tutorial</a> for more specifics about how to create one. If you have created a library and would like to have it included in the list, follow the instructions below!
 
 1. Fork the repo
-2. Add a file to the <a href="/src/content/libraries/en/">`src/content/libraries/en`</a> folder named `yourLibraryName.yaml` (or consider <a href="src/content/libraries/en/p5.warp.yaml">copying an existing library</a> as a starting point)
+2. Add a file to the <a href="/src/content/libraries/en/">`src/content/libraries/en`</a> folder named `yourLibraryName.yaml` (or consider <a href="/src/content/libraries/en/p5.warp.yaml">copying an existing library</a> as a starting point)
 3. Inside it, add the following content:
    - `name`: The name of the library
    - `category`: A category that you think best fits your library. Your choices include: `drawing`, `color`, `ui`, `math`, `physics`, `algorithms`, `3d`, `ai-ml-cv`, `animation`, `shaders`, `language`, `hardware`, `sound`, `data`, `teaching`, `networking`, `export`, or `utils`.


### PR DESCRIPTION
Cherry-pick of #1467 from v1 to main.

Fixes the broken example YAML link in docs/contributing_libraries.md