### PR TITLE
Update `websiteUrl` for c2.js

### DIFF
--- a/src/content/libraries/en/c2.js.yaml
+++ b/src/content/libraries/en/c2.js.yaml
@@ -5,7 +5,7 @@ author:
   name: Ren Yuan
   url: https://renyuan.io
 sourceUrl: https://github.com/ren-yuan/c2.js
-websiteUrl: https://c2js.org
+websiteUrl: https://renyuan.io/c2-js/
 npm: c2.js
 npmFilePath: dist/c2.min.js
 featuredImage: ../images/c2.js.png


### PR DESCRIPTION
Previous link was no longer working. The new link is the one currently declared on the GitHub repo.