### PR TITLE
Fix 404 on localized library directory page

### DIFF
--- a/src/pages/[locale]/libraries/directory/index.astro
+++ b/src/pages/[locale]/libraries/directory/index.astro
@@ -1,0 +1,22 @@
+---
+import { getCollectionInLocaleWithFallbacks } from "@pages/_utils";
+import { nonDefaultSupportedLocales } from "@i18n/const";
+import LibrariesLayout from "@/src/layouts/LibrariesLayout.astro";
+
+export async function getStaticPaths() {
+  const pages = nonDefaultSupportedLocales.map(async (locale) => ({
+    params: {
+      locale,
+    },
+    props: {
+      entries: await getCollectionInLocaleWithFallbacks("libraries", locale),
+    },
+  }));
+
+  return await Promise.all(pages);
+}
+
+const { entries } = Astro.props;
+---
+
+<LibrariesLayout full title="Libraries" entries={entries} />


### PR DESCRIPTION
### Summary

The corresponding `[locale]` dynamic route file was missing for the `directory` subdirectory, this resulted in a 404 page.
Added the missing `src/pages/[locale]/libraries/directory/index.astro` localized route.

**Closes :-** #1517 

## Screen Recording

https://github.com/user-attachments/assets/038adbbd-2aa4-4849-87e9-1f3d2a361bd6



