### PR TITLE
fix: remove broken link to non-existent FES performance test

### DIFF
--- a/src/content/contributor-docs/en/fes_contribution_guide.mdx
+++ b/src/content/contributor-docs/en/fes_contribution_guide.mdx
@@ -459,7 +459,7 @@ The functionality described under `fesErrorMonitor()` currently only works on th
 
 ### Performance Issue with the FES
 
-By default, FES is enabled for p5.js and disabled in `p5.min.js` to prevent FES functions from slowing down the process. The error-checking system can significantly slow down your code (up to \~10x in some cases). See the [Friendly Error performance test](https://github.com/processing/p5.js-website/tree/main/src/assets/learn/performance/code/friendly-error-system).
+By default, FES is enabled for p5.js and disabled in `p5.min.js` to prevent FES functions from slowing down the process. The error-checking system can significantly slow down your code (up to \~10x in some cases).
 
 You can disable the FES with one line of code at the top of your sketch:
 


### PR DESCRIPTION
## Description

Remove the broken link to the "Friendly Error performance test" in the FES contribution guide. The linked path (`src/assets/learn/performance/code/friendly-error-system`) no longer exists and returns 404.

## Fix

The link in `src/content/contributor-docs/en/fes_contribution_guide.mdx` pointed to a non-existent directory. Since the referenced content has been removed or moved, the broken link is removed while preserving the documentation of FES performance impact.

Fixes #1578