### PR TITLE
feat: setup local a11y playwright test for homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ public/p5.min.js
 # optional local preferences for vscode
 local.code-workspace
 .zed
+
+# Playwright accessibility test output
+test-results/
+playwright-report/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,10 +16,15 @@ if (shouldSkipCompress) {
   console.log("WILL SKIP COMPRESS BUILD STEP");
 }
 
+const isA11yTest = Boolean(process.env.A11Y_TEST);
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://p5js.org',
   compressHTML: false,
+  devToolbar: {
+    enabled: !isA11yTest,
+  },
   integrations: [
     mermaid({autoTheme: true}),
     preact({

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "vitest": "^4.1.7"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@codemirror/lang-javascript": "^6.2.2",
         "@playwright/test": "^1.54.1",
         "@preact/preset-vite": "^2.10.5",
@@ -368,6 +369,19 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7426,6 +7440,16 @@
       "optional": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy": "wrangler deploy --env beta",
     "astro": "astro",
     "test": "vitest",
+    "test:a11y": "playwright test",
     "build:contributor-docs": "tsx ./src/scripts/builders/contribute.ts",
     "build:contributors": "tsx ./src/scripts/builders/people.ts",
     "build:reference": "tsx ./src/scripts/builders/reference.ts",
@@ -59,6 +60,7 @@
     "vite": "^7"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@codemirror/lang-javascript": "^6.2.2",
     "@playwright/test": "^1.54.1",
     "@preact/preset-vite": "^2.10.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 4321;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./test/a11y",
+  testMatch: "**/*.spec.ts",
+  outputDir: "./test-results",
+  fullyParallel: true,
+  reporter: [
+    ["list"],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }]
+  ],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+
+  // One engine, two viewports. axe-core inspects the DOM and computed styles,
+  // which agree across engines, so a browser matrix mostly re-runs the same
+  // assertions; a responsive layout can ship genuinely different markup per
+  // breakpoint, so that is the axis worth covering.
+  projects: [
+    {
+      name: "desktop",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "mobile",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+
+  webServer: {
+    command: "npm run dev",
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 180_000,
+    env: {
+      A11Y_TEST: "1",
+    },
+  },
+});

--- a/test/a11y/homepage.spec.ts
+++ b/test/a11y/homepage.spec.ts
@@ -1,0 +1,12 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("a11y-home-page", () => {
+  test("should not have any automatically detectable accessibility issues", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,7 +21,8 @@ export default getViteConfig({
           exclude: [
             "test/api/OpenProcessing.test.ts",
             "test/pages/*",
-            "test/mocks/*"
+            "test/mocks/*",
+            "test/a11y/**"
           ]
         }
       },


### PR DESCRIPTION
Hi everyone,

This PR picks back up on the automated accessibility testing work originally discussed in https://github.com/processing/p5.js-website/issues/827.

Earlier in https://github.com/processing/p5.js-website/pull/933, we put together initial playwright and axe-core settings and tests, but it looks like those changes didn't make it onto the current main branch. This PR re-introduces that foundation with just enough lightweight configuration to get the tests running smoothly on local environments again.

### What's Included
* Restored Dependencies: Re-adds playwright and axe-core baseline setups.
* Core Tests: Restores the initial batch of accessibility test suites (on EN homepage).
* Local Workflow: Re-establishes local test execution support so anyone can run quick local checks.

### Next Steps (Following PRs)
* Triage and fix any new accessibility issues identified by the automated scans.
* Will work on integrating automated scans directly into PR CI pipeline to catch potential regressions early.
* Expand test coverage across more pages and localized versions.

Feedback and suggestions are welcome! Thanks!