### PR TITLE
fix(mobile): prevent margin-top misalignment in Jump to links on mobile

### DIFF
--- a/src/components/Nav/styles.module.scss
+++ b/src/components/Nav/styles.module.scss
@@ -299,5 +299,7 @@
 }
 
 .jumpto ul li.linklabel:not(:global(.small), :first-child) {
-  margin-top: 10px;
+  @media (min-width: variables.$breakpoint-tablet) {
+    margin-top: 10px;
+  }
 }


### PR DESCRIPTION
## Description

On mobile, the Jump to links section in the reference pages uses a two-column grid layout. The rule `.jumpto ul li.linklabel:not(:global(.small), :first-child) { margin-top: 10px; }` was causing second-column items to be pushed down, creating visual misalignment.

## Fix

Wrapped the `margin-top: 10px` rule in a desktop-only media query (`@media (min-width: variables.$breakpoint-tablet)`) so it only applies on tablet+ screens where the `inline-block` layout needs vertical spacing. On mobile, the grid layout handles spacing automatically.

## Before/After

See screenshots in the issue: #1554

Fixes #1554