### PR TITLE
Update to use p5.js v2 convention

### DIFF
--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -102,7 +102,7 @@ tutorialCategories:
   "advanced": "Advanced Topics"
   "p5-strands": p5.strands
   criticalAI: "Critical AI"
-  "2.0": "New in p5.js 2.0"
+  "2.0": "New in p5.js v2"
 tutorialsPage:
   education-resources: Education Resources
   education-resources-snippet: "Every teaching experience has unique goals, messages, conditions, and environments. By documenting and sharing p5.js educational resources, such as workshops and classes, we aim to better connect the p5.js learner and educator communities worldwide. "


### PR DESCRIPTION
Recently we have decided to adopt "p5.js v2" as the convention to refer to versions 2.0+. No localizations have been added so far so this only updates en strings. Observe this string on the "Tutorials" page.