### PR TITLE
test: add regression test for reference descriptions

### DIFF
--- a/test/scripts/build-search.test.ts
+++ b/test/scripts/build-search.test.ts
@@ -80,3 +80,20 @@ describe("Search Index Event Description Generation", () => {
     expect(eventEntry?.description).not.toContain("undefined");
   });
 });
+
+describe("Search Index Reference Description Generation", () => {
+  test("includes the expected description in reference search index entries", async () => {
+    mockedGetContentFilePaths.mockResolvedValue([
+      "src/content/reference/en/p5/mouseX.mdx",
+    ]);
+
+    const result = await generateSearchIndex("reference", "en");
+
+    expect(result).toBeDefined();
+    expect(result?.["mouseX"]).toBeDefined();
+    expect(result?.["mouseX"].description).toContain(
+      "A <code>Number</code> system variable that tracks the mouse's horizontal position.",
+    );
+  });
+});
+


### PR DESCRIPTION
This PR adds a regression test for the recently fixed issue where reference entries in the generated search index omitted their `description` field.
The test verifies that reference entries include their expected description in the generated search index, helping prevent similar regressions in the future.

Follow-up to #1539.