### PR TITLE
fix: include descriptions for reference entries in search index

### DIFF
--- a/src/scripts/builders/search.ts
+++ b/src/scripts/builders/search.ts
@@ -256,6 +256,7 @@ export const generateSearchIndex = async (
         if (!data.description) {
           continue;
         }
+        description = data.description;
         break;
       case "libraries":
         title = data.name;


### PR DESCRIPTION
This PR fixes an issue where reference entries in the generated search index were missing their `description` field. While the builder verified that a description existed, it never assigned it before creating the search index entry, causing the field to be omitted from the generated JSON and preventing reference descriptions from being indexed for search.

fixes #1537 