### PR TITLE
ES Traduction of Transition Guide for Educators

### DIFF
--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -3,7 +3,7 @@ title: "Guía para profesores sobre p5.js v2"
 description: Una guía para educadores de secundaria y preparatoria sobre la transición desde versiones anteriores a la versión 2 de p5.js.
 category: "2.0"
 featuredImage: ../images/featured/v2-transition.gif
-featuredImageAlt: Diagrama animado de los cambios en la API entre la versión 1 y la versión 2 o p5.js
+featuredImageAlt: Diagrama animado de los cambios en la API entre la versión 1 y la versión 2 de p5.js
 relatedContent:
   references:
     - en/p5/mousebutton

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -96,7 +96,7 @@ if (keyIsPressed) {
 }
 ```
 
-A menudo `keyIsPressed` es enseñado inicialmente como una variable simple de tipo booleano y `key ===` encaja con la estructura de comparación que los estudiantes ya están usando.
+A menudo `keyIsPressed` se enseñá inicialmente como una variable simple de tipo booleano y `key ===` encaja con la estructura de comparación que los estudiantes ya están usando.
 
 En la versión 2 de p5.js, la manera recomendada de verificar por teclas es:
 

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -42,48 +42,47 @@ La mayoría del tiempo, tus estudiantes y tú pueden usar la versión 2 de p5.js
 Sin embargo, si abres un sketch viejo (por ejemplo, algo que un estudiante creó en años anteriores o un ejemplo desde un curriculum diseñado para la versión 1 de p5.js), y su comportamiento no es el mismo, tienes estas opciones:
 
 * **Actualizar el sketch** usando el ejemplo de esta guía
-* You can **update the sketch** using the examples in this guide
 * Activar el **complemento de compatibilidad** 
 * Volver al sketch para la versión 1 de p5.js en el Editor Web 
 
 ![Pantallazo de la selección de veriones de p5.js en el Editor Web.](../images/2.0/v2-libman.png)
 
 
-## Input Events
+## Eventos de Input
 
-Input events are likely to be the first place you notice differences in p5.js v2. Students may use input events to: 
+Es probable que los eventos de Input sean el primer lugar donde notes diferencias en la versión 2 de p5.js. Los estudiantes pueden usar eventos de input para:
 
-* Select or toggle buttons 
-* Draw with the mouse while pressed
-* Change variables when a key is pressed 
-* Clear or save the canvas
-* Moving a game character with arrow keys
+* Seleccionar o alternar botones
+* Dibujar con el ratón mientras se mantiene pulsado
+* Cambiar variables al pulsar una tecla
+* Borrar o guardar el lienzo
+* Mover un personaje de un juego con las teclas de flecha
 
 This section covers the input event code you’re most likely to see in MS/HS classrooms and the changes introduced in p5.js v2.
+Esta sección abarca el código de eventos de input que probablemente verás en las aulas de secundaria o preparatoria y los cambios introducidos en la versión 2 de p5.js.
+
+### Clicks del Mouse
 
 
-### Mouse Clicks
-
-
-In p5.js v1, checking for a specific mouse button looked like this: 
+En la versión 1 de p5.js, verificar por un botón específico del mouse se veía así:
 
 ```js
 if (mouseButton === RIGHT) {
-  // do a thing (p5.js v1)
+  // haz algo (p5.js v1)
 }
 ```
 
-In p5.js v2, it looks like this:
+En la versión 2 de p5.js se ve así:
 
 ```js
 if (mouseButton.right) {
-  // do a thing (p5.js v2)
+  // haz algo (p5.js v2)
 }
 ```
 
-**Reference:** [mouseButton](/reference/p5/mouseButton/)
+**Referencia:** [mouseButton](/reference/p5/mouseButton/)
 
-<Callout title="Teacher Note">
+<Callout title="Nota del profesor">
 In v2, mouseButton is now an object with boolean properties (left, right, center). This makes it possible to detect multiple buttons at once. This is especially helpful for drawing apps or paint tools, where students may want different behaviors for different mouse buttons.
 </Callout>
 

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -24,29 +24,29 @@ Siendo educador de secundaria, entiendo que una nueva versión de una herramient
 
 Si te sientes aprehensivo de la transición a la version 2 de p5.js, esta guía es para tranquilizarte. La mayoría de lo que hacen sus estudiantes funciona exactamente igual a como era antes.
 
-After reviewing multiple middle school and high school p5.js curricula ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) just two areas consistently require updates when moving from p5.js v1 to v2: 
+Después de revisar multiples curriculum de escuelas secundarias y escuelas de preparatoria ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) solamente dos áreas requieren actualizarse al ir de p5.js v1 hacia v2.
 
+* Eventos de Input
+* Carga de Assets
 
-* Input Events
-* Asset Loading
+Aunque existe [otras actualizaciones en v2](https://github.com/processing/p5.js-compatibility) (así como cambios a formas curvas, medición de texto, y funciones utilitarias), éstas no aparecen generalmente en los curriculum de escuelas secundarias y escuelas preparatorias, y son poco probables de que impaces en el tu trabajo con estudiantes. 
 
-Although there are [other v2 updates](https://github.com/processing/p5.js-compatibility) (such as changes to curved shapes, text measurement, and utility functions), these do not typically appear in middle school or high school curricula and are unlikely to impact your work with students. 
+Está guía te explica los cambios más comunes que encontrarás en un aula de secuandaria o preparatoria. Aprenderás como actualizar tu código para la versión 2 de p5.js, y cuándo los complementos de compatibilidad puedan ser útiles para sketches antiguos. 
 
-This guide walks you through just the changes you’re likely to encounter in a Middle School (MS) or High School (HS) classroom. You’ll learn how to update your code for p5.js v2, and when compatibility add-ons might be helpful for older sketches.
+He tratado de incluir solo que necesitas y nada más, para que puedas ponerte al día fácilmente y estar seguro de enseñar con la versión 2 de p5.js. 
 
-I’ve tried to include everything you need and nothing you don’t, so you can get up to speed easily and feel confident teaching with p5.js v2.
+## Versiones en el Editor Web
 
-## Versions in the Web Editor
+La mayoría del tiempo, tus estudiantes y tú pueden usar la versión 2 de p5.js sin hacer cambios.
 
-Most of the time, you and your students can use p5.js v2 without changing anything.
+Sin embargo, si abres un sketch viejo (por ejemplo, algo que un estudiante creó en años anteriores o un ejemplo desde un curriculum diseñado para la versión 1 de p5.js), y su comportamiento no es el mismo, tienes estas opciones:
 
-However, if you open an older sketch (for example, something a student created in a previous year or an example from a curriculum designed for p5.js v1), and it doesn’t behave quite the same, you have options:
-
+* **Actualizar el sketch** usando el ejemplo de esta guía
 * You can **update the sketch** using the examples in this guide
-* You can **turn on a compatibility add-on**
-* You can **switch the sketch back to p5.js v1** in the Editor
+* Activar el **complemento de compatibilidad** 
+* Volver al sketch para la versión 1 de p5.js en el Editor Web 
 
-![Screenshot of the p5.js Web Editor version picker showing a list of versions.](../images/2.0/v2-libman.png)
+![Pantallazo de la selección de veriones de p5.js en el Editor Web.](../images/2.0/v2-libman.png)
 
 
 ## Input Events

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -23,7 +23,7 @@ Siendo profesor de secundaria, entiendo que una nueva versión de una herramient
 
 Si sientes cierta incomodidad sobre lo que implica la transición hacia la versión 2 de p5.js, esta guía va a servir para que puedas entender las diferencias con mayor tranquilidad. La mayoría de las acciones que tus estudiantes realizan funcionan de la misma manera que en versiones anteriores.
 
-Después de revisar múltiples curriculums de escuelas secundarias y escuelas de preparatoria ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) solamente dos áreas requieren actualizarse al ir de p5.js v1 hacia v2.
+Después de revisar múltiples programas de escuelas secundarias y escuelas preparatorias ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) solamente dos áreas requieren actualizarse al ir de p5.js v1 hacia v2.
 
 * Eventos de Input
 * Carga de Recursos

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -58,7 +58,6 @@ Es probable que los eventos de Input sean el primer lugar donde notes diferencia
 * Borrar o guardar el lienzo
 * Mover un personaje de un juego con las teclas de flecha
 
-This section covers the input event code you’re most likely to see in MS/HS classrooms and the changes introduced in p5.js v2.
 Esta sección abarca el código de eventos de input que probablemente verás en las aulas de secundaria o preparatoria y los cambios introducidos en la versión 2 de p5.js.
 
 ### Clicks del Mouse
@@ -188,7 +187,7 @@ Referencia
 </table>
 
 
-### Complementos de compatibilidad (Opcional)
+### Complementos de Compatibilidad (Opcional)
 
 Para la nueva enseñanza, sigue el código de versión 2 que se muestra arriba. 
 
@@ -242,7 +241,7 @@ async function setup() {
 
 
 
-### Asset Loading Quick Reference
+### Referencia Rápida de Carda de Recursos
 
 
 
@@ -297,36 +296,36 @@ async function setup() {
 </table>
 
 
-**Reference:** [async_await](https://beta.p5js.org/reference/p5/async_await/)
+**Referencia:** [async_await](https://beta.p5js.org/reference/p5/async_await/)
 
 
 
-### Compatibility Add-Ons (Optional)
+### Complementos de Compatibilidad (Opcional)
 
-For new teaching, follow the v2 code above.
+Para la nueva enseñanza, sigue el código de versión 2 que se muestra arriba. 
 
-If you have older sketches that you want to keep working without updating the code, the **Preload** compatibility add-on restores the v1 behavior. 
+Si tienes sketches antiguos que quieres seguir usando sin actualizar el código, el complemento de compatibilidad **Preload** restaura el comportamiento de la versión 1.
 
-See *Compatibility Add-Ons* section below for more detail. 
+Consula la sección *Complementos de compatibilidad* a continuación para obtener más detalles.
 
-## Compatibility Add-Ons
+## Complementos de Compatibilidad
 
-Compatibility add‑ons are optional helper files you can turn on in the p5.js Web Editor to make older p5.js v1 sketches behave the same way in p5.js v2, without updating the code.
+Los complementos de compatibilidad son archivos axiliares opcionales que puedes activar en el editor de p5.js para que los sketches antiguos de la versión 1 de p5.js se comporten de la misma manera en la versión 2 de p5.js, sin actualizar el código. 
 
-These add-ons are only needed if you or your students open older sketches from online or older curriculum materials that use the p5.js v1 patterns and you aren’t ready to update the code to the v2 patterns yet.
+Éstos complementos son necesarios si tú o tus estudiantes abren sketches antiguos desde la web o de material didáctico que usen partrones de la versión 1 de p5.js y aún no estás listo para actualizar el código a la versión 2 de p5.js.
 
-For new teaching, it’s better to use the v2 ways of writing code so students learn the version that will be supported going forward.
+Para la nueva enseñanza, es mejor usar la sintaxtis de la versión 2 para escribir código, de esta manera los estudiantes aprender con la versión que tendrá soporte en adelante. 
 
-* For Input Events, use the **Data & Events** Compatibility Add-On.
-* For Asset Loading, use the **Preload** Compatibility Add-On. 
-
-
-![A screenshot of the library management tab in the p5.js Editor, where a user can toggle add-on libraries for 1.x compatibility.](../images/2.0/v2-addons.png)
-
-*You will also see a **Shapes** Compatibility Add-On - the Shapes API changes only affect more advanced custom shapes that do not commonly appear in MS/HS curricula, so most MS/HS teachers won’t need the Shapes Compatibility Add-On.*
+* Para Eventos de Inputs, usa los Complementos de Compatibilidad **Datos y Eventos**
+* Para Carga de Recursos, usa los Complementos de Compatibilidad **Preload**
 
 
-## Teacher Quick Reference
+![Captura de pantalla de la pestaña de administración de librerías en el Editor p5.js, donde el usuario puede activar o desactivar librerías complementarias compatibles con las versiones 1.x ](../images/2.0/v2-addons.png)
+
+*También verás un Complemento de Compatibilidad para **Formas** - los cambios en la API de Formas afecta solamente a formas personalizadas más avanzadas que no suelen aparecer en el curriculum de secundaria y preparatoria, así que la mayoría de estos educadores no necesitarán este complemento de compatibilidad*
+
+
+## Referencia Rápida para Educadores
 
 
 
@@ -348,13 +347,13 @@ p5.js v2
 
 <th>
 
-Reference
+Referencia
 
 </th>
 
 <tr>
 <th colspan="3">
-Input Events
+Eventos de Input
 </th>
 </tr>
 
@@ -409,7 +408,7 @@ Input Events
 
 <tr>
 <th colspan="3">
-Asset Loading
+Carga de Recursos
 </th>
 </tr>
 
@@ -456,7 +455,7 @@ async function setup() {
 
 
 
-<Callout title="Teacher Note">
-This quick reference includes only the p5.js v2 changes that commonly affect MS & HS curricula (input events and asset loading). Other v2 updates (such as changes to curved shapes, text measurement, and utility functions) do not appear in the reviewed curricula. For the full list of v2 changes, see the [Technical Transition Guide](https://github.com/processing/p5.js-compatibility). 
+<Callout title="Note de Educador">
+Esta referencia rápida incluye solamente los cambios en la versión 2 de p5.js que a menudo afectan al curriculum de secundaria y preparatoria (eventos de input y carga de recursos). Otras actualizaciones de la versión 2 (como cambios en formas curvas, medición de texto, y funciones de utilidad) no aparecen en el curriculum revisado. Para ver la lista completa de cambios en la versión 2, consulta la [Guía Técnica de Transición](https://github.com/processing/p5.js-compatibility). 
 </Callout>
 

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -21,7 +21,7 @@ import Callout from "../../../components/Callout/index.astro";
 
 Siendo profesor de secundaria, entiendo que una nueva versión de una herramienta en la que confías se puede sentir como un gran ajuste, sobre todo cuando tienes una serie de clases y actividades que conoces y disfrutas.
 
-Si te sientes aprehensivo de la transición a la versión 2 de p5.js, esta guía es para tranquilizarte. La mayoría de lo que hacen tus estudiantes funciona exactamente igual a como era antes.
+Si sientes cierta incomodidad sobre lo que implica la transición hacia la versión 2 de p5.js, esta guía va a servir para que puedas entender las diferencias con mayor tranquilidad. La mayoría de las acciones que tus estudiantes realizan funcionan de la misma manera que en versiones anteriores.
 
 Después de revisar múltiples curriculums de escuelas secundarias y escuelas de preparatoria ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) solamente dos áreas requieren actualizarse al ir de p5.js v1 hacia v2.
 

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -19,7 +19,7 @@ import Callout from "../../../components/Callout/index.astro";
 
 ## p5.js v2 Guía de Transición para Educadores de Secundaria y Preparatoria
 
-Siendo educador de secundaria, entiendo que una nueva versión de una herramienta en la que confías se puede sentir como un gran ajuste, sobre todo cuando tienes una serie de clases y actividades que manejas y quieres.
+Siendo profesor de secundaria, entiendo que una nueva versión de una herramienta en la que confías se puede sentir como un gran ajuste, sobre todo cuando tienes una serie de clases y actividades que conoces y disfrutas.
 
 Si te sientes aprehensivo de la transición a la versión 2 de p5.js, esta guía es para tranquilizarte. La mayoría de lo que hacen tus estudiantes funciona exactamente igual a como era antes.
 

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -62,29 +62,28 @@ Input events are likely to be the first place you notice differences in p5.js v2
 This section covers the input event code you’re most likely to see in MS/HS classrooms and the changes introduced in p5.js v2.
 
 
-### Mouse Clicks
+### Clicks de Mouse 
 
-
-In p5.js v1, checking for a specific mouse button looked like this: 
+En la versión 1 de p5.js, verificar por un botón específico del mouse se veía así:
 
 ```js
 if (mouseButton === RIGHT) {
-  // do a thing (p5.js v1)
+  // haz algo (p5.js v1)
 }
 ```
 
-In p5.js v2, it looks like this:
+En la versión 2 de p5.js, se ve así:
 
 ```js
 if (mouseButton.right) {
-  // do a thing (p5.js v2)
+  // haz algo (p5.js v2)
 }
 ```
 
-**Reference:** [mouseButton](/reference/p5/mouseButton/)
+**Referencia:** [mouseButton](/reference/p5/mouseButton/)
 
-<Callout title="Teacher Note">
-In v2, mouseButton is now an object with boolean properties (left, right, center). This makes it possible to detect multiple buttons at once. This is especially helpful for drawing apps or paint tools, where students may want different behaviors for different mouse buttons.
+<Callout title="Nota de profesor">
+En v2, mouseButton es ahora un objeto con propiedades booleanas (izquierda, derecha, centro). Esto hace posible detectar multiples botones de una vez. Esto es especialmente útil para aplicaciones de dibujo o herramientas para pintar, donde tus estudiantes quieran diferentes comportamientos para los diferentes botones del mouse.
 </Callout>
 
 ### Keyboard Input

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -134,7 +134,7 @@ p5.js v2
 
 <th>
 
-Reference
+Referencia
 
 </th>
 
@@ -188,31 +188,31 @@ Reference
 </table>
 
 
-### Compatibility Add-On (Optional)
+### Complementos de compatibilidad (Opcional)
 
-For new teaching, follow the v2 code shown above.
+Para la nueva enseñanza, sigue el código de versión 2 que se muestra arriba. 
 
-If you have older sketches that you want to keep working without updating the code, the **Data & Events** compatibility add-on restores the v1 behavior. 
+Si tienes sketches antiguos que quieres seguir usando sin actualizar el código, el complemento de compatibilidad **Datos y Eventos** restaura el comportamiento de la versión 1.
 
-See *Compatibility Add-Ons* section below for more detail. 
+Consula la sección *Complementos de compatibilidad* a continuación para obtener más detalles.
 
 
-## Loading Assets
+## Carga de Recursos
 
-As students advance in the curriculum, they may want to personalize their sketches by adding images, sounds, fonts, or other assets. 
+A medida que los estudiantes avanzan en el curriculum, podrían querer personalizar sus sketches añadiendo imágenes, sonidos, fuentes tipográficas, u otros recursos.
 
-In p5.js v1, this was done using `preload()`.  
-In p5.js v2, we use `async` and `await` inside `setup()`. 
+En la versión 1 de p5.js, esto se hacía usando `preload()`.
+En la versión 2 de p5.js, usamos `async` y `await` dentro de `setup()`.
 
-### `preload()` in p5.js v1
+### `preload()` en p5.js v1
 
-In p5.js v1, `preload()` stopped the sketch from running until everything inside it finished loading:
+En la versión 1 de p5.js, `preload()` detenía el sketch de ejecutarse hasta que todo lo que contenía terminara de cargarse:
 
 ```js
 let img;
 
 function preload(){
-  // used in p5.js v1, but not in v2
+  // usada en p5.js v1, pero no en v2
   img = loadImage("cat.jpg");
 }
 
