### PR TITLE
docs: add zh-Hans translation for p5.nvim

### DIFF
--- a/src/content/libraries/zh-Hans/p5.nvim.yaml
+++ b/src/content/libraries/zh-Hans/p5.nvim.yaml
@@ -1,0 +1,10 @@
+name: p5.nvim
+description: 为 Neovim 中的 p5.js 草图提供更好的编辑支持
+category: utils
+sourceUrl: https://github.com/prjctimg/p5.nvim
+featuredImage: ../images/p5-nvim.png
+featuredImageAlt: p5.nvim 标志
+author:
+  name: prjctimg
+  url: https://prjctimg.me
+license: GPL-3.0


### PR DESCRIPTION
## Summary

- Add the Simplified Chinese (`zh-Hans`) translation for `p5.nvim`.
- Preserve the name, category, URLs, image, author, and license from the English source.
- Translate only the description and featured image alt text.
- Leave `package-lock.json` unchanged.

## Validation

- `npm ci`
- `npm run test -- --run` (37 tests passed)
- `npm run lint`
- `npm run check` (0 errors)
- `SKIP_BUILD_COMPRESS=1 NODE_OPTIONS=--max_old_space_size=4096 npm run build` (6,295 pages built)
- `npm run build:search`, confirming the generated `zh-Hans` search entry uses the Chinese description while the English entry remains unchanged

Addresses #1335

@lirenjie95 This is ready for review. Thank you!
