### PR TITLE
fix: anchor Start Coding/Donate buttons to sidebar bottom when Jump To nav is collapsed

### DIFF
--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -87,9 +87,14 @@
 
     &:global(.open),
     &:global(.noJumpTo) {
-      grid-template-rows: min-content 2fr;
+      grid-template-rows: min-content 1fr min-content;
       min-height: 350px;
-      height: 100%;
+      height: auto;
+      max-height: none;
+    }
+
+    &:global(.noJumpTo) {
+      flex-grow: 1;
     }
   }
 
@@ -125,6 +130,12 @@
         display: none;
       }
     }
+  }
+}
+
+@media (min-width: variables.$breakpoint-tablet) {
+  .container:has(.jumpto:not(:global(.open))) .mainlinks:global(.open) {
+    flex-grow: 1;
   }
 }
 
@@ -176,11 +187,13 @@
 
   @media (min-width: variables.$breakpoint-tablet) {
     height: fit-content;
+    flex-grow: 0;
     border-top-width: 1px;
-    margin-top: auto;
 
     &:global(.open) {
-      height: 100%;
+      height: auto;
+      min-height: 0;
+      flex-grow: 1;
       overflow-y: scroll;
     }
 
@@ -270,7 +283,8 @@
   height: unset;
 
   @media (min-width: variables.$breakpoint-tablet) {
-    height: 100%;
+    height: auto;
+    min-height: 0;
     overflow-y: scroll;
 
     ul {
@@ -287,4 +301,3 @@
 .jumpto ul li.linklabel:not(:global(.small), :first-child) {
   margin-top: 10px;
 }
-


### PR DESCRIPTION
Resolves #1434

### Problem

On pages that have both the Primary nav and the Secondary ("Jump To") nav
(e.g. **Reference**, Tutorials, Contribute, Community, contributor-doc pages),
collapsing the **Jump To** (secondary) nav left the **Start Coding** and
**Donate** buttons stuck in the middle of the side panel. They should drop to
the bottom of the primary nav — the way they already do on the **Homepage**.


### Changes

All changes are in `src/components/Nav/styles.module.scss` and scoped to the
`breakpoint-tablet` media query (mobile is untouched).  Drive side-nav heights with **flexbox**:

### Resulting behavior (tablet+)

- **Homepage (no Jump To):** `.mainlinks.noJumpTo` fills the viewport; buttons sit at the bottom. ✅
- **Both navs open (desktop default):** primary nav stays compact; Jump To fills the remainder and scrolls. ✅
- **Jump To collapsed (the bug):** primary nav now fills the sidebar; **buttons drop to the bottom**, matching the homepage. ✅

### Screenshots

<img width="1413" height="882" alt="image" src="https://github.com/user-attachments/assets/b8556c90-6f11-4f66-833a-0ba7fb8a804d" />

<img width="1424" height="885" alt="image" src="https://github.com/user-attachments/assets/ace0e04e-26df-4c99-a1e2-168d7d285f65" />

### Testing

- [x] `npm run lint`
- [x] Manual: open a **Reference** page at desktop width → collapse the Jump To nav → confirm **Start Coding** and **Donate** sit at the bottom of the sidebar
- [x] Manual: Reference page, Jump To **open** → primary nav stays compact, Jump To fills/scrolls (no regression)
- [x] Manual: **Homepage** → buttons at the bottom (no regression)