@@ -223,9 +223,9 @@ function setup(){
 ```
 
 
-### `async` and `await` in p5.js v2
+### `async` y `await` en p5.js v2
 
-In the p5.js v2, `preload()` is no longer used, and assets are loaded using `await` inside `async setup()`.  This works for images, sounds, fonts, and other files: 
+En la versión 2 de p5.js, `preload()` ya no se usa, y los recursos son cargados usando `await` dentro de `async setup()`. Esto funciona para imágenes, sonidos, fuentes tipográficas, y otros arhivos:
 
 ```js
 let img;
@@ -233,7 +233,7 @@ let img;
 async function setup() {
   createCanvas(100, 100);
   
-  // waits for asset to load
+  // espera a que los recursos se carguen
   img = await loadImage("cat.jpg");
   
   image (img, 0, 0);

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -86,34 +86,34 @@ if (mouseButton.right) {
 En v2, mouseButton es ahora un objeto con propiedades booleanas (izquierda, derecha, centro). Esto hace posible detectar multiples botones de una vez. Esto es especialmente útil para aplicaciones de dibujo o herramientas para pintar, donde tus estudiantes quieran diferentes comportamientos para los diferentes botones del mouse.
 </Callout>
 
-### Keyboard Input
+### Entrada de Teclado
 
-In p5.js v1, most MS/HS curricula checked for keys using code like: 
+En la versión 1 de p5.js, la mayoría del curriculum de secundaria y preparatoria verificaban el uso de teclas en código como:
 
 ```js
 if (keyIsPressed) {
   if (key === UP_ARROW){
-    // do a thing (p5.js v1)
+    // haz algo (p5.js v1)
   }
 }
 ```
 
-`keyIsPressed` is often introduced early as a simple Boolean variable and `key ===` fits into the comparison structures students are already using.
+A menudo `keyIsPressed` es enseñado inicialmente como una variable simple de tipo Booleado y `key ===` encaja con la estructura de comparación que los estudiantes ya están usando.
 
-In p5.js v2, the recommended way to check for keys is:
+En la versión 2 de p5.js, la manera recomendada de ceritifcar por teclas es:
 
 ```js
 if (keyIsDown(UP_ARROW)) {
-  // do a thing (p5.js v2)
+  // has algo (p5.js v2)
 }
 ```
 
-`keyIsDown()` is now the recommended approach because it works consistently across both v1 and v2 and supports checking multiple keys at once.
+`keyIsDown()` es el acercamiento recomendado actual ya que funciona consistentemente a travez de ambas versiones v1 y v2, y soporta verificaciones de múltiples teclas a la vez.
 
 
-**Reference:** [keyIsDown](https://beta.p5js.org/reference/p5/keyIsDown/)
+**Referencia:** [keyIsDown](https://beta.p5js.org/reference/p5/keyIsDown/)
 
-### Input Events Quick Reference
+### Referencia Rápida de Eventos de Entrada
 
 
 <table>

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -1,0 +1,463 @@
+---
+title: "Teachers' Guide to p5.js v2"
+description: A guide for middle school and high school educators for transtioning to p5.js version 2 from using previous versions.
+category: "2.0"
+featuredImage: ../images/featured/v2-transition.gif
+featuredImageAlt: TODO BETTER IMAGE
+relatedContent:
+  references:
+    - en/p5/mousebutton
+    - en/p5/keyispressed
+    - en/p5/loadimage
+    - en/p5/keyisdown
+  examples:
+    - en/16_parallel_loading_promise/01_async_image_loader
+authors:
+  - Adrienne Gifford
+---
+import Callout from "../../../components/Callout/index.astro";
+
+## p5.js v2 Transition Guide for Middle School and High School Educators
+
+As a middle school teacher, I know a version update to a tool you rely on can feel like a big adjustment, especially when you already have a set of lessons and activities you know and love. 
+
+If you’re feeling some trepidation about the transition to p5.js v2, this guide is here to reassure you. Most of what your students already do works exactly the same as before.
+
+
+After reviewing multiple middle school and high school p5.js curricula ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) just two areas consistently require updates when moving from p5.js v1 to v2: 
+
+
+* Input Events
+* Asset Loading
+
+Although there are [other v2 updates](https://github.com/processing/p5.js-compatibility) (such as changes to curved shapes, text measurement, and utility functions), these do not typically appear in middle school or high school curricula and are unlikely to impact your work with students. 
+
+This guide walks you through just the changes you’re likely to encounter in a Middle School (MS) or High School (HS) classroom. You’ll learn how to update your code for p5.js v2, and when compatibility add-ons might be helpful for older sketches.
+
+I’ve tried to include everything you need and nothing you don’t, so you can get up to speed easily and feel confident teaching with p5.js v2.
+
+## Versions in the Web Editor
+
+Most of the time, you and your students can use p5.js v2 without changing anything.
+
+However, if you open an older sketch (for example, something a student created in a previous year or an example from a curriculum designed for p5.js v1), and it doesn’t behave quite the same, you have options:
+
+* You can **update the sketch** using the examples in this guide
+* You can **turn on a compatibility add-on**
+* You can **switch the sketch back to p5.js v1** in the Editor
+
+![Screenshot of the p5.js Web Editor version picker showing a list of versions.](../images/2.0/v2-libman.png)
+
+
+## Input Events
+
+Input events are likely to be the first place you notice differences in p5.js v2. Students may use input events to: 
+
+* Select or toggle buttons 
+* Draw with the mouse while pressed
+* Change variables when a key is pressed 
+* Clear or save the canvas
+* Moving a game character with arrow keys
+
+This section covers the input event code you’re most likely to see in MS/HS classrooms and the changes introduced in p5.js v2.
+
+
+### Mouse Clicks
+
+
+In p5.js v1, checking for a specific mouse button looked like this: 
+
+```js
+if (mouseButton === RIGHT) {
+  // do a thing (p5.js v1)
+}
+```
+
+In p5.js v2, it looks like this:
+
+```js
+if (mouseButton.right) {
+  // do a thing (p5.js v2)
+}
+```
+
+**Reference:** [mouseButton](/reference/p5/mouseButton/)
+
+<Callout title="Teacher Note">
+In v2, mouseButton is now an object with boolean properties (left, right, center). This makes it possible to detect multiple buttons at once. This is especially helpful for drawing apps or paint tools, where students may want different behaviors for different mouse buttons.
+</Callout>
+
+### Keyboard Input
+
+In p5.js v1, most MS/HS curricula checked for keys using code like: 
+
+```js
+if (keyIsPressed) {
+  if (key === UP_ARROW){
+    // do a thing (p5.js v1)
+  }
+}
+```
+
+`keyIsPressed` is often introduced early as a simple Boolean variable and `key ===` fits into the comparison structures students are already using.
+
+In p5.js v2, the recommended way to check for keys is:
+
+```js
+if (keyIsDown(UP_ARROW)) {
+  // do a thing (p5.js v2)
+}
+```
+
+`keyIsDown()` is now the recommended approach because it works consistently across both v1 and v2 and supports checking multiple keys at once.
+
+
+**Reference:** [keyIsDown](https://beta.p5js.org/reference/p5/keyIsDown/)
+
+### Input Events Quick Reference
+
+
+<table>
+
+<tr>
+
+<th>
+
+p5.js v1
+
+</th>
+
+<th>
+
+p5.js v2
+
+</th>
+
+<th>
+
+Reference
+
+</th>
+
+</tr>
+
+<tr>
+
+<td>
+
+`mouseButton === RIGHT`
+
+
+</td>
+
+<td>
+
+`mouseButton.right`
+
+</td>
+
+<td>
+
+[mouseButton](https://beta.p5js.org/reference/p5/mouseButton/)
+
+</td>
+
+</tr>
+
+<tr>
+
+<td>
+
+`keyIsPressed` <br /> `key === UP_ARROW`
+
+</td>
+
+<td>
+
+`keyIsDown(UP_ARROW)`
+
+</td>
+
+<td>
+
+[keyIsDown](https://beta.p5js.org/reference/p5/keyIsDown/)
+
+</td>
+
+</tr>
+
+</table>
+
+
+### Compatibility Add-On (Optional)
+
+For new teaching, follow the v2 code shown above.
+
+If you have older sketches that you want to keep working without updating the code, the **Data & Events** compatibility add-on restores the v1 behavior. 
+
+See *Compatibility Add-Ons* section below for more detail. 
+
+
+## Loading Assets
+
+As students advance in the curriculum, they may want to personalize their sketches by adding images, sounds, fonts, or other assets. 
+
+In p5.js v1, this was done using `preload()`.  
+In p5.js v2, we use `async` and `await` inside `setup()`. 
+
+### `preload()` in p5.js v1
+
+In p5.js v1, `preload()` stopped the sketch from running until everything inside it finished loading:
+
+```js
+let img;
+
+function preload(){
+  // used in p5.js v1, but not in v2
+  img = loadImage("cat.jpg");
+}
+
+function setup(){
+  createCanvas(100, 100);
+  image(img, 0, 0);
+}
+```
+
+
+### `async` and `await` in p5.js v2
+
+In the p5.js v2, `preload()` is no longer used, and assets are loaded using `await` inside `async setup()`.  This works for images, sounds, fonts, and other files: 
+
+```js
+let img;
+
+async function setup() {
+  createCanvas(100, 100);
+  
+  // waits for asset to load
+  img = await loadImage("cat.jpg");
+  
+  image (img, 0, 0);
+}
+```
+
+
+
+### Asset Loading Quick Reference
+
+
+
+<table>
+
+<tr>
+
+<th>
+
+p5.js v1
+
+</th>
+
+<th>
+
+p5.js v2
+
+</th>
+
+
+</tr>
+
+<tr>
+
+<td>
+
+```js
+function preload(){   
+  img = loadImage(
+    "cat.jpg"
+  );
+}
+```
+
+</td>
+
+<td>
+
+```js
+async function setup() {
+  createCanvas(100, 100);
+  img = await loadImage(
+    "cat.jpg"
+  ); 
+}
+```
+
+</td>
+
+
+</tr>
+</table>
+
+
+**Reference:** [async_await](https://beta.p5js.org/reference/p5/async_await/)
+
+
+
+### Compatibility Add-Ons (Optional)
+
+For new teaching, follow the v2 code above.
+
+If you have older sketches that you want to keep working without updating the code, the **Preload** compatibility add-on restores the v1 behavior. 
+
+See *Compatibility Add-Ons* section below for more detail. 
+
+## Compatibility Add-Ons
+
+Compatibility add‑ons are optional helper files you can turn on in the p5.js Web Editor to make older p5.js v1 sketches behave the same way in p5.js v2, without updating the code.
+
+These add-ons are only needed if you or your students open older sketches from online or older curriculum materials that use the p5.js v1 patterns and you aren’t ready to update the code to the v2 patterns yet.
+
+For new teaching, it’s better to use the v2 ways of writing code so students learn the version that will be supported going forward.
+
+* For Input Events, use the **Data & Events** Compatibility Add-On.
+* For Asset Loading, use the **Preload** Compatibility Add-On. 
+
+
+![A screenshot of the library management tab in the p5.js Editor, where a user can toggle add-on libraries for 1.x compatibility.](../images/2.0/v2-addons.png)
+
+*You will also see a **Shapes** Compatibility Add-On - the Shapes API changes only affect more advanced custom shapes that do not commonly appear in MS/HS curricula, so most MS/HS teachers won’t need the Shapes Compatibility Add-On.*
+
+
+## Teacher Quick Reference
+
+
+
+<table>
+
+<tr>
+
+<th>
+
+p5.js v1
+
+</th>
+
+<th>
+
+p5.js v2
+
+</th>
+
+<th>
+
+Reference
+
+</th>
+
+<tr>
+<th colspan="3">
+Input Events
+</th>
+</tr>
+
+</tr>
+
+<tr>
+
+<td>
+
+`mouseButton === RIGHT`
+
+
+</td>
+
+<td>
+
+`mouseButton.right`
+
+</td>
+
+<td>
+
+[mouseButton](https://beta.p5js.org/reference/p5/mouseButton/)
+
+</td>
+
+</tr>
+
+<tr>
+
+<td>
+
+`keyIsPressed` <br />
+`key === UP_ARROW`
+
+</td>
+
+<td>
+
+`keyIsDown(UP_ARROW)`
+
+</td>
+
+<td>
+
+[keyIsDown](https://beta.p5js.org/reference/p5/keyIsDown/)
+
+</td>
+
+</tr>
+
+
+<tr>
+<th colspan="3">
+Asset Loading
+</th>
+</tr>
+
+
+<tr>
+
+
+</tr>
+
+<tr>
+
+<td>
+
+```js
+function preload(){   
+  img = loadImage("cat.jpg");
+}
+```
+
+</td>
+
+<td>
+
+```js
+async function setup() {
+  createCanvas(100, 100);
+  img = await loadImage("cat.jpg"); 
+}
+```
+
+</td>
+
+<td>
+
+[async_await](https://beta.p5js.org/reference/p5/async_await/)
+
+</td>
+
+</tr>
+</table>
+
+
+
+
+
+
+<Callout title="Teacher Note">
+This quick reference includes only the p5.js v2 changes that commonly affect MS & HS curricula (input events and asset loading). Other v2 updates (such as changes to curved shapes, text measurement, and utility functions) do not appear in the reviewed curricula. For the full list of v2 changes, see the [Technical Transition Guide](https://github.com/processing/p5.js-compatibility). 
+</Callout>
+

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -3,7 +3,7 @@ title: "Guía para profesores sobre p5.js v2"
 description: Una guía para educadores de secundaria y preparatoria sobre la transición desde versiones anteriores a la versión 2 de p5.js.
 category: "2.0"
 featuredImage: ../images/featured/v2-transition.gif
-featuredImageAlt: TODO BETTER IMAGE
+featuredImageAlt: Diagrama animado de los cambios en la API entre la versión 1 y la versión 2 o p5.js
 relatedContent:
   references:
     - en/p5/mousebutton

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Guía para profesores sobre p5.js v2"
+title: "Guía para docentes sobre la versión 2 de p5.js"
 description: Una guía para educadores de secundaria y preparatoria sobre la transición desde versiones anteriores a la versión 2 de p5.js.
 category: "2.0"
 featuredImage: ../images/featured/v2-transition.gif

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -28,7 +28,7 @@ Después de revisar múltiples programas de escuelas secundarias y escuelas prep
 * Eventos de Input
 * Carga de Recursos
 
-Aunque existen [otras actualizaciones en v2](https://github.com/processing/p5.js-compatibility) (así como cambios a formas curvas, medición de texto, y funciones utilitarias), éstas no aparecen generalmente en los curriculums de escuelas secundarias y escuelas preparatorias, y es poco probable que impacten en tu trabajo con estudiantes. 
+Aunque existen [otras actualizaciones en v2](https://github.com/processing/p5.js-compatibility) (así como cambios a formas curvas, medición de texto, y funciones utilitarias), éstas no aparecen generalmente en los programas de las escuelas secundarias y preparatorias, y es poco probable que impacten en tu trabajo con estudiantes. 
 
 Esta guía te explica los cambios más comunes que encontrarás en un aula de secundaria o preparatoria. Aprenderás cómo actualizar tu código para la versión 2 de p5.js, y cuándo los complementos de compatibilidad puedan ser útiles para sketches antiguos. 
 

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Guía para profesores sobre p5.js v2"
 description: Una guía para educadores de secundaria y preparatoria sobre la transición desde versiones anteriores a la versión 2 de p5.js.
-description: A guide for middle school and high school educators for transtioning to p5.js version 2 from using previous versions.
 category: "2.0"
 featuredImage: ../images/featured/v2-transition.gif
 featuredImageAlt: TODO BETTER IMAGE
@@ -20,20 +19,20 @@ import Callout from "../../../components/Callout/index.astro";
 
 ## p5.js v2 Guía de Transición para Educadores de Secundaria y Preparatoria
 
-Siendo educador de secundaria, entiendo que una nueva versión de una herramienta en la que confías se puede sentir como un gran ajuste, sobre todo cuando tienes una serie de clases y activities que manejas y quieres.
+Siendo educador de secundaria, entiendo que una nueva versión de una herramienta en la que confías se puede sentir como un gran ajuste, sobre todo cuando tienes una serie de clases y actividades que manejas y quieres.
 
-Si te sientes aprehensivo de la transición a la version 2 de p5.js, esta guía es para tranquilizarte. La mayoría de lo que hacen sus estudiantes funciona exactamente igual a como era antes.
+Si te sientes aprehensivo de la transición a la versión 2 de p5.js, esta guía es para tranquilizarte. La mayoría de lo que hacen tus estudiantes funciona exactamente igual a como era antes.
 
-Después de revisar multiples curriculum de escuelas secundarias y escuelas de preparatoria ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) solamente dos áreas requieren actualizarse al ir de p5.js v1 hacia v2.
+Después de revisar múltiples curriculums de escuelas secundarias y escuelas de preparatoria ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) solamente dos áreas requieren actualizarse al ir de p5.js v1 hacia v2.
 
 * Eventos de Input
-* Carga de Assets
+* Carga de Recursos
 
-Aunque existe [otras actualizaciones en v2](https://github.com/processing/p5.js-compatibility) (así como cambios a formas curvas, medición de texto, y funciones utilitarias), éstas no aparecen generalmente en los curriculum de escuelas secundarias y escuelas preparatorias, y son poco probables de que impaces en el tu trabajo con estudiantes. 
+Aunque existen [otras actualizaciones en v2](https://github.com/processing/p5.js-compatibility) (así como cambios a formas curvas, medición de texto, y funciones utilitarias), éstas no aparecen generalmente en los curriculums de escuelas secundarias y escuelas preparatorias, y es poco probable que impacten en tu trabajo con estudiantes. 
 
-Está guía te explica los cambios más comunes que encontrarás en un aula de secuandaria o preparatoria. Aprenderás como actualizar tu código para la versión 2 de p5.js, y cuándo los complementos de compatibilidad puedan ser útiles para sketches antiguos. 
+Esta guía te explica los cambios más comunes que encontrarás en un aula de secundaria o preparatoria. Aprenderás cómo actualizar tu código para la versión 2 de p5.js, y cuándo los complementos de compatibilidad puedan ser útiles para sketches antiguos. 
 
-He tratado de incluir solo que necesitas y nada más, para que puedas ponerte al día fácilmente y estar seguro de enseñar con la versión 2 de p5.js. 
+He tratado de incluir solo lo que necesitas y nada más, para que puedas ponerte al día fácilmente y estar seguro de enseñar con la versión 2 de p5.js. 
 
 ## Versiones en el Editor Web
 
@@ -45,7 +44,7 @@ Sin embargo, si abres un sketch viejo (por ejemplo, algo que un estudiante creó
 * Activar el **complemento de compatibilidad** 
 * Volver al sketch para la versión 1 de p5.js en el Editor Web 
 
-![Pantallazo de la selección de veriones de p5.js en el Editor Web.](../images/2.0/v2-libman.png)
+![Pantallazo de la selección de versiones de p5.js en el Editor Web.](../images/2.0/v2-libman.png)
 
 
 ## Eventos de Input
@@ -81,8 +80,8 @@ if (mouseButton.right) {
 
 **Referencia:** [mouseButton](/reference/p5/mouseButton/)
 
-<Callout title="Nota de profesor">
-En v2, mouseButton es ahora un objeto con propiedades booleanas (izquierda, derecha, centro). Esto hace posible detectar multiples botones de una vez. Esto es especialmente útil para aplicaciones de dibujo o herramientas para pintar, donde tus estudiantes quieran diferentes comportamientos para los diferentes botones del mouse.
+<Callout title="Nota del Educador">
+En v2, mouseButton es ahora un objeto con propiedades booleanas (izquierda, derecha, centro). Esto hace posible detectar múltiples botones de una vez. Esto es especialmente útil para aplicaciones de dibujo o herramientas para pintar, donde tus estudiantes quieran diferentes comportamientos para los diferentes botones del mouse.
 </Callout>
 
 ### Entrada de Teclado
@@ -97,17 +96,17 @@ if (keyIsPressed) {
 }
 ```
 
-A menudo `keyIsPressed` es enseñado inicialmente como una variable simple de tipo Booleado y `key ===` encaja con la estructura de comparación que los estudiantes ya están usando.
+A menudo `keyIsPressed` es enseñado inicialmente como una variable simple de tipo booleano y `key ===` encaja con la estructura de comparación que los estudiantes ya están usando.
 
-En la versión 2 de p5.js, la manera recomendada de ceritifcar por teclas es:
+En la versión 2 de p5.js, la manera recomendada de verificar por teclas es:
 
 ```js
 if (keyIsDown(UP_ARROW)) {
-  // has algo (p5.js v2)
+  // haz algo (p5.js v2)
 }
 ```
 
-`keyIsDown()` es el acercamiento recomendado actual ya que funciona consistentemente a travez de ambas versiones v1 y v2, y soporta verificaciones de múltiples teclas a la vez.
+`keyIsDown()` es el enfoque recomendado actual ya que funciona consistentemente a través de ambas versiones v1 y v2, y soporta verificaciones de múltiples teclas a la vez.
 
 
 **Referencia:** [keyIsDown](https://beta.p5js.org/reference/p5/keyIsDown/)
@@ -193,7 +192,7 @@ Para la nueva enseñanza, sigue el código de versión 2 que se muestra arriba.
 
 Si tienes sketches antiguos que quieres seguir usando sin actualizar el código, el complemento de compatibilidad **Datos y Eventos** restaura el comportamiento de la versión 1.
 
-Consula la sección *Complementos de compatibilidad* a continuación para obtener más detalles.
+Consulta la sección *Complementos de compatibilidad* a continuación para obtener más detalles.
 
 
 ## Carga de Recursos
@@ -224,7 +223,7 @@ function setup(){
 
 ### `async` y `await` en p5.js v2
 
-En la versión 2 de p5.js, `preload()` ya no se usa, y los recursos son cargados usando `await` dentro de `async setup()`. Esto funciona para imágenes, sonidos, fuentes tipográficas, y otros arhivos:
+En la versión 2 de p5.js, `preload()` ya no se usa, y los recursos son cargados usando `await` dentro de `async setup()`. Esto funciona para imágenes, sonidos, fuentes tipográficas, y otros archivos:
 
 ```js
 let img;
@@ -241,7 +240,7 @@ async function setup() {
 
 
 
-### Referencia Rápida de Carda de Recursos
+### Referencia Rápida de Carga de Recursos
 
 
 
@@ -306,15 +305,15 @@ Para la nueva enseñanza, sigue el código de versión 2 que se muestra arriba.
 
 Si tienes sketches antiguos que quieres seguir usando sin actualizar el código, el complemento de compatibilidad **Preload** restaura el comportamiento de la versión 1.
 
-Consula la sección *Complementos de compatibilidad* a continuación para obtener más detalles.
+Consulta la sección *Complementos de compatibilidad* a continuación para obtener más detalles.
 
 ## Complementos de Compatibilidad
 
-Los complementos de compatibilidad son archivos axiliares opcionales que puedes activar en el editor de p5.js para que los sketches antiguos de la versión 1 de p5.js se comporten de la misma manera en la versión 2 de p5.js, sin actualizar el código. 
+Los complementos de compatibilidad son archivos auxiliares opcionales que puedes activar en el editor de p5.js para que los sketches antiguos de la versión 1 de p5.js se comporten de la misma manera en la versión 2 de p5.js, sin actualizar el código. 
 
-Éstos complementos son necesarios si tú o tus estudiantes abren sketches antiguos desde la web o de material didáctico que usen partrones de la versión 1 de p5.js y aún no estás listo para actualizar el código a la versión 2 de p5.js.
+Estos complementos son necesarios si tú o tus estudiantes abren sketches antiguos desde la web o de material didáctico que usen patrones de la versión 1 de p5.js y aún no estás listo para actualizar el código a la versión 2 de p5.js.
 
-Para la nueva enseñanza, es mejor usar la sintaxtis de la versión 2 para escribir código, de esta manera los estudiantes aprender con la versión que tendrá soporte en adelante. 
+Para la nueva enseñanza, es mejor usar la sintaxis de la versión 2 para escribir código, de esta manera los estudiantes aprenden con la versión que tendrá soporte de aquí en adelante. 
 
 * Para Eventos de Inputs, usa los Complementos de Compatibilidad **Datos y Eventos**
 * Para Carga de Recursos, usa los Complementos de Compatibilidad **Preload**
@@ -455,7 +454,7 @@ async function setup() {
 
 
 
-<Callout title="Note de Educador">
+<Callout title="Nota del Educador">
 Esta referencia rápida incluye solamente los cambios en la versión 2 de p5.js que a menudo afectan al curriculum de secundaria y preparatoria (eventos de input y carga de recursos). Otras actualizaciones de la versión 2 (como cambios en formas curvas, medición de texto, y funciones de utilidad) no aparecen en el curriculum revisado. Para ver la lista completa de cambios en la versión 2, consulta la [Guía Técnica de Transición](https://github.com/processing/p5.js-compatibility). 
 </Callout>
 

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Guía para docentes sobre la versión 2 de p5.js"
-description: Una guía para educadores de secundaria y preparatoria sobre la transición desde versiones anteriores a la versión 2 de p5.js.
+description: Una guía para profesores de secundaria y preparatoria sobre la transición desde versiones anteriores a la versión 2 de p5.js.
 category: "2.0"
 featuredImage: ../images/featured/v2-transition.gif
 featuredImageAlt: Diagrama animado de los cambios en la API entre la versión 1 y la versión 2 de p5.js

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Teachers' Guide to p5.js v2"
+title: "Guía para profesores sobre p5.js v2"
+description: Una guía para educadores de secundaria y preparatoria sobre la transición desde versiones anteriores a la versión 2 de p5.js.
 description: A guide for middle school and high school educators for transtioning to p5.js version 2 from using previous versions.
 category: "2.0"
 featuredImage: ../images/featured/v2-transition.gif
@@ -17,12 +18,11 @@ authors:
 ---
 import Callout from "../../../components/Callout/index.astro";
 
-## p5.js v2 Transition Guide for Middle School and High School Educators
+## p5.js v2 Guía de Transición para Educadores de Secundaria y Preparatoria
 
-As a middle school teacher, I know a version update to a tool you rely on can feel like a big adjustment, especially when you already have a set of lessons and activities you know and love. 
+Siendo educador de secundaria, entiendo que una nueva versión de una herramienta en la que confías se puede sentir como un gran ajuste, sobre todo cuando tienes una serie de clases y activities que manejas y quieres.
 
-If you’re feeling some trepidation about the transition to p5.js v2, this guide is here to reassure you. Most of what your students already do works exactly the same as before.
-
+Si te sientes aprehensivo de la transición a la version 2 de p5.js, esta guía es para tranquilizarte. La mayoría de lo que hacen sus estudiantes funciona exactamente igual a como era antes.
 
 After reviewing multiple middle school and high school p5.js curricula ([CS4All Creative Web](https://blueprint.cs4all.nyc/curriculum/creative-web/), [CS4All Introduction to Computational Media](https://blueprint.cs4all.nyc/curriculum/intro-to-computational-media/), [CodeHS Digital Art with p5.js](https://codehs.com/course/p5-js/overview), [CSinSF Creative Computing](https://sites.google.com/sfusd.edu/csinsfcreativecomputing/home?authuser=0), [Processing Foundation Art + Code](https://processing.github.io/art-plus-code/codeAsCreativeMedium-intro/)) just two areas consistently require updates when moving from p5.js v1 to v2: 
 

--- a/src/content/tutorials/es/v2_transition.mdx
+++ b/src/content/tutorials/es/v2_transition.mdx
@@ -313,7 +313,7 @@ Los complementos de compatibilidad son archivos auxiliares opcionales que puedes
 
 Estos complementos son necesarios si tú o tus estudiantes abren sketches antiguos desde la web o de material didáctico que usen patrones de la versión 1 de p5.js y aún no estás listo para actualizar el código a la versión 2 de p5.js.
 
-Para la nueva enseñanza, es mejor usar la sintaxis de la versión 2 para escribir código, de esta manera los estudiantes aprenden con la versión que tendrá soporte de aquí en adelante. 
+Al generar nuevos ejercicios, es mejor usar la sintaxis de la versión 2 para escribir código, de esta manera los estudiantes aprenden con la versión que tendrá soporte de aquí en adelante. 
 
 * Para Eventos de Inputs, usa los Complementos de Compatibilidad **Datos y Eventos**
 * Para Carga de Recursos, usa los Complementos de Compatibilidad **Preload**


### PR DESCRIPTION
Hi @ksen0 and @marioguzzzman I have translated the transition guide for educators into Spanish. I would appreciate feedback on Spanish words related to "profesor" or "educador," as well as on the terminology used for MS/MH, since it differs in Latin American countries. Some options include "educación secundaria" (MS) and "educación preparatoria" (MH). I would also appreciate any other comments on the translation.