### PR TITLE
fix: add missing No Results translation for es and hi

### DIFF
--- a/src/content/ui/es.yaml
+++ b/src/content/ui/es.yaml
@@ -36,6 +36,7 @@ Related Examples: Ejemplos Relacionados
 Show Code: Mostrar el código
 Donate to p5.js: Dona a p5.js
 Download p5.js: Descarga p5.js
+No Results: No se encontraron resultados para esa búsqueda.
 briefPageDescriptions:
   Reference: Encuentra explicaciones sencillas para cada pieza de código de p5.js.
   Examples: Explora las posibilidades de p5.js con ejemplos cortos.

--- a/src/content/ui/hi.yaml
+++ b/src/content/ui/hi.yaml
@@ -36,6 +36,7 @@ Related Examples: संबंधित उदाहरण
 Show Code: कोड दिखाएं
 Donate to p5.js: p5.js को दान करें
 Download p5.js: p5.js डाउनलोड करें
+No Results: इस खोज के लिए कोई परिणाम नहीं मिला।
 briefPageDescriptions:
   Reference: p5.js कोड के प्रत्येक भाग के लिए आसान व्याख्या ढूंढें।
   Examples: p5.js की संभावनाओं का पता लगाएं छोटे उदाहरणों के साथ।


### PR DESCRIPTION
Cherry-pick of #1451 from v1 to main.

Adds the missing "No Results" translation for Spanish and Hindi.

Closes #1390