### PR TITLE
Restore full hero image rotation for non-English locales

### DIFF
--- a/src/content/homepage/es.yaml
+++ b/src/content/homepage/es.yaml
@@ -2,8 +2,44 @@ title: p5.js
 heroText: >
   p5.js es una herramienta amigable para aprender a programar y hacer arte. Es una biblioteca de JavaScript libre y de código abierto construida por una comunidad inclusiva y solidaria. ¡p5.js da la bienvenida a artistas, diseñadores, principiantes, educadores y cualquier otra persona!
 heroImages:
+  - image: ./images/hero.webp
+    linkTarget: "https://archive.org/details/processing-community-catalog-2021"
+    altText: Lauren Lee McCarthy reading the Processing Community Catalog.
+    caption: "Lauren Lee McCarthy reading the Processing Community Catalog. Photo credit: Maximo Xtravaganza."
+  - image: ./images/p5for50plus.webp
+    linkTarget: ""
+    altText: Inhwa Yeom teaching p5.js to people aged 50+.
+    caption: "Coding Club for people aged 50+ in Korea, led by Inhwa Yeom."
+  - image: ./images/salon-2.webp
+    linkTarget: ""
+    altText: Qianqian Ye holding a mic next to a big t.v. screen that has a grid of p5.js contributor photos on it.
+    caption: "Qianqian Ye introducing 600+ p5.js contributors at p5.js Community Salon. Photo credit: Ziyuan Lin."
+  - image: ./images/ccfest2018.webp
+    linkTarget: ""
+    altText: p5.js workshop participants coding while showing their projects on screen.
+    caption: "p5.js workshop at CC Fest NYC at ITP-NYU in November 2018."
+  - image: ./images/tunapanda.webp
+    linkTarget: ""
+    altText: Students learning to code while checking a p5.js book.
+    caption: "p5.js workshop at Tunapanda Institute in Nairobi. Photo credit: Tunapanda Institute."
+  - image: ./images/contributor-conf-2019_10.webp
+    linkTarget: ""
+    altText: Person with a microphone speaking to fellow participants in front of text that reads p5.js will not add any new features except those that increase access.
+    caption: "p5.js will not add any new features except those that increase access."
+  - image: ./images/contributor-conf-2015.webp
+    linkTarget: ""
+    altText: Participants jump, smile and throw their hands in the air on a green lawn.
+    caption: "p5.js Contributors Conference 2015."
+  - image: ./images/contributor-conf-2019-17.webp
+    linkTarget: ""
+    altText: Participants sit around a table with their laptops and observe code on a screen.
+    caption: "p5.js Contributors Conference 2019."
+  - image: ./images/hello-p5-2024.png
+    linkTarget: "https://hello.p5js.org"
+    altText: Eight portrait photos of p5 contributors overlaid by the text "Hello, p5.js"
+    caption: "Find out how to get started with animation, audio, WebGL, accessibility, and contribution to p5.js in this interactive video:"
   - image: ./images/2.3.png
-    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0" 
+    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0"
     altText: An abstract image showing "p5.js 2.3" surrounded by a simulation of Conway's Game of Life
     caption: "p5.js 2.3 illustration by Dave Pagurek."
 referenceHeaderText: Explore the p5.js library reference

--- a/src/content/homepage/es.yaml
+++ b/src/content/homepage/es.yaml
@@ -38,10 +38,6 @@ heroImages:
     linkTarget: "https://hello.p5js.org"
     altText: Eight portrait photos of p5 contributors overlaid by the text "Hello, p5.js"
     caption: "Find out how to get started with animation, audio, WebGL, accessibility, and contribution to p5.js in this interactive video:"
-  - image: ./images/2.3.png
-    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0"
-    altText: An abstract image showing "p5.js 2.3" surrounded by a simulation of Conway's Game of Life
-    caption: "p5.js 2.3 illustration by Dave Pagurek."
 referenceHeaderText: Explore the p5.js library reference
 examplesHeaderText: Learn p5.js with examples
 communityHeaderText: See the p5.js community in action

