### PR TITLE
fix: escape HTML in reference pages to prevent <canvas/> rendering as element

### DIFF
--- a/src/content/reference/en/p5.Graphics/remove.mdx
+++ b/src/content/reference/en/p5.Graphics/remove.mdx
@@ -8,7 +8,7 @@ description: >
 
   <p>Calling <code>myGraphics.remove()</code> removes the graphics buffer's
 
-  <code><canvas/></code> element from the web page. The graphics buffer also
+  <code>&lt;canvas/&gt;</code> element from the web page. The graphics buffer also
   uses
 
   a bit of memory on the CPU that can be freed like so:</p>

--- a/src/content/reference/en/p5/drawingContext.mdx
+++ b/src/content/reference/en/p5/drawingContext.mdx
@@ -6,9 +6,9 @@ file: src/core/rendering.js
 description: >
   <p>A system variable that provides direct access to the sketch's
 
-  <code><canvas/></code> element.</p>
+  <code>&lt;canvas/&gt;</code> element.</p>
 
-  <p>The <code><canvas/></code> element provides many specialized features that
+  <p>The <code>&lt;canvas/&gt;</code> element provides many specialized features that
   aren't
 
   included in the p5.js library. The <code>drawingContext</code> system variable

--- a/src/content/reference/en/p5/p5.Graphics.mdx
+++ b/src/content/reference/en/p5/p5.Graphics.mdx
@@ -124,7 +124,7 @@ methods:
 
       <p>Calling <code>myGraphics.remove()</code> removes the graphics buffer's
 
-      <code><canvas/></code> element from the web page. The graphics buffer also
+      <code>&lt;canvas/&gt;</code> element from the web page. The graphics buffer also
       uses
 
       a bit of memory on the CPU that can be freed like so:</p>


### PR DESCRIPTION
Fixes #1389

## Problem
The `<canvas/>` tag in reference page descriptions was being rendered as an actual HTML canvas element instead of being displayed as escaped code text.

## Root cause
Three reference pages contained `<code><canvas/></code>` in their YAML frontmatter `description` fields. The static site generator renders this HTML directly, causing the `<canvas/>` self-closing tag to create a real canvas element on the page.

## Fix
Escaped the angle brackets: `<code>&lt;canvas/&gt;</code>` so the browser displays the text as intended.

## Files changed
- `src/content/reference/en/p5.Graphics/remove.mdx`
- `src/content/reference/en/p5/drawingContext.mdx`
- `src/content/reference/en/p5/p5.Graphics.mdx`