### PR TITLE
Remove link from compatibility add-on mention

### DIFF
--- a/src/content/tutorials/en/v2_transition.mdx
+++ b/src/content/tutorials/en/v2_transition.mdx
@@ -43,7 +43,7 @@ Most of the time, you and your students can use p5.js v2 without changing anythi
 However, if you open an older sketch (for example, something a student created in a previous year or an example from a curriculum designed for p5.js v1), and it doesn’t behave quite the same, you have options:
 
 * You can **update the sketch** using the examples in this guide
-* You can **turn on a [compatibility add-on](https://docs.google.com/document/d/1Dk5nqLYL_ryw_7xjADhgPHOi5N6xkC9v_FM2vOz_Hc8/edit?tab=t.ocxorofdcw24)**
+* You can **turn on a compatibility add-on**
 * You can **switch the sketch back to p5.js v1** in the Editor
 
 ![Screenshot of the p5.js Web Editor version picker showing a list of versions.](../images/2.0/v2-libman.png)


### PR DESCRIPTION
During https://github.com/processing/p5.js-website/issues/1526 @eupthere noticed a link that was not accessible. This should actually link to the correct heading but heading permalinks are TBA https://github.com/processing/p5.js-website/issues/1398