### PR TITLE
Change p5 version branch from 'dev-2.0' to 'stable'

### DIFF
--- a/src/scripts/p5-version.ts
+++ b/src/scripts/p5-version.ts
@@ -14,7 +14,7 @@ export const p5SoundVersion = "0.2.0" as const;\n`;
 const run = async () => {
   console.log("Reading latest p5 version to update config...");
 
-  await cloneLibraryRepo(clonedRepoPath, p5RepoUrl, "dev-2.0");
+  await cloneLibraryRepo(clonedRepoPath, p5RepoUrl, "stable");
 
   // read version from package.json
   const packageConfigContents = await readFile(


### PR DESCRIPTION
We're working on setting up a branch for small patch releases ([stable](https://github.com/processing/p5.js/tree/stable)) so this should refer to that. The PR also addresses [this build failure](https://github.com/processing/p5.js/actions/runs/30574360004/job/90978779959)