### PR TITLE
fix: reinstate reference page filter with search by title and desc

### DIFF
--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -1,4 +1,6 @@
 import type { ReferenceDocContentItem } from "@/src/content/types";
+import { useMemo, useRef, useState } from "preact/hooks";
+import { Icon } from "../Icon";
 import flask from "@src/content/ui/images/icons/flask.svg?raw";
 import warning from "@src/content/ui/images/icons/warning.svg?raw";
 
@@ -10,7 +12,15 @@ type ReferenceDirectoryEntry = ReferenceDocContentItem & {
   };
 };
 
-type ReferenceDirectoryProps = {
+type FilteredCategoryData = {
+  name: string;
+  subcats: {
+    name: string;
+    entries: ReferenceDirectoryEntry[];
+  }[];
+};
+
+type ReferenceDirectoryWithFilterProps = {
   categoryData: {
     name: string;
     subcats: {
@@ -19,6 +29,7 @@ type ReferenceDirectoryProps = {
       entries: ReferenceDirectoryEntry[];
     }[];
   }[];
+  uiTranslations: { [key: string]: string };
 };
 
 /**
@@ -50,7 +61,67 @@ const getOneLineDescription = (description: string): string => {
 
 export const ReferenceDirectoryWithFilter = ({
   categoryData,
-}: ReferenceDirectoryProps) => {
+  uiTranslations,
+}: ReferenceDirectoryWithFilterProps) => {
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filteredEntries = useMemo(() => {
+    if (!searchKeyword) return categoryData;
+
+    const lowerKeyword = searchKeyword.toLowerCase();
+
+    return categoryData.reduce((acc: FilteredCategoryData[], category) => {
+      // If the category name matches, include the whole category
+      if (category.name?.toLowerCase().includes(lowerKeyword)) {
+        acc.push(category);
+        return acc;
+      }
+
+      const filteredSubcats = category.subcats.reduce(
+        (subAcc: typeof category.subcats, subcat) => {
+          // If the subcategory name matches, include all its entries
+          if (subcat.name?.toLowerCase().includes(lowerKeyword)) {
+            subAcc.push(subcat);
+            return subAcc;
+          }
+
+          const matchingEntries = subcat.entries.filter((entry) => {
+            const titleMatch = entry.data.title
+              .toLowerCase()
+              .includes(lowerKeyword);
+            const shortDescription = getOneLineDescription(
+              entry.data.description ?? "",
+            )
+              .replace(/<[^>]*>/g, "")
+              .toLowerCase();
+            const descriptionMatch = shortDescription.includes(lowerKeyword);
+            return titleMatch || descriptionMatch;
+          });
+          if (
+            subcat.entry &&
+            subcat.entry.data.title
+              .toLowerCase()
+              .includes(lowerKeyword)
+          ) {
+            matchingEntries.push(subcat.entry);
+          }
+
+          if (matchingEntries.length > 0) {
+            subAcc.push({ ...subcat, entries: matchingEntries });
+          }
+          return subAcc;
+        },
+        [],
+      );
+
+      if (filteredSubcats.length > 0) {
+        acc.push({ ...category, subcats: filteredSubcats });
+      }
+      return acc;
+    }, []);
+  }, [categoryData, searchKeyword]);
+
   const renderEntries = (entries: ReferenceDirectoryEntry[]) =>
     entries.length === 0 ? null : (
       <div class="content-grid">
@@ -121,7 +192,10 @@ export const ReferenceDirectoryWithFilter = ({
   };
 
   const renderCategoryData = () => {
-    return categoryData.map((category) => (
+    if (filteredEntries.length === 0) {
+      return <div class="mt-lg">{uiTranslations["No Results"]}</div>;
+    }
+    return filteredEntries.map((category) => (
       <section key={category.name}>
         <h2
           class={
@@ -143,9 +217,45 @@ export const ReferenceDirectoryWithFilter = ({
     ));
   };
 
+  const clearInput = () => {
+    if (inputRef.current) {
+      inputRef.current.value = "";
+      setSearchKeyword("");
+    }
+  };
+
   return (
-    <div class="-top-[75px] mx-5 min-h-[50vh] md:mx-lg">
-      {renderCategoryData()}
+    <div>
+      <div class="h-0 overflow-visible">
+        <div class="content-grid-simple absolute -left-0 -right-0 -top-[60px] h-[75px] border-b border-sidebar-type-color bg-accent-color px-5 pb-lg md:px-lg ">
+          <div class="text-body col-span-2 flex w-full max-w-[750px] border-b border-accent-type-color text-accent-type-color">
+            <input
+              type="text"
+              id="search"
+              ref={inputRef}
+              class="w-full bg-transparent py-xs text-accent-type-color placeholder:text-accent-type-color focus:outline-0"
+              placeholder={uiTranslations["Filter"]}
+              onKeyUp={(e) => {
+                const target = e.target as HTMLInputElement;
+                setSearchKeyword(target?.value);
+              }}
+            />
+            {searchKeyword.length > 0 && (
+              <button
+                type="reset"
+                class=""
+                onClick={clearInput}
+                aria-label="Clear search input"
+              >
+                <Icon kind="close" className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+      <div class="-top-[75px] mx-5 min-h-[50vh] md:mx-lg">
+        {renderCategoryData()}
+      </div>
     </div>
   );
 };

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -59,6 +59,127 @@ const getOneLineDescription = (description: string): string => {
   return oneLineDescription ?? "";
 };
 
+// Trim, lowercase, and strip surrounding punctuation so "sin." matches sin()
+export const normalizeKeyword = (keyword: string): string =>
+  keyword.trim().toLowerCase().replace(/^\W+|\W+$/g, "");
+
+type MatchMode = "strict" | "loose";
+
+// Bare name for exact comparison: drop HTML and the trailing "()" of methods
+const canonicalName = (name: string | undefined | null): string =>
+  (name ?? "")
+    .replace(/<[^>]*>/g, "")
+    .replace(/\(\)$/, "")
+    .trim()
+    .toLowerCase();
+
+// strict: name must equal the keyword (so "sin" != "asin")
+// loose: keyword may appear anywhere ("typog" -> "Typography")
+const nameMatches = (
+  name: string | undefined | null,
+  keyword: string,
+  mode: MatchMode,
+): boolean => {
+  if (!name) return false;
+  if (mode === "strict") return canonicalName(name) === keyword;
+  return name.replace(/<[^>]*>/g, "").toLowerCase().includes(keyword);
+};
+
+// Whole-word match: "sin" hits "the sin of an angle" but not "using"/"single"
+const wordMatches = (text: string, keyword: string): boolean => {
+  if (!text || !keyword) return false;
+  return text
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .some((token) => token === keyword);
+};
+
+// strict: whole-word description match; loose: substring match
+const descriptionMatches = (
+  description: string | undefined | null,
+  keyword: string,
+  mode: MatchMode,
+): boolean => {
+  const text = getOneLineDescription(description ?? "").replace(
+    /<[^>]*>/g,
+    "",
+  );
+  if (!text) return false;
+  if (mode === "strict") return wordMatches(text, keyword);
+  return text.toLowerCase().includes(keyword);
+};
+
+const entryMatchesKeyword = (
+  entry: ReferenceDirectoryEntry,
+  keyword: string,
+  mode: MatchMode,
+): boolean =>
+  nameMatches(entry.data.title, keyword, mode) ||
+  descriptionMatches(entry.data.description, keyword, mode);
+
+// Walk the tree once at a fixed strictness: a category/subcategory name match
+// pulls in the whole section, otherwise entries match by title or description.
+const filterTree = (
+  categoryData: ReferenceDirectoryWithFilterProps["categoryData"],
+  keyword: string,
+  mode: MatchMode,
+): FilteredCategoryData[] =>
+  categoryData.reduce((acc: FilteredCategoryData[], category) => {
+    // If the category name matches, include the whole category.
+    if (nameMatches(category.name, keyword, mode)) {
+      acc.push(category);
+      return acc;
+    }
+
+    const filteredSubcats = category.subcats.reduce(
+      (subAcc: typeof category.subcats, subcat) => {
+        // If the subcategory name matches, include all its entries.
+        if (nameMatches(subcat.name, keyword, mode)) {
+          subAcc.push(subcat);
+          return subAcc;
+        }
+
+        const matchingEntries = subcat.entries.filter((entry) =>
+          entryMatchesKeyword(entry, keyword, mode),
+        );
+
+        // A subcategory that represents a class (e.g. p5.Vector) carries its
+        // own entry; match it too.
+        if (subcat.entry && entryMatchesKeyword(subcat.entry, keyword, mode)) {
+          matchingEntries.push(subcat.entry);
+        }
+
+        if (matchingEntries.length > 0) {
+          subAcc.push({ ...subcat, entries: matchingEntries });
+        }
+        return subAcc;
+      },
+      [],
+    );
+
+    if (filteredSubcats.length > 0) {
+      acc.push({ ...category, subcats: filteredSubcats });
+    }
+    return acc;
+  }, []);
+
+// Two passes: prefer exact-name / whole-word matches, and only fall back to
+// substring matching when nothing precise is found. This keeps partial hits
+// like "using"/"since"/"single"/"asin" out of a "sin" search, while still
+// letting prefixes like "typog" or "circ" work when there's no exact match.
+export const filterCategoryData = (
+  categoryData: ReferenceDirectoryWithFilterProps["categoryData"],
+  rawKeyword: string,
+): FilteredCategoryData[] => {
+  const keyword = normalizeKeyword(rawKeyword);
+  if (!keyword) return categoryData;
+
+  const strictMatches = filterTree(categoryData, keyword, "strict");
+  return strictMatches.length > 0
+    ? strictMatches
+    : filterTree(categoryData, keyword, "loose");
+};
+
 export const ReferenceDirectoryWithFilter = ({
   categoryData,
   uiTranslations,
@@ -66,61 +187,10 @@ export const ReferenceDirectoryWithFilter = ({
   const [searchKeyword, setSearchKeyword] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const filteredEntries = useMemo(() => {
-    if (!searchKeyword) return categoryData;
-
-    const lowerKeyword = searchKeyword.toLowerCase();
-
-    return categoryData.reduce((acc: FilteredCategoryData[], category) => {
-      // If the category name matches, include the whole category
-      if (category.name?.toLowerCase().includes(lowerKeyword)) {
-        acc.push(category);
-        return acc;
-      }
-
-      const filteredSubcats = category.subcats.reduce(
-        (subAcc: typeof category.subcats, subcat) => {
-          // If the subcategory name matches, include all its entries
-          if (subcat.name?.toLowerCase().includes(lowerKeyword)) {
-            subAcc.push(subcat);
-            return subAcc;
-          }
-
-          const matchingEntries = subcat.entries.filter((entry) => {
-            const titleMatch = entry.data.title
-              .toLowerCase()
-              .includes(lowerKeyword);
-            const shortDescription = getOneLineDescription(
-              entry.data.description ?? "",
-            )
-              .replace(/<[^>]*>/g, "")
-              .toLowerCase();
-            const descriptionMatch = shortDescription.includes(lowerKeyword);
-            return titleMatch || descriptionMatch;
-          });
-          if (
-            subcat.entry &&
-            subcat.entry.data.title
-              .toLowerCase()
-              .includes(lowerKeyword)
-          ) {
-            matchingEntries.push(subcat.entry);
-          }
-
-          if (matchingEntries.length > 0) {
-            subAcc.push({ ...subcat, entries: matchingEntries });
-          }
-          return subAcc;
-        },
-        [],
-      );
-
-      if (filteredSubcats.length > 0) {
-        acc.push({ ...category, subcats: filteredSubcats });
-      }
-      return acc;
-    }, []);
-  }, [categoryData, searchKeyword]);
+  const filteredEntries = useMemo(
+    () => filterCategoryData(categoryData, searchKeyword),
+    [categoryData, searchKeyword],
+  );
 
   const renderEntries = (entries: ReferenceDirectoryEntry[]) =>
     entries.length === 0 ? null : (

--- a/src/components/ReferenceDirectoryWithFilter/index.tsx
+++ b/src/components/ReferenceDirectoryWithFilter/index.tsx
@@ -234,7 +234,7 @@ export const ReferenceDirectoryWithFilter = ({
               id="search"
               ref={inputRef}
               class="w-full bg-transparent py-xs text-accent-type-color placeholder:text-accent-type-color focus:outline-0"
-              placeholder={uiTranslations["Filter"]}
+              placeholder={uiTranslations["Filter by keyword"]}
               onKeyUp={(e) => {
                 const target = e.target as HTMLInputElement;
                 setSearchKeyword(target?.value);

--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -11,6 +11,7 @@ Donate: Donate
 Download: Download
 Accessibility: Accessibility
 Search: Search
+Filter: Filter
 Jump To: Jump to
 Resources: Resources
 Information: Information

--- a/src/content/ui/en.yaml
+++ b/src/content/ui/en.yaml
@@ -11,7 +11,7 @@ Donate: Donate
 Download: Download
 Accessibility: Accessibility
 Search: Search
-Filter: Filter
+Filter by keyword: Filter by keyword
 Jump To: Jump to
 Resources: Resources
 Information: Information

--- a/src/content/ui/es.yaml
+++ b/src/content/ui/es.yaml
@@ -10,6 +10,7 @@ Donate: Donar
 Download: Descargar
 Accessibility: Accesibilidad
 Search: Buscar
+Filter by keyword: Filtrar por palabra clave
 Jump To: Saltar a
 Resources: Recursos
 Information: Información

--- a/src/content/ui/hi.yaml
+++ b/src/content/ui/hi.yaml
@@ -10,6 +10,7 @@ Donate: दान
 Download: डाउनलोड
 Accessibility: अभिगम्यता
 Search: खोजें
+Filter by keyword: कीवर्ड द्वारा फ़िल्टर करें
 Jump To: इस पर जाएं
 Resources: संसाधन
 Information: जानकारी

--- a/src/content/ui/ko.yaml
+++ b/src/content/ui/ko.yaml
@@ -13,6 +13,7 @@ Donate: 기부
 Download: 다운로드
 Accessibility: 접근성
 Search: 검색
+Filter by keyword: 키워드로 필터링
 Jump To: 이동
 Resources: 자료
 Information: 정보

--- a/src/content/ui/zh-Hans.yaml
+++ b/src/content/ui/zh-Hans.yaml
@@ -11,6 +11,7 @@ Donate: 捐赠
 Download: 下载
 Accessibility: 无障碍
 Search: 搜索
+Filter by keyword: 按关键字筛选
 Jump To: 跳转到
 Resources: 资源
 Information: 信息

--- a/src/layouts/ReferenceLayout.astro
+++ b/src/layouts/ReferenceLayout.astro
@@ -14,6 +14,7 @@ import {
 } from "../globals/state";
 import {
   getCurrentLocale,
+  getUiTranslationWithFallback,
   getUiTranslator,
 } from "../i18n/utils";
 
@@ -35,6 +36,7 @@ function strCompare(a: string, b: string) {
 
 const currentLocale = getCurrentLocale(Astro.url.pathname);
 const t = await getUiTranslator(currentLocale);
+const uiTranslations = await getUiTranslationWithFallback(currentLocale);
 
 const { entries } = Astro.props;
 
@@ -153,6 +155,8 @@ const pageJumpToState: JumpToState = {
 
 <BaseLayout title={Astro.props.title} mainContentParentClass="mx-0" jumpToState={pageJumpToState}>
   <ReferenceDirectoryWithFilter
+    client:load
     categoryData={categoryData as any}
+    uiTranslations={uiTranslations}
   />
 </BaseLayout>

--- a/test/components/ReferenceDirectoryWithFilter.test.tsx
+++ b/test/components/ReferenceDirectoryWithFilter.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterCategoryData,
+  normalizeKeyword,
+} from "@components/ReferenceDirectoryWithFilter";
+
+// Method titles are stored as name + "()", e.g. "circle()"
+const makeEntry = (title: string, description: string) =>
+  ({
+    id: title,
+    slug: title,
+    data: {
+      title,
+      description,
+      path: title.replace(/\(\)$/, ""),
+    },
+  }) as any;
+
+// "using", "single" and "since" all contain "sin" but must not match "sin"
+const categoryData: any = [
+  {
+    name: "Math",
+    subcats: [
+      {
+        name: "Trigonometry",
+        entry: undefined,
+        entries: [
+          makeEntry("sin()", "<p>Calculates the sine of an angle.</p>"),
+          makeEntry("asin()", "<p>Calculates the arc sine of a value.</p>"),
+          makeEntry("cos()", "<p>Calculates the cosine of an angle.</p>"),
+          makeEntry(
+            "angleMode()",
+            "<p>Sets whether sin and cos use degrees or radians.</p>",
+          ),
+        ],
+      },
+      {
+        name: "Calculation",
+        entry: undefined,
+        entries: [
+          makeEntry(
+            "map()",
+            "<p>Re-maps a number using a single input range.</p>",
+          ),
+          makeEntry(
+            "constrain()",
+            "<p>Constrains a value computed since the last frame.</p>",
+          ),
+        ],
+      },
+    ],
+  },
+  {
+    name: "Typography",
+    subcats: [
+      {
+        name: "Loading & Displaying",
+        entry: undefined,
+        entries: [
+          makeEntry("text()", "<p>Draws text to the canvas.</p>"),
+          makeEntry("textFont()", "<p>Sets the font used to draw text.</p>"),
+        ],
+      },
+    ],
+  },
+  {
+    name: "Shape",
+    subcats: [
+      {
+        name: "2D Primitives",
+        entry: undefined,
+        entries: [
+          makeEntry("circle()", "<p>Draws a circle to the canvas.</p>"),
+          makeEntry("rect()", "<p>Draws a rectangle to the canvas.</p>"),
+        ],
+      },
+    ],
+  },
+];
+
+// Flatten surviving entry titles (including a class subcat's own entry)
+const titlesOf = (result: any[]): string[] => {
+  const titles: string[] = [];
+  for (const category of result) {
+    for (const subcat of category.subcats) {
+      if (subcat.entry) titles.push(subcat.entry.data.title);
+      for (const entry of subcat.entries) titles.push(entry.data.title);
+    }
+  }
+  return titles;
+};
+
+describe("normalizeKeyword", () => {
+  it("trims, lowercases and strips surrounding punctuation", () => {
+    expect(normalizeKeyword("  Circle ")).toBe("circle");
+    expect(normalizeKeyword("SIN")).toBe("sin");
+    // A trailing period (the maintainer's "sin." test) resolves to "sin".
+    expect(normalizeKeyword("sin.")).toBe("sin");
+    expect(normalizeKeyword("2D Primitives")).toBe("2d primitives");
+  });
+
+  it("returns an empty string when nothing usable remains", () => {
+    expect(normalizeKeyword("")).toBe("");
+    expect(normalizeKeyword("   ")).toBe("");
+    expect(normalizeKeyword("...")).toBe("");
+  });
+});
+
+describe("filterCategoryData", () => {
+  it("returns the whole tree when the keyword is empty", () => {
+    expect(filterCategoryData(categoryData, "")).toBe(categoryData);
+    expect(filterCategoryData(categoryData, "   ")).toBe(categoryData);
+  });
+
+  it("returns no results for a keyword that matches nothing", () => {
+    expect(filterCategoryData(categoryData, "xyzzy")).toEqual([]);
+  });
+
+  it('finds a function by its exact name ("circle" -> circle())', () => {
+    const titles = titlesOf(filterCategoryData(categoryData, "circle"));
+    expect(titles).toContain("circle()");
+    expect(titles).not.toContain("rect()");
+  });
+
+  it("matches function names case-insensitively", () => {
+    expect(titlesOf(filterCategoryData(categoryData, "CIRCLE"))).toContain(
+      "circle()",
+    );
+  });
+
+  it('supports partial/prefix name searches as a fallback ("circ" -> circle())', () => {
+    const titles = titlesOf(filterCategoryData(categoryData, "circ"));
+    expect(titles).toContain("circle()");
+  });
+
+  it('shows a whole section for a category-name search ("typog" -> Typography)', () => {
+    const result = filterCategoryData(categoryData, "typog");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Typography");
+    expect(titlesOf(result)).toEqual(["text()", "textFont()"]);
+  });
+
+  it('shows a whole subcategory for a subcategory-name search ("2D Primitives")', () => {
+    const result = filterCategoryData(categoryData, "2D Primitives");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Shape");
+    expect(titlesOf(result)).toEqual(["circle()", "rect()"]);
+  });
+
+  it("matches a whole word in a description", () => {
+    // "single" is a whole word in map()'s description.
+    expect(titlesOf(filterCategoryData(categoryData, "single"))).toContain(
+      "map()",
+    );
+  });
+
+  it('excludes partial substrings for "sin" (no "using"/"since"/"single"/"asin")', () => {
+    const titles = titlesOf(filterCategoryData(categoryData, "sin"));
+    // Included: exact function name + whole-word description match.
+    expect(titles).toContain("sin()");
+    expect(titles).toContain("angleMode()");
+    // Excluded: "sin" only appears as a partial substring of these.
+    expect(titles).not.toContain("asin()"); // "asin" contains "sin"
+    expect(titles).not.toContain("map()"); // "using", "single"
+    expect(titles).not.toContain("constrain()"); // "since"
+    expect(titles).not.toContain("cos()"); // "sine" != "sin"
+    expect(titles).toEqual(["sin()", "angleMode()"]);
+  });
+
+  it('treats "sin." the same as "sin"', () => {
+    expect(titlesOf(filterCategoryData(categoryData, "sin."))).toEqual([
+      "sin()",
+      "angleMode()",
+    ]);
+  });
+
+  it('treats "SIN" the same as "sin" (case-insensitive)', () => {
+    expect(titlesOf(filterCategoryData(categoryData, "SIN"))).toEqual([
+      "sin()",
+      "angleMode()",
+    ]);
+  });
+
+  it('an exact function name wins over partial substrings ("asin" -> asin() only)', () => {
+    const titles = titlesOf(filterCategoryData(categoryData, "asin"));
+    expect(titles).toEqual(["asin()"]);
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/processing/p5.js-website/issues/1401
applies https://github.com/processing/p5.js-website/pull/1465 to `main`