### PR TITLE
feat: add underline to links within text

### DIFF
--- a/src/components/EducationResource/index.astro
+++ b/src/components/EducationResource/index.astro
@@ -25,7 +25,9 @@ const authorHTML = (await Astro.slots.render("author")).replace(/\<p[^\>]*\>/gm,
       <div set:html={authorHTML} />
       <slot name="description" />
     </div>
-    <div class="text-sm leading-8 [&_a]:whitespace-nowrap [&_a]:rounded-full [&_a]:mr-1 [&_a]:py-1 [&_a]:px-2 [&_a]:outline [&_a]:outline-1 [&_a]:outline-[var(--type-magenta-dark)]">
+    <!-- Materials render as outlined pills, so opt them out of the underline
+         that .rendered-markdown links get -->
+    <div class="text-sm leading-8 [&_a]:whitespace-nowrap [&_a]:rounded-full [&_a]:mr-1 [&_a]:py-1 [&_a]:px-2 [&_a]:outline [&_a]:outline-1 [&_a]:outline-[var(--type-magenta-dark)] [&_a]:!no-underline">
       <slot name="materials" />
     </div>
   </div>

--- a/src/components/EducationResource/index.astro
+++ b/src/components/EducationResource/index.astro
@@ -25,9 +25,11 @@ const authorHTML = (await Astro.slots.render("author")).replace(/\<p[^\>]*\>/gm,
       <div set:html={authorHTML} />
       <slot name="description" />
     </div>
-    <!-- Materials render as outlined pills, so opt them out of the underline
-         that .rendered-markdown links get -->
-    <div class="text-sm leading-8 [&_a]:whitespace-nowrap [&_a]:rounded-full [&_a]:mr-1 [&_a]:py-1 [&_a]:px-2 [&_a]:outline [&_a]:outline-1 [&_a]:outline-[var(--type-magenta-dark)] [&_a]:!no-underline">
+    <!-- Materials render as outlined pills, so drop the persistent underline
+         that .rendered-markdown links get, but keep the hover underline. The
+         !important is needed to beat .rendered-markdown, and would otherwise
+         kill :hover too -- hence the second utility. -->
+    <div class="text-sm leading-8 [&_a]:whitespace-nowrap [&_a]:rounded-full [&_a]:mr-1 [&_a]:py-1 [&_a]:px-2 [&_a]:outline [&_a]:outline-1 [&_a]:outline-[var(--type-magenta-dark)] [&_a]:!no-underline [&_a]:hover:!underline">
       <slot name="materials" />
     </div>
   </div>

--- a/src/components/EducationResource/index.astro
+++ b/src/components/EducationResource/index.astro
@@ -29,7 +29,7 @@ const authorHTML = (await Astro.slots.render("author")).replace(/\<p[^\>]*\>/gm,
          that .rendered-markdown links get, but keep the hover underline. The
          !important is needed to beat .rendered-markdown, and would otherwise
          kill :hover too -- hence the second utility. -->
-    <div class="text-sm leading-8 [&_a]:whitespace-nowrap [&_a]:rounded-full [&_a]:mr-1 [&_a]:py-1 [&_a]:px-2 [&_a]:outline [&_a]:outline-1 [&_a]:outline-[var(--type-magenta-dark)] [&_a]:!no-underline [&_a]:hover:!underline">
+    <div class="text-sm leading-8 [&_a]:whitespace-nowrap [&_a]:rounded-full [&_a]:mr-1 [&_a]:py-1 [&_a]:px-2 [&_a]:outline-1 [&_a]:outline-(--type-magenta-dark) [&_a]:no-underline! [&_a]:hover:underline!">
       <slot name="materials" />
     </div>
   </div>

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -84,7 +84,7 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
     >
   </section>
 
-  <section>
+  <section class="text-link">
     <h2 id="contact">{t("Contact")}</h2>
     <div
       class="text-2xl grid grid-cols-6 lg:grid-cols-9 gap-x-gutter-sm md:gap-x-gutter-md mt-xl"
@@ -106,7 +106,7 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
       </div>
     </div>
   </section>
-  <section>
+  <section class="text-link">
     <h2 id="supporters">Supporters</h2>
     <ul class="text-2xl mt-xl">
       <li>
@@ -123,7 +123,7 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
       <li><a href="https://www.usebutter.com/">Butter</a></li>
     </ul>
   </section>
-  <section>
+  <section class="text-link">
     <h2 id="processing-foundation">The Processing Ecosystem</h2>
     <ul class="text-2xl mt-xl">
       <li><a href="https://processing.org">Processing</a></li>
@@ -135,11 +135,3 @@ const displayedFeaturedPeople = sortedFeaturedPeople.slice(0, 6);
     </ul>
   </section>
 </BaseLayout>
-
-<style lang="scss">
-  @reference "../../styles/global.css";
-
-  a {
-    @apply text-type-magenta-dark;
-  }
-</style>

--- a/src/layouts/ReferenceItemLayout.astro
+++ b/src/layouts/ReferenceItemLayout.astro
@@ -177,7 +177,7 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
           return (
             <div
               set:html={part}
-              class="[&_a]:text-type-magenta-dark [&_a]:!decoration-type-magenta-dark mb-xl reference-item rendered-markdown"
+              class="mb-xl reference-item rendered-markdown"
             />
           );
         }
@@ -326,7 +326,7 @@ function normalizeP5ReferenceLinks(html: string | undefined): string | undefined
       {
         entry.data.file && entry.data.line &&(
           <div class="my-xl">
-           <div class="text-body [&_a]:text-type-magenta-dark [&_a]:!decoration-type-magenta-dark my-lg">
+           <div class="text-body text-link my-lg">
             Notice any errors or typos? <a href={`https://github.com/${githubRepo}/issues`}>Please let us know</a>. Please feel free to edit
             <a
                 href={`https://github.com/${githubRepo}/blob/${githubRef}/${entry.data.file}#L${entry.data.line}`}

--- a/src/layouts/SketchLayout.astro
+++ b/src/layouts/SketchLayout.astro
@@ -114,13 +114,9 @@ const iframeTitle = `OpenProcessing Sketch: ${title} by ${authorName}`;
 
     {instructions && <p class="text-md my-sm md:my-lg">{instructions}</p>}
 
-    <p class="text-xs md:text-base mb-3xl">
-      This <a class="text-type-magenta" href={makeSketchLinkUrl(sketchIdNumber)}
-        >sketch</a
-      > is ported from the <a
-        class="text-type-magenta"
-        href="https://openprocessing.org">OpenProcessing</a
-      >
+    <p class="text-xs md:text-base mb-3xl text-link">
+      This <a href={makeSketchLinkUrl(sketchIdNumber)}>sketch</a> is ported from
+      the <a href="https://openprocessing.org">OpenProcessing</a>
       sketch archive.
     </p>
   </div>

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -201,6 +201,23 @@ a {
   }
 }
 
+// Single source of truth for links styled as text rather than as a button.
+// The color and the underline live together here so the two can't drift apart.
+// Put .text-link on a link itself, or on any container to style every link
+// inside it. Markdown-generated content gets the treatment automatically.
+a.text-link:not(.button-link),
+.text-link a:not(.button-link),
+.rendered-markdown a:not(.button-link) {
+  color: var(--type-magenta-dark);
+  text-decoration: underline;
+  text-decoration-color: var(--type-magenta-dark);
+
+  .dark-theme & {
+    color: var(--type-magenta);
+    text-decoration-color: var(--type-magenta);
+  }
+}
+
 code {
   @extend .text-body-mono;
   font-size: inherit;

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -18,8 +18,9 @@
     max-width: variables.$breakpoint-tablet;
   }
 
-  a {
+  a:not(.button-link) {
     color: var(--type-magenta-dark);
+    text-decoration: underline;
     text-decoration-color: var(--type-magenta-dark);
 
     .dark-theme & {

--- a/styles/markdown.scss
+++ b/styles/markdown.scss
@@ -18,17 +18,6 @@
     max-width: variables.$breakpoint-tablet;
   }
 
-  a:not(.button-link) {
-    color: var(--type-magenta-dark);
-    text-decoration: underline;
-    text-decoration-color: var(--type-magenta-dark);
-
-    .dark-theme & {
-      color: var(--type-magenta);
-      text-decoration-color: var(--type-magenta);
-    }
-  }
-
   a.button-link {
     margin-top: var(--spacing-md);
     min-width: 180px;


### PR DESCRIPTION
To address: https://github.com/processing/p5.js-website/issues/1505 .

### Summary

- `styles/markdown.scss`: add persistent `text-decoration: underline` to prose links inside `.rendered-markdown`, scoped as `a:not(.button-link)` so styled button links are excluded.