--- a/src/content/homepage/hi.yaml
+++ b/src/content/homepage/hi.yaml
@@ -2,8 +2,44 @@ title: p5.js
 heroText: >
   p5.js कोड करना और कला बनाना सीखने के लिए एक अनुकूल उपकरण है। यह एक नि:शुल्क और ओपन-सोर्स जावास्क्रिप्ट लाइब्रेरी है जो एक समावेशी, पोषित समुदाय द्वारा बनाई गई है। p5.js कलाकारों, डिज़ाइनरों, नौसिखिया, शिक्षकों और किसी अन्य का भी स्वागत करता है!
 heroImages:
+  - image: ./images/hero.webp
+    linkTarget: "https://archive.org/details/processing-community-catalog-2021"
+    altText: Lauren Lee McCarthy reading the Processing Community Catalog.
+    caption: "Lauren Lee McCarthy reading the Processing Community Catalog. Photo credit: Maximo Xtravaganza."
+  - image: ./images/p5for50plus.webp
+    linkTarget: ""
+    altText: Inhwa Yeom teaching p5.js to people aged 50+.
+    caption: "Coding Club for people aged 50+ in Korea, led by Inhwa Yeom."
+  - image: ./images/salon-2.webp
+    linkTarget: ""
+    altText: Qianqian Ye holding a mic next to a big t.v. screen that has a grid of p5.js contributor photos on it.
+    caption: "Qianqian Ye introducing 600+ p5.js contributors at p5.js Community Salon. Photo credit: Ziyuan Lin."
+  - image: ./images/ccfest2018.webp
+    linkTarget: ""
+    altText: p5.js workshop participants coding while showing their projects on screen.
+    caption: "p5.js workshop at CC Fest NYC at ITP-NYU in November 2018."
+  - image: ./images/tunapanda.webp
+    linkTarget: ""
+    altText: Students learning to code while checking a p5.js book.
+    caption: "p5.js workshop at Tunapanda Institute in Nairobi. Photo credit: Tunapanda Institute."
+  - image: ./images/contributor-conf-2019_10.webp
+    linkTarget: ""
+    altText: Person with a microphone speaking to fellow participants in front of text that reads p5.js will not add any new features except those that increase access.
+    caption: "p5.js will not add any new features except those that increase access."
+  - image: ./images/contributor-conf-2015.webp
+    linkTarget: ""
+    altText: Participants jump, smile and throw their hands in the air on a green lawn.
+    caption: "p5.js Contributors Conference 2015."
+  - image: ./images/contributor-conf-2019-17.webp
+    linkTarget: ""
+    altText: Participants sit around a table with their laptops and observe code on a screen.
+    caption: "p5.js Contributors Conference 2019."
+  - image: ./images/hello-p5-2024.png
+    linkTarget: "https://hello.p5js.org"
+    altText: Eight portrait photos of p5 contributors overlaid by the text "Hello, p5.js"
+    caption: "Find out how to get started with animation, audio, WebGL, accessibility, and contribution to p5.js in this interactive video:"
   - image: ./images/2.3.png
-    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0" 
+    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0"
     altText: An abstract image showing "p5.js 2.3" surrounded by a simulation of Conway's Game of Life
     caption: "p5.js 2.3 illustration by Dave Pagurek."
 referenceHeaderText: Explore the p5.js library reference

--- a/src/content/homepage/hi.yaml
+++ b/src/content/homepage/hi.yaml
@@ -38,10 +38,6 @@ heroImages:
     linkTarget: "https://hello.p5js.org"
     altText: Eight portrait photos of p5 contributors overlaid by the text "Hello, p5.js"
     caption: "Find out how to get started with animation, audio, WebGL, accessibility, and contribution to p5.js in this interactive video:"
-  - image: ./images/2.3.png
-    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0"
-    altText: An abstract image showing "p5.js 2.3" surrounded by a simulation of Conway's Game of Life
-    caption: "p5.js 2.3 illustration by Dave Pagurek."
 referenceHeaderText: Explore the p5.js library reference
 examplesHeaderText: Learn p5.js with examples
 communityHeaderText: See the p5.js community in action

--- a/src/content/homepage/ko.yaml
+++ b/src/content/homepage/ko.yaml
@@ -2,8 +2,44 @@ title: p5.js
 heroText: >
   p5.js는 코딩을 배우고 예술을 만드는 친근한 도구입니다. 이는 포용적이고 육성적인 커뮤니티에 의해 만들어진 무료 오픈소스 자바스크립트 라이브러리입니다. p5.js는 예술가, 디자이너, 초심자, 교육자 및 여러분 모두를 환영합니다!
 heroImages:
+  - image: ./images/hero.webp
+    linkTarget: "https://archive.org/details/processing-community-catalog-2021"
+    altText: Lauren Lee McCarthy reading the Processing Community Catalog.
+    caption: "Lauren Lee McCarthy reading the Processing Community Catalog. Photo credit: Maximo Xtravaganza."
+  - image: ./images/p5for50plus.webp
+    linkTarget: ""
+    altText: Inhwa Yeom teaching p5.js to people aged 50+.
+    caption: "Coding Club for people aged 50+ in Korea, led by Inhwa Yeom."
+  - image: ./images/salon-2.webp
+    linkTarget: ""
+    altText: Qianqian Ye holding a mic next to a big t.v. screen that has a grid of p5.js contributor photos on it.
+    caption: "Qianqian Ye introducing 600+ p5.js contributors at p5.js Community Salon. Photo credit: Ziyuan Lin."
+  - image: ./images/ccfest2018.webp
+    linkTarget: ""
+    altText: p5.js workshop participants coding while showing their projects on screen.
+    caption: "p5.js workshop at CC Fest NYC at ITP-NYU in November 2018."
+  - image: ./images/tunapanda.webp
+    linkTarget: ""
+    altText: Students learning to code while checking a p5.js book.
+    caption: "p5.js workshop at Tunapanda Institute in Nairobi. Photo credit: Tunapanda Institute."
+  - image: ./images/contributor-conf-2019_10.webp
+    linkTarget: ""
+    altText: Person with a microphone speaking to fellow participants in front of text that reads p5.js will not add any new features except those that increase access.
+    caption: "p5.js will not add any new features except those that increase access."
+  - image: ./images/contributor-conf-2015.webp
+    linkTarget: ""
+    altText: Participants jump, smile and throw their hands in the air on a green lawn.
+    caption: "p5.js Contributors Conference 2015."
+  - image: ./images/contributor-conf-2019-17.webp
+    linkTarget: ""
+    altText: Participants sit around a table with their laptops and observe code on a screen.
+    caption: "p5.js Contributors Conference 2019."
+  - image: ./images/hello-p5-2024.png
+    linkTarget: "https://hello.p5js.org"
+    altText: Eight portrait photos of p5 contributors overlaid by the text "Hello, p5.js"
+    caption: "Find out how to get started with animation, audio, WebGL, accessibility, and contribution to p5.js in this interactive video:"
   - image: ./images/2.3.png
-    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0" 
+    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0"
     altText: An abstract image showing "p5.js 2.3" surrounded by a simulation of Conway's Game of Life
     caption: "p5.js 2.3 illustration by Dave Pagurek."
 referenceHeaderText: Explore the p5.js library reference

--- a/src/content/homepage/ko.yaml
+++ b/src/content/homepage/ko.yaml
@@ -38,10 +38,6 @@ heroImages:
     linkTarget: "https://hello.p5js.org"
     altText: Eight portrait photos of p5 contributors overlaid by the text "Hello, p5.js"
     caption: "Find out how to get started with animation, audio, WebGL, accessibility, and contribution to p5.js in this interactive video:"
-  - image: ./images/2.3.png
-    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0"
-    altText: An abstract image showing "p5.js 2.3" surrounded by a simulation of Conway's Game of Life
-    caption: "p5.js 2.3 illustration by Dave Pagurek."
 referenceHeaderText: Explore the p5.js library reference
 examplesHeaderText: Learn p5.js with examples
 communityHeaderText: See the p5.js community in action

--- a/src/content/homepage/zh-Hans.yaml
+++ b/src/content/homepage/zh-Hans.yaml
@@ -38,10 +38,6 @@ heroImages:
     linkTarget: "https://hello.p5js.org"
     altText: Eight portrait photos of p5 contributors overlaid by the text "Hello, p5.js"
     caption: "Find out how to get started with animation, audio, WebGL, accessibility, and contribution to p5.js in this interactive video:"
-  - image: ./images/2.3.png
-    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0"
-    altText: An abstract image showing "p5.js 2.3" surrounded by a simulation of Conway's Game of Life
-    caption: "p5.js 2.3 illustration by Dave Pagurek."
 referenceHeaderText: Explore the p5.js library reference
 examplesHeaderText: Learn p5.js with examples
 communityHeaderText: See the p5.js community in action

--- a/src/content/homepage/zh-Hans.yaml
+++ b/src/content/homepage/zh-Hans.yaml
@@ -2,8 +2,44 @@ title: p5.js
 heroText: >
   p5.js 是一款旨在帮助人们学习编程并进行艺术创作的友好工具。作为一个免费的开源 JavaScript 库，它由一个充满包容和关怀的社区共同打造。无论是艺术家、设计师、初学者、教育者，还是其他任何人，p5.js 都欢迎你的加入！
 heroImages:
+  - image: ./images/hero.webp
+    linkTarget: "https://archive.org/details/processing-community-catalog-2021"
+    altText: Lauren Lee McCarthy reading the Processing Community Catalog.
+    caption: "Lauren Lee McCarthy reading the Processing Community Catalog. Photo credit: Maximo Xtravaganza."
+  - image: ./images/p5for50plus.webp
+    linkTarget: ""
+    altText: Inhwa Yeom teaching p5.js to people aged 50+.
+    caption: "Coding Club for people aged 50+ in Korea, led by Inhwa Yeom."
+  - image: ./images/salon-2.webp
+    linkTarget: ""
+    altText: Qianqian Ye holding a mic next to a big t.v. screen that has a grid of p5.js contributor photos on it.
+    caption: "Qianqian Ye introducing 600+ p5.js contributors at p5.js Community Salon. Photo credit: Ziyuan Lin."
+  - image: ./images/ccfest2018.webp
+    linkTarget: ""
+    altText: p5.js workshop participants coding while showing their projects on screen.
+    caption: "p5.js workshop at CC Fest NYC at ITP-NYU in November 2018."
+  - image: ./images/tunapanda.webp
+    linkTarget: ""
+    altText: Students learning to code while checking a p5.js book.
+    caption: "p5.js workshop at Tunapanda Institute in Nairobi. Photo credit: Tunapanda Institute."
+  - image: ./images/contributor-conf-2019_10.webp
+    linkTarget: ""
+    altText: Person with a microphone speaking to fellow participants in front of text that reads p5.js will not add any new features except those that increase access.
+    caption: "p5.js will not add any new features except those that increase access."
+  - image: ./images/contributor-conf-2015.webp
+    linkTarget: ""
+    altText: Participants jump, smile and throw their hands in the air on a green lawn.
+    caption: "p5.js Contributors Conference 2015."
+  - image: ./images/contributor-conf-2019-17.webp
+    linkTarget: ""
+    altText: Participants sit around a table with their laptops and observe code on a screen.
+    caption: "p5.js Contributors Conference 2019."
+  - image: ./images/hello-p5-2024.png
+    linkTarget: "https://hello.p5js.org"
+    altText: Eight portrait photos of p5 contributors overlaid by the text "Hello, p5.js"
+    caption: "Find out how to get started with animation, audio, WebGL, accessibility, and contribution to p5.js in this interactive video:"
   - image: ./images/2.3.png
-    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0" 
+    linkTarget: "https://github.com/processing/p5.js/releases/tag/v2.3.0"
     altText: An abstract image showing "p5.js 2.3" surrounded by a simulation of Conway's Game of Life
     caption: "p5.js 2.3 illustration by Dave Pagurek."
 referenceHeaderText: Explore the p5.js library reference


### PR DESCRIPTION
Resolves #1524

The homepage hero images rotate randomly, but that only happens when there's more than one image in the list for that locale. en.yaml has all 9 community photos, but es, hi, ko, and zh-Hans got cut down to just one image a while back when the beta site was pointing at a specific version release, and nobody added the rest back after that. So those locales have just been stuck on one static image since.

This puts the same 9 photos back in all four locale files, and keeps the current version image in there too instead of removing it.

Captions for these photos have never been translated into other languages, even going back through older versions of the site, so I just left them in English like they already were.
